### PR TITLE
Automate dependency wheel builds to facilitate updates and expand Python version compatibility

### DIFF
--- a/bin/build_deps.bat
+++ b/bin/build_deps.bat
@@ -1,0 +1,43 @@
+@echo off
+rem Build custom binaries for MagellanMapper dependencies on Windows platforms
+
+rem Usage:
+rem   setup_venv.sh [envs-dir] [output-dir]
+
+rem Args:
+rem   [env-dir]: Path to environment directory; defaults to `..\venvs\vmag`.
+rem   [output-dir]: Path to output directory; defaults to `..\build_deps`.
+
+
+rem parse user arg for path containing Venvs
+set "venvs_dir=..\venvs"
+if not "%~1" == "" (
+  set "venvs_dir=%~1"
+)
+echo Setting the Venvs directory path to %venvs_dir%
+
+rem parse user env directory path
+set "output_dir=..\build_deps"
+if not "%~2" == "" (
+  set "output_dir=%~2"
+)
+echo Setting the output directory path to %output_dir%
+
+pushd "%~dp0"
+cd ..
+
+rem build binaries within each Python version Venv environment
+for %%v in (3.6.8) do (
+  echo Activating Venv for py%%v
+  call "%venvs_dir%\py%%v\Scripts\Activate.bat"
+  call pip install wheel
+  call bin\build_se.bat "%output_dir%\build_se_py%%v"
+  call copy "%output_dir%\build_se_py%%v\SimpleITK-build\Wrapping\Python\dist\"*.whl "%output_dir%"
+  call copy "%output_dir%\build_se_py%%v\SimpleITK-build\Wrapping\Python\dist\"*.tar.gz "%output_dir%"
+  call deactivate
+)
+
+popd
+
+rem keep window open if user double-clicked this script to launch it
+pause

--- a/bin/build_deps.bat
+++ b/bin/build_deps.bat
@@ -27,13 +27,21 @@ pushd "%~dp0"
 cd ..
 
 rem build binaries within each Python version Venv environment
-for %%v in (3.6.8) do (
+for %%v in (3.6.8 3.7.7 3.8.7 3.9.1) do (
   echo Activating Venv for py%%v
   call "%venvs_dir%\py%%v\Scripts\Activate.bat"
   call pip install wheel
+  
+  rem build SimpleElastix
   call bin\build_se.bat "%output_dir%\build_se_py%%v"
   call copy "%output_dir%\build_se_py%%v\SimpleITK-build\Wrapping\Python\dist\"*.whl "%output_dir%"
   call copy "%output_dir%\build_se_py%%v\SimpleITK-build\Wrapping\Python\dist\"*.tar.gz "%output_dir%"
+  
+  rem build Javabridge; Numpy 1.19 is latest ver for Python 3.6
+  pip install cython
+  pip install numpy~=1.19
+  call bin\build_jb.bat "%output_dir%"
+  
   call deactivate
 )
 

--- a/bin/build_deps.sh
+++ b/bin/build_deps.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Build wheels for MagellanMapper dependencies
+
+venv_dir="../venvs"
+output_dir="../builds_se"
+HELP="
+Create Venv environments for multiple Python versions.
+
+Assumes that environments for each Python version have been set up using
+\"setup_multi_venvs.sh\".
+
+Arguments:
+  -h: Show help and exit.
+  -d [path]: Path to build directory; defaults to \"$output_dir\".
+  -e [path]: Path to folder where the new venv directory will be placed. 
+    Defaults to \"$venv_dir\".
+  -s [path]: Path to SimpleElastix directory, passed to \"build_se.sh\".
+"
+
+se_dir=()
+
+OPTIND=1
+while getopts hd:e:s: opt; do
+  case $opt in
+    h)
+      echo "$HELP"
+      exit 0
+      ;;
+    d)
+      output_dir="$OPTARG"
+      echo "Changed build directory to $output_dir"
+      ;;
+    e)
+      venv_dir="$OPTARG"
+      echo "Set the venv directory to $venv_dir"
+      ;;
+    s)
+      se_dir+=(-s "$OPTARG")
+      echo "Changed SimpleElastix directory to $OPTARG"
+      ;;
+    :)
+      echo "Option -$OPTARG requires an argument"
+      exit 1
+      ;;
+    *)
+      echo "$HELP" >&2
+      exit 1
+      ;;
+  esac
+done
+
+echo "Initating build of SimpleElastix..."
+
+# base directory is script's parent directory
+BASE_DIR="$(dirname "$0")/.."
+cd "$BASE_DIR" || { echo "Unable to find folder $BASE_DIR, exiting"; exit 1; }
+
+# Build SimpleElastix in the given Python version environment.
+# Args:
+#   1: Python version, used to activate the corresponding Venv environment.
+build_se_ver() {
+  # activate the environment
+  local ver="$1"
+  local vdir
+  vdir="$(cd "${venv_dir}/py${ver}" && pwd)"
+  . "${vdir}/bin/activate"
+  if [[ "$VIRTUAL_ENV" != "$vdir" ]]; then
+    echo "Could not activate $vdir Venv environment, skipping"
+    return
+  fi
+  
+  # install package to build wheels
+  pip install wheel
+  
+  # build SimpleElastix and copy wheel to output dir
+  local output="${output_dir}/build_se_py${ver}"
+  bin/build_se.sh -d "$output" "${se_dir[@]}"
+  local dist="${output}/SimpleITK-build/Wrapping/Python/dist"
+  cp -v "${dist}/"*.whl "${dist}/"*.tar.gz "$output_dir"
+}
+
+if [[ ! -d "$output_dir" ]]; then
+  # make output directory and its parents
+  mkdir -p "$output_dir"
+fi
+
+# build dependencies for each of all supported Python versions
+py_vers=(3.6 3.7 3.8 3.9)
+for py_ver in "${py_vers[@]}"; do
+  build_se_ver "$py_ver"
+done

--- a/bin/build_deps.sh
+++ b/bin/build_deps.sh
@@ -2,9 +2,9 @@
 # Build wheels for MagellanMapper dependencies
 
 venv_dir="../venvs"
-output_dir="../builds_se"
+output_dir="../build_deps"
 HELP="
-Create Venv environments for multiple Python versions.
+Build dependencies in Venv environments for multiple Python versions.
 
 Assumes that environments for each Python version have been set up using
 \"setup_multi_venvs.sh\".
@@ -14,13 +14,15 @@ Arguments:
   -d [path]: Path to build directory; defaults to \"$output_dir\".
   -e [path]: Path to folder where the new venv directory will be placed. 
     Defaults to \"$venv_dir\".
+  -j [path]: Path to Javabridge directory, passed to \"build_jb.sh\".
   -s [path]: Path to SimpleElastix directory, passed to \"build_se.sh\".
 "
 
 se_dir=()
+jb_dir=()
 
 OPTIND=1
-while getopts hd:e:s: opt; do
+while getopts hd:e:j:s: opt; do
   case $opt in
     h)
       echo "$HELP"
@@ -33,6 +35,10 @@ while getopts hd:e:s: opt; do
     e)
       venv_dir="$OPTARG"
       echo "Set the venv directory to $venv_dir"
+      ;;
+    j)
+      jb_dir+=(-d "$OPTARG")
+      echo "Changed Python-Javabridge directory to $OPTARG"
       ;;
     s)
       se_dir+=(-s "$OPTARG")
@@ -55,28 +61,49 @@ echo "Initating build of SimpleElastix..."
 BASE_DIR="$(dirname "$0")/.."
 cd "$BASE_DIR" || { echo "Unable to find folder $BASE_DIR, exiting"; exit 1; }
 
-# Build SimpleElastix in the given Python version environment.
+# Activate Venv environment for the given Python version and install wheels
+# package.
 # Args:
-#   1: Python version, used to activate the corresponding Venv environment.
-build_se_ver() {
+#   1: Python version given as x.y, eg "3.6".
+# Returns:
+#   1 if the environment could not be activated, 0 otherwise.
+activate_venv() {
   # activate the environment
   local ver="$1"
   local vdir
   vdir="$(cd "${venv_dir}/py${ver}" && pwd)"
+  echo "Activating $vdir"
   . "${vdir}/bin/activate"
   if [[ "$VIRTUAL_ENV" != "$vdir" ]]; then
     echo "Could not activate $vdir Venv environment, skipping"
-    return
+    return 1
   fi
   
   # install package to build wheels
   pip install wheel
-  
-  # build SimpleElastix and copy wheel to output dir
+  return 0
+}
+
+# Build SimpleElastix in the given Python version environment.
+# Args:
+#   1: Python version, used to activate the corresponding Venv environment.
+build_se_ver() {
+  # build SimpleElastix
+  local ver="$1"
   local output="${output_dir}/build_se_py${ver}"
   bin/build_se.sh -d "$output" "${se_dir[@]}"
+  
+  # copy wheel to output dir
   local dist="${output}/SimpleITK-build/Wrapping/Python/dist"
   cp -v "${dist}/"*.whl "${dist}/"*.tar.gz "$output_dir"
+}
+
+# Build Javabridge in the given Python version environment.
+# Also installs Cython and Numpy.
+build_jb_ver() {
+  pip install cython
+  pip install numpy<=1.19 # v1.19 is last ver supporting Python 3.6
+  bin/build_jb.sh "${jb_dir[@]}" -o "$output_dir" -j "$(/usr/libexec/java_home -v 1.8)"
 }
 
 if [[ ! -d "$output_dir" ]]; then
@@ -87,5 +114,9 @@ fi
 # build dependencies for each of all supported Python versions
 py_vers=(3.6 3.7 3.8 3.9)
 for py_ver in "${py_vers[@]}"; do
-  build_se_ver "$py_ver"
+  if activate_venv "$py_ver"; then
+    build_se_ver "$py_ver"
+    build_jb_ver
+    deactivate
+  fi
 done

--- a/bin/build_deps.sh
+++ b/bin/build_deps.sh
@@ -17,6 +17,8 @@ Arguments:
   -j [opt1:arg1[:...]]: Arguments to \"build_jb.sh\" for Javabridge build,
     delimted by \":\". Javabridge will only be built if this option is set.
     To set while retaining defauls, pass as ' '.
+  -p [ver1:ver2[:...]]: Python versions delimted by \":\", for which binaries
+    will be built. Defaults to 3.6-3.9.
   -s [opt1:arg1[:...]]: Arguments to \"build_se.sh\" for SimpleElastix,
     build delimted by \":\". SimpleElastix will only be built if this option
     is set. To set while retaining defauls, pass as ' '.
@@ -24,9 +26,10 @@ Arguments:
 
 se_args=()
 jb_args=()
+py_vers=(3.6 3.7 3.8 3.9)
 
 OPTIND=1
-while getopts hd:e:j::s: opt; do
+while getopts hd:e:j:p:s: opt; do
   case $opt in
     h)
       echo "$HELP"
@@ -44,6 +47,9 @@ while getopts hd:e:j::s: opt; do
       IFS=':' read -r -a jb_args <<< "$OPTARG"
       echo "Set Python-Javabridge arguments to: ${jb_args[*]}"
       ;;
+    p)
+      IFS=':' read -r -a py_vers <<< "$OPTARG"
+      echo "Set Python versions to: ${py_vers[*]}"
       ;;
     s)
       IFS=':' read -r -a se_args <<< "$OPTARG"
@@ -121,7 +127,6 @@ if [[ ! -d "$output_dir" ]]; then
 fi
 
 # build dependencies for each of all supported Python versions
-py_vers=(3.6 3.7 3.8 3.9)
 for py_ver in "${py_vers[@]}"; do
   # activate Venv environment for the given Python version
   if activate_venv "$py_ver"; then

--- a/bin/build_deps.sh
+++ b/bin/build_deps.sh
@@ -102,8 +102,12 @@ build_se_ver() {
 # Also installs Cython and Numpy.
 build_jb_ver() {
   pip install cython
-  pip install numpy<=1.19 # v1.19 is last ver supporting Python 3.6
-  bin/build_jb.sh "${jb_dir[@]}" -o "$output_dir" -j "$(/usr/libexec/java_home -v 1.8)"
+  pip install 'numpy~=1.19' # v1.19 is last ver supporting Python 3.6
+  local java_args=()
+  if command -v "/usr/libexec/java_home" &> /dev/null; then
+    java_args+=(-j "$(/usr/libexec/java_home -v 1.8)")
+  fi
+  bin/build_jb.sh "${jb_dir[@]}" -o "$output_dir" "${java_args[@]}"
 }
 
 if [[ ! -d "$output_dir" ]]; then

--- a/bin/build_jb.bat
+++ b/bin/build_jb.bat
@@ -1,0 +1,74 @@
+rem Build Python-Javabridge with MSVC and OpenJDK on Windows
+
+rem Build Python-Javabridge wheels for Windows using MSVC build tools.
+rem
+rem Usage:
+rem   build_jb.bat [build-dir] [path-to-Javabridge]
+rem
+rem Args:
+rem   build-dir: Path to output build directory; defaults to "build_jb".
+rem   path-to-Javabridge: Path to existing Javabridge directory or
+rem     where it will be stored; defaults to "..\python-javabridge".
+
+rem parse arg for output build directory
+set "build_dir=build_jb"
+if not "%~1" == "" (
+  set "build_dir=%~1"
+)
+call :get_abs_path "%build_dir%"
+set "build_dir=%abs_path%"
+echo Setting the build directory path to %build_dir%
+
+rem parse arg for SimpleElastix, converting to an absolute path
+set "jb_dir=..\python-javabridge"
+if not "%~2" == "" (
+  set "jb_dir=%~2"
+)
+call :get_abs_path "%jb_dir%"
+set "jb_dir=%abs_path%"
+echo Setting the Javabridge path to %jb_dir%
+
+rem Javabridge on Windows requires JDK_HOME, not JAVA_HOME (though may want
+rem to set JAVA_HOME to same path and point PATH to JAVA_HOME\bin just to
+rem be safe)
+if "%JDK_HOME%" == "" (
+  echo JDK_HOME not found, required for Javabridge build, exiting
+  exit /b 1
+)
+
+rem get and/or enter git repo
+pushd "%~dp0"
+if not exist "%jb_dir%\" (
+  echo Cloning Python-Javabridge git repo to %jb_dir%...
+  git clone https://github.com/LeeKamentsky/python-javabridge.git "%jb_dir%"
+)
+if not exist "%jb_dir%\" (
+  echo Could not create %jb_dir%, existing
+  exit /b 1
+)
+cd "%jb_dir%"
+
+rem restore repo dir to pristine state
+git clean -dfx
+
+rem build binaries, wheel, and source distribution
+echo "Building Python-Javabridge"
+python setup.py build
+python setup.py bdist_wheel
+python setup.py sdist
+
+rem make build folder
+if not exist "%build_dir%\" (
+  mkdir "%build_dir%"
+)
+copy dist\*.whl "%build_dir%"
+copy dist\*.tar.gz "%build_dir%"
+
+popd
+
+exit /b
+
+rem Convert a path to an absolute path.
+:get_abs_path
+  set "abs_path=%~f1
+  exit /b

--- a/bin/build_jb.bat
+++ b/bin/build_jb.bat
@@ -2,6 +2,9 @@ rem Build Python-Javabridge with MSVC and OpenJDK on Windows
 
 rem Build Python-Javabridge wheels for Windows using MSVC build tools.
 rem
+rem Assumes that "JDK_HOME" has been set as an environment variable to the
+rem Java installation, typically JDK 8 to maximize compatibility.
+rem
 rem Usage:
 rem   build_jb.bat [build-dir] [path-to-Javabridge]
 rem

--- a/bin/build_jb.sh
+++ b/bin/build_jb.sh
@@ -64,13 +64,20 @@ fi
 
 echo "Initating build of Javabridge..."
 
-# base directory is script's parent directory, and default repo and build dirs 
-# are in parent directory of base dir
+# base directory is script's parent directory
 BASE_DIR="$(dirname "$0")/.."
 cd "$BASE_DIR" || { echo "Unable to find folder $BASE_DIR, exiting"; exit 1; }
 base_dir="$PWD"
 if [[ -z "$jb_dir" ]]; then
+  # default to look for repo in parent of base dir
   jb_dir="${base_dir}/../python-javabridge"
+elif [[ "$jb_dir" != /* ]]; then
+  # convert relative Javabridge to abs dir path
+  jb_dir="${base_dir}/${jb_dir}"
+fi
+if [[ "$out_dir" != /* ]]; then
+  # convert relative output to abs dir path
+  out_dir="${base_dir}/${out_dir}"
 fi
 
 # get and/or enter git repo

--- a/bin/build_jb.sh
+++ b/bin/build_jb.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Build script to compile Javabridge
+
+HELP="
+Compile Python-Javabridge and build wheels.
+
+The repository will be cleaned to its original state, removing all untracked
+files, to ensure that the build does not have stale artifacts.
+
+Assumes that the Venv environments have been set up by
+\"bin/setup_multi_venvs.sh\".
+
+Arguments:
+  -h: Show help and exit.
+  -d [path]: Javabridge directory.
+  -j [path]: Java home path.
+  -o [path]: Output directory to copy wheel and source distribution.
+"
+
+jb_dir=""
+out_dir=""
+java_home=""
+
+OPTIND=1
+while getopts hd:j:o: opt; do
+  case $opt in
+    h)
+      echo "$HELP"
+      exit 0
+      ;;
+    d)
+      jb_dir="$OPTARG"
+      echo "Changed Python-Javabridge directory to $jb_dir"
+      ;;
+    j)
+      java_home="$OPTARG"
+      echo "Changed Java home to $java_home"
+      ;;
+    o)
+      out_dir="$OPTARG"
+      echo "Changed output directory to $out_dir"
+      ;;
+    :)
+      echo "Option -$OPTARG requires an argument"
+      exit 1
+      ;;
+    *)
+      echo "$HELP" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# attempt compatibility with lowest Mac target; Python must have been
+# compiled with at least this target, or setting will be ignored
+export MACOSX_DEPLOYMENT_TARGET=10.9
+
+if [[ -n "$java_home" ]]; then
+  # use the given Java
+  export JAVA_HOME="$java_home"
+  export PATH="${JAVA_HOME}/bin:$PATH"
+  java -version
+fi
+
+echo "Initating build of Javabridge..."
+
+# base directory is script's parent directory, and default repo and build dirs 
+# are in parent directory of base dir
+BASE_DIR="$(dirname "$0")/.."
+cd "$BASE_DIR" || { echo "Unable to find folder $BASE_DIR, exiting"; exit 1; }
+base_dir="$PWD"
+if [[ -z "$jb_dir" ]]; then
+  jb_dir="${base_dir}/../python-javabridge"
+fi
+
+# get and/or enter git repo
+if [[ ! -d "$jb_dir" ]]; then
+  echo "Cloning Python-Javabridge git repo to ${jb_dir}..."
+  git clone https://github.com/LeeKamentsky/python-javabridge.git "$jb_dir"
+fi
+cd "$jb_dir" || { echo "Unable to find folder $jb_dir, exiting"; exit 1; }
+
+# restore repo dir to pristine state
+git clean -dfx
+
+# build binaries, wheel, and source distribution
+echo "Building Python-Javabridge"
+python setup.py build
+python setup.py bdist_wheel
+python setup.py sdist
+
+if [[ -n "$out_dir" ]]; then
+  # copy wheel and source distribution to output dir
+  if [[ ! -d "$out_dir" ]]; then
+    mkdir "$out_dir"
+  fi
+  cp -v "dist/"*.whl "dist/"*.tar.gz "$out_dir"
+fi
+
+echo "Done building Python-Javabridge"

--- a/bin/build_se.bat
+++ b/bin/build_se.bat
@@ -63,10 +63,12 @@ SET "python_incl_arg=-DPYTHON_INCLUDE_DIR=%python_incl_dir%"
 for /F "delims=" %%i in (%python_ver_path%) do set dirname="%%~dpi"
 SET "python_ver_majmin=%python_ver_path:~-5,-2%"
 SET "python_ver_majmin=%python_ver_majmin:.=%"
-SET "python_lib_path=%python_ver_path%\libs\libpython%python_ver_majmin%.a"
+:: TODO: the .lib file may be sufficient
+SET "python_lib_path_a=%python_ver_path%\libs\libpython%python_ver_majmin%.a"
+SET "python_lib_path_lib=%python_ver_path%\libs\python%python_ver_majmin%.lib"
 SET "python_lib_arg="
-IF EXIST "%python_lib_path%" (
-  SET "python_lib_arg=-DPYTHON_LIBRARY=%python_lib_path%"
+IF EXIST "%python_lib_path_a%" (
+  SET "python_lib_arg=-DPYTHON_LIBRARY=%python_lib_path_a%;%python_lib_path_lib%"
 )
 ECHO Set Python include dir arg to: %python_incl_arg%
 ECHO Set Python library arg to: %python_lib_arg%

--- a/bin/build_se.bat
+++ b/bin/build_se.bat
@@ -3,6 +3,22 @@
 
 :: Build SimpleElastix for Windows using MSVC build tools. Compiled files
 :: will be found in ../../build_se relative to this script.
+::
+:: Usage:
+::   build_se.bat [build-dir] [path-to-SimpleElastix]
+::
+:: Args:
+::   build-dir: Path to output build directory.
+::   path-to-SimpleElastix: Path to existing SimpleElastix directory or
+::     where it will be stored.
+::
+:: MSVC requirements:
+:: - MSVC C++ x64/x86 build tools (tested on MSVC v142 VS 2019 C++ with the
+::   "Latest" version checked)
+:: - C++ CMake Tools for Windows
+:: - Git (eg "Git for Windows")
+:: - Run this script in an "x64 Native Tools Command Prompt to VS 2019"
+::
 :: Assumes:
 :: - The SimpleElastix git repo has been cloned to the parent
 ::   folder of this script's folder
@@ -10,8 +26,24 @@
 ::   the CONDA_PREFIX environment variable
 :: Tested with CMake 3.15; has *not* worked with MSVS CMake 3.14 on our testing.
 
-SET "cmake=cmake.exe"
+:: parse arg for output build directory
 SET "build_dir=build_se"
+IF NOT "%~1" == "" (
+  SET "build_dir=%~1"
+)
+ECHO Setting the build directory path to %build_dir%
+
+:: parse arg for SimpleElastix, converting to an absolute path
+SET "se_dir=..\SimpleElastix"
+IF NOT "%~2" == "" (
+  SET "se_dir=%~2"
+)
+call :get_abs_path "%se_dir%"
+SET "se_dir=%abs_path%"
+ECHO Setting the SimpleElastix path to %se_dir%
+
+:: set up Cmake
+SET "cmake=cmake.exe"
 SET "generator=Visual Studio 16 2019"
 SET "arch=x64"
 SET "python_exe="
@@ -33,9 +65,9 @@ cd "%build_dir%"
  %python_exe% -DWRAP_LUA:BOOL=OFF -DWRAP_R:BOOL=OFF -DWRAP_RUBY:BOOL=OFF^
  -DWRAP_TCL:BOOL=OFF -DWRAP_CSHARP:BOOL=OFF -DBUILD_EXAMPLES:BOOL=OFF^
  -DBUILD_TESTING:BOOL=OFF -DSimpleITK_PYTHON_USE_VIRTUALENV:BOOL=OFF^
- ..\SimpleElastix\SuperBuild
+ "%se_dir%\SuperBuild"
 "%cmake%" -G "%generator%" -A "%arch%" -T host="%arch%"^
- ..\SimpleElastix\SuperBuild
+ "%se_dir%\SuperBuild"
 
 :: build SimpleElastix
 msbuild ALL_BUILD.vcxproj /p:Configuration=Release
@@ -45,3 +77,10 @@ cd SimpleITK-build/Wrapping/Python
 python Packaging/setup.py build sdist bdist_wheel
 
 popd
+
+exit /b
+
+:: Convert a path to an absolute path.
+:get_abs_path
+  set "abs_path=%~f1
+  exit /b

--- a/bin/build_se.bat
+++ b/bin/build_se.bat
@@ -63,12 +63,10 @@ SET "python_incl_arg=-DPYTHON_INCLUDE_DIR=%python_incl_dir%"
 for /F "delims=" %%i in (%python_ver_path%) do set dirname="%%~dpi"
 SET "python_ver_majmin=%python_ver_path:~-5,-2%"
 SET "python_ver_majmin=%python_ver_majmin:.=%"
-:: TODO: the .lib file may be sufficient
-SET "python_lib_path_a=%python_ver_path%\libs\libpython%python_ver_majmin%.a"
-SET "python_lib_path_lib=%python_ver_path%\libs\python%python_ver_majmin%.lib"
+SET "python_lib_path=%python_ver_path%\libs\python%python_ver_majmin%.lib"
 SET "python_lib_arg="
-IF EXIST "%python_lib_path_a%" (
-  SET "python_lib_arg=-DPYTHON_LIBRARY=%python_lib_path_a%;%python_lib_path_lib%"
+IF EXIST "%python_lib_path%" (
+  SET "python_lib_arg=-DPYTHON_LIBRARY=%python_lib_path%"
 )
 ECHO Set Python include dir arg to: %python_incl_arg%
 ECHO Set Python library arg to: %python_lib_arg%

--- a/bin/build_se.bat
+++ b/bin/build_se.bat
@@ -94,7 +94,7 @@ msbuild ALL_BUILD.vcxproj /p:Configuration=Release
 
 :: build Python source and wheel packages for distribution
 cd SimpleITK-build/Wrapping/Python
-python Packaging/setup.py build sdist bdist_wheel
+python setup.py build sdist bdist_wheel
 
 popd
 

--- a/bin/build_se.sh
+++ b/bin/build_se.sh
@@ -106,6 +106,17 @@ if [[ $install_wrapper -ne 1 ]] || [[ ! -d "${build_dir}/${PKG}" ]]; then
   backup_file "$build_dir"
   mkdir "$build_dir"
   cd "$build_dir" || { echo "Unable to enter $build_dir, exiting"; exit 1; }
+  
+  # identify the Python include and library dirs from the Python executable
+  # since Cmake may discover paths for other Python installations
+  inc_cmd="from distutils.sysconfig import get_python_inc; "
+  inc_cmd+="print(get_python_inc())"
+  py_inc_dir=$(python -c "$inc_cmd")
+  lib_cmd="import distutils.sysconfig as sysconfig; "
+  lib_cmd+="print(sysconfig.get_config_var('LIBDIR'))"
+  py_lib=$(python -c "$lib_cmd")
+  echo "Python include directory: $py_inc_dir"
+  echo "Python library directory: $py_lib"
 
   echo "Building SimpleElastix"
   # run SuperBuild with flags to find clang on later Mac versions,
@@ -114,6 +125,7 @@ if [[ $install_wrapper -ne 1 ]] || [[ ! -d "${build_dir}/${PKG}" ]]; then
   cmake -DCMAKE_CXX_COMPILER:STRING=/usr/bin/$compiler_cpp \
     -DCMAKE_C_COMPILER:STRING=/usr/bin/$compiler_c \
     -DWRAP_PYTHON:BOOL=ON \
+    -DPYTHON_INCLUDE_DIR="$py_inc_dir" -DPYTHON_LIBRARY="$py_lib" \
     -DWRAP_JAVA:BOOL=OFF -DWRAP_LUA:BOOL=OFF \
     -DWRAP_R:BOOL=OFF -DWRAP_RUBY:BOOL=OFF \
     -DWRAP_TCL:BOOL=OFF -DWRAP_CSHARP:BOOL=OFF -DBUILD_EXAMPLES:BOOL=OFF \

--- a/bin/build_se.sh
+++ b/bin/build_se.sh
@@ -23,6 +23,10 @@ Arguments:
     to this script's directory. Default to \"../SimpleElastix\".
 "
 
+# attempt compatibility with lowest Mac target; Python must have been
+# compiled with at least this target, or setting will be ignored
+export MACOSX_DEPLOYMENT_TARGET=10.9
+
 build_dir=""
 se_dir=""
 PKG="SimpleITK-build/Wrapping/Python"

--- a/bin/build_se.sh
+++ b/bin/build_se.sh
@@ -109,6 +109,7 @@ if [[ $install_wrapper -ne 1 ]] || [[ ! -d "${build_dir}/${PKG}" ]]; then
   # turn off virtual environment creation
   cmake -DCMAKE_CXX_COMPILER:STRING=/usr/bin/$compiler_cpp \
     -DCMAKE_C_COMPILER:STRING=/usr/bin/$compiler_c \
+    -DWRAP_PYTHON:BOOL=ON \
     -DWRAP_JAVA:BOOL=OFF -DWRAP_LUA:BOOL=OFF \
     -DWRAP_R:BOOL=OFF -DWRAP_RUBY:BOOL=OFF \
     -DWRAP_TCL:BOOL=OFF -DWRAP_CSHARP:BOOL=OFF -DBUILD_EXAMPLES:BOOL=OFF \

--- a/bin/build_se.sh
+++ b/bin/build_se.sh
@@ -126,8 +126,8 @@ if [[ $install_wrapper -ne 1 ]] || [[ ! -d "${build_dir}/${PKG}" ]]; then
   # build distributions
   echo "Generating source and platform wheel distributions..."
   cd "$PKG" || { echo "$PKG does not exist, exiting"; exit 1; }
-  python Packaging/setup.py sdist
-  python Packaging/setup.py bdist_wheel
+  python setup.py sdist
+  python setup.py bdist_wheel
   cd - || exit 1
 fi
 

--- a/bin/setup_multi_venvs.bat
+++ b/bin/setup_multi_venvs.bat
@@ -1,0 +1,35 @@
+@echo off
+rem Set up Venv environments for multiple Python versions on Windows platforms
+
+rem Usage:
+rem   setup_venv.sh [env-dir]
+
+rem Args:
+rem   [env-dir]: Path to environment directory; defaults to "..\venvs\vmag".
+
+
+rem parse user env directory path
+set "venvs_dir=..\venvs"
+if not "%~1" == "" (
+  set "venvs_dir=%~1"
+)
+echo Setting the Venvs directory path to %venvs_dir%
+
+pushd "%~dp0"
+cd ..
+
+rem specify full Python versions
+for %%v in (3.6.8 3.7.7 3.8.7 3.9.1) do (
+  echo Creating Venv for Python %%v
+  call pyenv local "%%v"
+  if exist "%venvs_dir%\py%%v"\ (
+    echo Directory already exists, skipping
+  ) else (
+    call python -m venv "%venvs_dir%\py%%v""
+  )
+)
+
+popd
+
+rem keep window open if user double-clicked this script to launch it
+pause

--- a/bin/setup_multi_venvs.sh
+++ b/bin/setup_multi_venvs.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Script to set up Venv environments for multiple Python versions
+
+HELP="
+Create Venv environments for multiple Python versions.
+
+Arguments:
+  -h: Show help and exit.
+  -d [path]: Path to folder where the new venv directory will be placed. 
+    Defaults to \"../venvs\".
+"
+
+venv_dir="../venvs"
+
+OPTIND=1
+while getopts hd: opt; do
+  case $opt in
+    h)
+      echo "$HELP"
+      exit 0
+      ;;
+    d)
+      venv_dir="$OPTARG"
+      echo "Set the venv directory to $venv_dir"
+      ;;
+    :)
+      echo "Option -$OPTARG requires an argument"
+      exit 1
+      ;;
+    *)
+      echo "$HELP" >&2
+      exit 1
+      ;;
+  esac
+done
+
+echo "Initating build of Venvs for multiple Python versions..."
+
+# base directory is script's parent directory
+BASE_DIR="$(dirname "$0")/.."
+cd "$BASE_DIR" || { echo "Unable to find folder $BASE_DIR, exiting"; exit 1; }
+
+# check if Pyenv is installed and if so, store local Python ver setting
+pyenv_local=""
+if command -v pyenv &> /dev/null; then
+  pyenv_local="$(pyenv local)"
+fi
+
+# Build Venv environment for the given Python version.
+# Args:
+#   1: Python version; if Pyenv is available, will get the latest matching ver.
+build_venv() {
+  local ver="$1"
+  # default to Python as pythonx.y, eg python3.6
+  local py="python${ver}"
+  if [[ -n "$pyenv_local" ]]; then
+    # find latest matching Python installed by Pyenv; eg if 3.6.3 and 3.6.11
+    # are installed, 3.6 will give 3.6.11
+    pyenv_ver="$(pyenv whence python | grep "$ver" | sort -V | tail -1)"
+    if [[ -n "$pyenv_ver" ]]; then
+      # set found version as the local Pyenv version
+      pyenv local "$pyenv_ver"
+      py=python
+    else
+      echo "Could not find Pyenv Python version for ${ver}, skipping"
+      return
+    fi
+  elif ! command -v "$py" &> /dev/null; then
+    echo "Could not find ${py}, skipping"
+    return
+  fi
+  
+  # generate new env if folder doesn't exist
+  echo "Building Venv for Python $ver"
+  py_venv="${venv_dir}/py${ver}"
+  if [[ -d "$py_venv" ]]; then
+    echo "$py_venv exists, skipping"
+  else
+    "$py" -m venv "$py_venv"
+  fi
+}
+
+# set up a Venv for each given Python version
+py_vers=(3.6 3.7 3.8 3.9)
+for py_ver in "${py_vers[@]}"; do
+  build_venv "$py_ver"
+done
+
+if [[ -n "$pyenv_local" ]]; then
+  # reset Pyenv local setting
+  pyenv local "$pyenv_local"
+fi

--- a/bin/setup_venv.bat
+++ b/bin/setup_venv.bat
@@ -1,0 +1,50 @@
+@echo off
+rem Set up a Venv environment for MagellanMapper on Windows platforms
+
+rem Usage:
+rem   setup_venv.sh [env-dir]
+
+rem Args:
+rem   [env-dir]: Path to environment directory; defaulst to ..\venvs\vmag
+
+
+rem parse user env directory path
+set "venv_dir=..\venvs\vmag"
+if not "%~1" == "" (
+  set "venv_dir=%~1"
+)
+set "env_act=%venv_dir%\Scripts\Activate.bat"
+echo Setting the Venv path to %venv_dir%
+
+pushd "%~dp0"
+cd ..
+
+rem create new env if a Venv env does not already exist there
+if exist "%venv_dir%\" (
+  if not exist "%env_act%" (
+    echo %venv_dir% exists but does not appear to be a venv."
+    echo "Please choose another venv path. Exiting."
+    exit /b 1
+  )
+  echo %venv_dir% Venv directory exist, will update...
+) else (
+  echo Creating a Venv environment in %venv_dir%
+  call python -m venv "%venv_dir%"
+)
+if not exist "%env_act%" (
+  echo Could not create environment at %env_act%, exiting
+  exit /b 1
+)
+
+rem install/update app and all its dependencies
+call "%env_act%"
+call python -m pip install -U pip
+call pip install --upgrade --upgrade-strategy eager -e .[all] --extra-index-url^
+  https://pypi.fury.io/dd8/
+echo Completed Venv environment setup! Please run %env_act%
+echo to activate the environment if you open a new command prompt.
+
+popd
+
+rem keep window open if user double-clicked this script to launch it
+pause

--- a/bin/setup_venv.sh
+++ b/bin/setup_venv.sh
@@ -84,7 +84,8 @@ if [[ -z "$python" ]]; then
     fi
   fi
   if [[ -z "$python" ]]; then
-    echo "Please install Python >= version ${py_ver_min[0]}.${py_ver_min[1]}"
+    echo "Sorry, could not detect a compatible Python version."
+    echo "Please install one of the following Python versions: ${py_vers[*]}"
     exit 1
   fi
 fi

--- a/bin/setup_venv.sh
+++ b/bin/setup_venv.sh
@@ -66,8 +66,10 @@ py_ver_min=(3 6) # minimum supported Python version
 py_vers=(3.6 3.7 3.8) # range of versions currently supported
 py_vers_prebuilt_deps=(3.6) # vers for which custom prebuilt deps are avail
 for ver in "${py_vers[@]}"; do
-  # prioritize specific versions in case "python" points to lower version
-  if command -v "python$ver" &> /dev/null; then
+  # prioritize specific versions in case "python" points to lower version,
+  # calling Python directly since `command` will show Pyenv Python binaries
+  # exist even if they will not work with a global/local version conflict
+  if "python$ver" -V >/dev/null 2>&1; then
     python=python$ver
     py_ver_majmin="$ver"
     break

--- a/bin/setup_venv.sh
+++ b/bin/setup_venv.sh
@@ -157,8 +157,10 @@ if [[ -z "$VIRTUAL_ENV" ]]; then
   exit 1
 fi
 
-# update pip, using python3 since python3.y may not be in env
-python3 -m pip install -U pip
+# update pip, using python since python3.y may not be in env, and wheel
+# package to speed up installs  
+python -m pip install -U pip
+pip install -U wheel
 
 # install MagellanMapper including required dependencies
 if [[ -n "$update" ]]; then

--- a/docker/buildse/Dockerfile
+++ b/docker/buildse/Dockerfile
@@ -9,6 +9,7 @@ ENV BASE_DIR /app
 # install build tools
 # - multiple Python version from deadsnakes PPA
 # - build tools including specific CMake version required for SimpleElastix
+# - OpenJDK 8 to build Python-Javabridge
 # - vim to allow editing
 RUN echo "deb http://ppa.launchpad.net/deadsnakes/ppa/ubuntu xenial main" \
         >> /etc/apt/sources.list \
@@ -37,6 +38,7 @@ RUN echo "deb http://ppa.launchpad.net/deadsnakes/ppa/ubuntu xenial main" \
         python3.9 \
         python3.9-venv \
         python3.9-dev \
+        default-jdk \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean \
     && apt-get autoclean \
@@ -67,6 +69,8 @@ COPY --chown=$username:$username bin/libmag.sh bin/build_se.sh \
 # assuming the output parent directory `<out>` has been mounted and contains
 # the SimpleElastix (otherwise it will be cloned there):
 # `bin/build_deps.sh -d <out>/builds_se -e venvs -s <out>/SimpleElastix`
-RUN echo 'export PATH=/opt/cmake-3.10.3-Linux-x86_64/bin:$PATH' >> ~/.bashrc \
+RUN echo 'export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64' >> ~/.bashrc \
+    && echo 'export PATH=/opt/cmake-3.10.3-Linux-x86_64/bin:$JAVA_HOME/bin:$PATH' \
+        >> ~/.bashrc \
     && . ~/.bashrc \
     && bin/setup_multi_venvs.sh -d venvs

--- a/docker/buildse/Dockerfile
+++ b/docker/buildse/Dockerfile
@@ -4,20 +4,45 @@
 
 FROM ubuntu:16.04
 
-# run with login Bash shell to allow Conda init
-SHELL ["/bin/bash", "--login", "-c"]
 ENV BASE_DIR /app
 
-# installer build tools
-RUN  apt-get update && apt-get install -y \
-    wget \
-    git \
-    gcc \
-    gawk \
-    bison \
-    make \
-    g++ \
-    && rm -rf /var/lib/apt/lists/*
+# install build tools
+# - multiple Python version from deadsnakes PPA
+# - build tools including specific CMake version required for SimpleElastix
+# - vim to allow editing
+RUN echo "deb http://ppa.launchpad.net/deadsnakes/ppa/ubuntu xenial main" \
+        >> /etc/apt/sources.list \
+    && echo "deb-src http://ppa.launchpad.net/deadsnakes/ppa/ubuntu xenial main" \
+        >> /etc/apt/sources.list \
+    && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys \
+        F23C5A6CF475977595C89F51BA6932366A755776 \
+    && apt-get update && apt-get install -y \
+        wget \
+        git \
+        gcc \
+        gawk \
+        bison \
+        make \
+        g++ \
+        vim \
+        python3.6 \
+        python3.6-venv \
+        python3.6-dev \
+        python3.7 \
+        python3.7-venv \
+        python3.7-dev \
+        python3.8 \
+        python3.8-venv \
+        python3.8-dev \
+        python3.9 \
+        python3.9-venv \
+        python3.9-dev \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get clean \
+    && apt-get autoclean \
+    && wget https://cmake.org/files/v3.10/cmake-3.10.3-Linux-x86_64.tar.gz -P /opt \
+    && tar xzvf /opt/cmake-3.10.3-Linux-x86_64.tar.gz -C /opt \
+    && rm /opt/cmake-3.10.3-Linux-x86_64.tar.gz
 
 # set up non-root user with sudo access
 ARG username=magellan
@@ -35,24 +60,13 @@ WORKDIR $BASE_DIR
 USER $username
 
 # copy in custom SimpleElastix build and Conda setup scripts
-COPY --chown=$username:$username bin/setup_conda bin/libmag.sh bin/build_se.sh \
-    ./bin/
+COPY --chown=$username:$username bin/libmag.sh bin/build_se.sh \
+    bin/setup_multi_venvs.sh bin/build_deps.sh ./bin/
 
-# download and extract CMake version required for SimpleElastix
-RUN wget https://cmake.org/files/v3.10/cmake-3.10.3-Linux-x86_64.tar.gz \
-    && tar xzvf cmake-3.10.3-Linux-x86_64.tar.gz \
-    && echo "export PATH=\"/$BASE_DIR/cmake-3.10.3-Linux-x86_64/bin:$PATH\"" \
-    >> ~/.bashrc
-
-# set up basic Conda environment with Python 3.6 and build SimpleElastix
-# within this environment
-RUN export PATH="$BASE_DIR/cmake-3.10.3-Linux-x86_64/bin:$PATH" \
-    && echo -e "dependencies:\n  - python=3.6" > env.yml \
-    && echo "y" | bin/setup_conda -n sd -s env.yml \
-    && echo "conda activate sd" >> ~/.bashrc \
-    && eval "$(/home/"$username"/miniconda3/bin/conda shell.bash hook)" \
-    && conda clean --all \
-    && rm -rf /home/$username/.cache/pip \
-    && rm Miniconda3-latest-Linux-x86_64.sh \
-    && conda activate sd \
-    && bin/build_se.sh -s SimpleElastix -d build_se
+# afterward, build SimpleElastix for multiple Python version by running,
+# assuming the output parent directory `data` has been mounted:
+# `bin/build_deps.sh -d data/builds_se -e venvs -s SimpleElastix`
+RUN echo 'export PATH=/opt/cmake-3.10.3-Linux-x86_64/bin:$PATH' >> ~/.bashrc \
+    && . ~/.bashrc \
+    && git clone https://github.com/SuperElastix/SimpleElastix.git \
+    && bin/setup_multi_venvs.sh -d venvs

--- a/docker/buildse/Dockerfile
+++ b/docker/buildse/Dockerfile
@@ -64,9 +64,9 @@ COPY --chown=$username:$username bin/libmag.sh bin/build_se.sh \
     bin/setup_multi_venvs.sh bin/build_deps.sh ./bin/
 
 # afterward, build SimpleElastix for multiple Python version by running,
-# assuming the output parent directory `data` has been mounted:
-# `bin/build_deps.sh -d data/builds_se -e venvs -s SimpleElastix`
+# assuming the output parent directory `<out>` has been mounted and contains
+# the SimpleElastix (otherwise it will be cloned there):
+# `bin/build_deps.sh -d <out>/builds_se -e venvs -s <out>/SimpleElastix`
 RUN echo 'export PATH=/opt/cmake-3.10.3-Linux-x86_64/bin:$PATH' >> ~/.bashrc \
     && . ~/.bashrc \
-    && git clone https://github.com/SuperElastix/SimpleElastix.git \
     && bin/setup_multi_venvs.sh -d venvs

--- a/docker/buildse/Dockerfile
+++ b/docker/buildse/Dockerfile
@@ -61,9 +61,9 @@ RUN mkdir /home/$username \
 WORKDIR $BASE_DIR
 USER $username
 
-# copy in custom SimpleElastix build and Conda setup scripts
-COPY --chown=$username:$username bin/libmag.sh bin/build_se.sh \
-    bin/setup_multi_venvs.sh bin/build_deps.sh ./bin/
+# copy in scripts for setting up multiple Venv environments
+COPY --chown=$username:$username bin/libmag.sh bin/setup_multi_venvs.sh \
+        ./bin/
 
 # afterward, build SimpleElastix for multiple Python version by running,
 # assuming the output parent directory `<out>` has been mounted and contains
@@ -74,3 +74,7 @@ RUN echo 'export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64' >> ~/.bashrc \
         >> ~/.bashrc \
     && . ~/.bashrc \
     && bin/setup_multi_venvs.sh -d venvs
+
+# copy in custom build scripts
+COPY --chown=$username:$username bin/build_se.sh bin/build_jb.sh \
+        bin/build_deps.sh ./bin/

--- a/docker/ubuntu1604/Dockerfile
+++ b/docker/ubuntu1604/Dockerfile
@@ -25,7 +25,7 @@ RUN mkdir /home/$username \
     && mkdir $BASE_DIR \
     && chown -R $username:$username $BASE_DIR
 
-# set up appliction base diretory and change to non-root user
+# set up appliction base directory and change to non-root user
 WORKDIR $BASE_DIR
 USER $username
 

--- a/docker/ubuntu1604_venv/Dockerfile
+++ b/docker/ubuntu1604_venv/Dockerfile
@@ -1,0 +1,72 @@
+# Docker build file for MagellanMapper with a Venv environment
+
+FROM ubuntu:16.04
+
+ENV BASE_DIR /app
+
+# install wget, apt-transport-https, and gnupg for AdoptOpenJDK; libsm6
+# and libgl1-mesa-glx fof VTK; and vim for any basic text editing
+RUN apt-get update \
+    && apt-get install -y \
+        wget \
+        sudo \
+        vim \
+        apt-transport-https \
+        gnupg \
+        libsm6 \
+        libgl1-mesa-glx
+
+# install AdoptOpenJDK and Python 3.6 from extra repos
+RUN echo "deb http://ppa.launchpad.net/deadsnakes/ppa/ubuntu xenial main" \
+        >> /etc/apt/sources.list \
+    && echo "deb-src http://ppa.launchpad.net/deadsnakes/ppa/ubuntu xenial main" \
+        >> /etc/apt/sources.list \
+    && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys \
+        F23C5A6CF475977595C89F51BA6932366A755776 \
+    && wget -qO - https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public \
+        | sudo apt-key add - \
+    && echo "deb https://adoptopenjdk.jfrog.io/adoptopenjdk/deb xenial main" \
+        | sudo tee /etc/apt/sources.list.d/adoptopenjdk.list \
+    && apt-get update \
+    && apt-get install -y \
+        python3.6 \
+        python3.6-venv \
+        python3.6-dev \
+        adoptopenjdk-15-hotspot-jre \
+    && rm -rf /var/lib/apt/lists/*
+
+# set up non-root user with sudo access
+ARG username=magellan
+RUN mkdir /home/$username \
+    && groupadd -r $username \
+    && useradd -r -s /bin/false -g $username $username \
+    && echo "$username:$username" | chpasswd \
+    && usermod -aG sudo $username \
+    && chown -R $username:$username /home/$username \
+    && mkdir $BASE_DIR \
+    && chown -R $username:$username $BASE_DIR
+
+# set up appliction base directory and change to non-root user
+WORKDIR $BASE_DIR
+USER $username
+
+# set up Venv environment for MagellanMapper
+COPY --chown=$username:$username bin/setup_venv.sh bin/libmag.sh ./bin/
+COPY --chown=$username:$username setup.py \
+    "SimpleITK-2.0.0rc2.dev908+g8244e-cp36-cp36m-linux_x86_64.whl" ./
+RUN bin/setup_venv.sh -e /home/$username/venvs \
+    && rm -rf /home/$username/.cache/pip \
+    && echo "export JAVA_HOME=/usr/lib/jvm/adoptopenjdk-15-hotspot-jre-amd64" \
+        >> ~/.bashrc \
+    && echo ". /home/$username/venvs/mag/bin/activate" >> ~/.bashrc \
+    && . /home/$username/venvs/mag/bin/activate \
+    && pip uninstall -y SimpleITK \
+    && pip install "SimpleITK-2.0.0rc2.dev908+g8244e-cp36-cp36m-linux_x86_64.whl"
+
+# extract application contents from a git archive to use only files in
+# the repository; copy after Venv setup to avoid triggering rebuilding
+# prior layers for code updates
+COPY --chown=$username:$username magellanmapper_gitarc.tar.gz ./
+RUN tar xzvf magellanmapper_gitarc.tar.gz \
+    && rm magellanmapper_gitarc.tar.gz \
+    "SimpleITK-2.0.0rc2.dev908+g8244e-cp36-cp36m-linux_x86_64.whl"

--- a/docs/install.md
+++ b/docs/install.md
@@ -36,17 +36,20 @@ See the [Readme](../README.md#run-magellanmapper) for instructions on running Ma
 
 ## Option 2: Install through Venv+Pip
 
-Venv is a virtual environment manager included with Python 3.3+. We have provided a convenient script to set up a new environment and install all dependencies using Pip:
+Venv is a virtual environment manager included with Python (3.3+). We have provided a convenient script to set up a new environment and install all dependencies using Pip:
 
 ```
 bin/setup_venv.sh [-n name]
 ```
 
-This option assumes that you have already installed Python 3.6 and a Java Development Kit (JDK) 8. Other versions of Python 3 and the JDK may work but with varying other requirements, such as a C compiler to build dependencies (see [below](#custom-precompiled-packages)).
+This option assumes that you have already installed Python 3.6 and Java 8+.
+
+**UPDATE**: In MagellanMapper 1.4, Python versions 3.6-3.8 are supported now that we have built custom dependencies for these version.
 
 This setup script will check and install the following dependencies:
 
-- Checks for an existing Python 3.6+, which already includes Venv
+- Checks for an existing compatible Python version
+- Checks for other requirements, such as a C compiler to [build some dependencies](#custom-precompiled-packages)
 - Performs a Pip install of MagellanMapper and all dependencies
 
 ## Option 3: Install in another virtual environment or system-wide
@@ -103,10 +106,12 @@ In most cases MagellanMapper can be installed without a compiler by using custom
 
 | Dependency | Precompiled Available? | Precompiled Run Req | Build Req | Purpose | 
 | --- | --- | --- | --- | --- |
-| Python-Javabridge | Yes, via custom package | Python 3.6, Java 8+ | JDK, C compiler| Import proprietary image formats |
+| Python-Javabridge | Yes, via custom package | Python 3.6-3.9[^\*], Java 8+ | JDK, C compiler| Import proprietary image formats |
 | Traits, Pyface, Traitsui | Yes, via Conda (not PyPI) | Python 3.6+ | C compiler, Python dev | GUI |
-| SimpleElastix | Yes, via custom package | Python 3.6 | C, C++ compilers | Load medical 3D formats, image regsitration |
+| SimpleElastix | Yes, via custom package | Python 3.6-3.9 | C, C++ compilers | Load medical 3D formats, image regsitration |
 | ImageJ/FIJI | Yes, via direct download | Java 8 | n/a | Image stitching |
+
+[^\*]: Extended wheels to Python 3.7-3.9 in MagellanMapper 1.4, though Python 3.9 is not supported yet until VTK also provides wheels for this version
 
 C compilers by platform:
 

--- a/docs/release/release_v1.4.md
+++ b/docs/release/release_v1.4.md
@@ -142,7 +142,9 @@ Code base and docs
 
 #### Python Dependency Changes
 
-- The `appdirs` [package](https://github.com/ActiveState/appdirs) has been added to store user application files in standard operating system-dependent locations, eg `~/Library/Application Support/MagellanMapper` on macOS and `%HOME%\AppData\Local\MagellanMapper` on Windows platforms, allowing the application to be stored in locations without standard write access
+- The `appdirs` [package](https://github.com/ActiveState/appdirs) has been added to store user application files in standard operating system-dependent locations, allowing the application to be stored in locations without standard write access (see [settings](../settings.md#user-application-folder) for more details)
+  - The database (`magmap.db`) is generated and stored there
+  - Any existing `magmap.db` in the project root folder is left in place; copy it to the user application folder if you would like to use it
 - Custom wheels have been built for SimpleElastix and Javabridge on Python 3.6-3.9
   - Wheels are compatible with macOS 10.9+, Windows 10, and Linux glibc 2.23 (eg Ubuntu 16.04)
   - Python 3.9 is not yet supported for MagellanMapper because VTK 9 currently does not support this Python version

--- a/docs/release/release_v1.4.md
+++ b/docs/release/release_v1.4.md
@@ -13,6 +13,7 @@ Installation
     - As we added a [new dependency](#python-dependency-changes), we made it easier to update existing environments
     - Re-running `bin\setup_conda.bat` on Windows updates as `bin/setup_conda` has on Mac/Linux
     - `bin/venv.sh` can now also be re-run to update Venv environments
+- Python version support has been expanded to 3.6-3.8 now that we have [built](#python-dependency-changes) custom dependencies for these Python versions
 
 GUI
 - Reorganized options to group by viewer
@@ -142,6 +143,9 @@ Code base and docs
 #### Python Dependency Changes
 
 - The `appdirs` [package](https://github.com/ActiveState/appdirs) has been added to store user application files in standard operating system-dependent locations, eg `~/Library/Application Support/MagellanMapper` on macOS and `%HOME%\AppData\Local\MagellanMapper` on Windows platforms, allowing the application to be stored in locations without standard write access
+- Custom wheels have been built for SimpleElastix and Javabridge on Python 3.6-3.9
+  - Wheels are compatible with macOS 10.9+, Windows 10, and Linux glibc 2.23 (eg Ubuntu 16.04)
+  - Python 3.9 is not yet supported for MagellanMapper because VTK 9 currently does not support this Python version
 
 #### R Dependency Changes
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -1,10 +1,21 @@
 # Settings in MagellanMapper
 
-MagellanMapper supports settings configuration at several different levels of "permanence." Starting from the most transient to more enduring settings, these settings are:
+MagellanMapper supports settings configuration at different levels of "permanence." Starting from the most transient to more enduring settings, these settings are:
 
 1. Graphical user interface (GUI) controls, configurable during runtime
 1. Command-line arguments, set at launch time
 1. Profiles, groups of settings saved in a file and set at launch time or loaded through the GUI
+
+Additional data and settings such as blob detections are stored in the user application folder.
+
+## User Application Folder
+
+As of v1.4, application support files such as the MagellanMapper database are stored in the following folder locations:
+- macOS: `~/Library/Application Support/MagellanMapper`
+- Windows: `%HOME%\AppData\Local\MagellanMapper`
+- Linux: `~/.local/share/MagellanMapper`
+
+Previously, the database (`magmap.db`) was stored in the application root folder. A new database will be generated in the user application folder, but the original file can be copied from there to use it insead if desired.
 
 ## GUI Parameters
 

--- a/setup.py
+++ b/setup.py
@@ -34,14 +34,14 @@ config = {
         "scikit-image",
         # PlotEditor performance regression with 3.3.0-3.3.1
         "matplotlib != 3.3.0, != 3.3.1",
-        "vtk<9.0.0",  # Mayavi 4.7.1 is not compatible with VTK 9
+        "vtk",
         "mayavi", 
         "pandas", 
         "PyQt5",
         "pyface",
         "traitsui",
         "scikit-learn",
-        "simpleitk==1.2.0rc2.dev1162+g2a79d",  # pre-built SimpleElastix
+        "simpleitk==2.0.2rc2.dev785+g8ac4f",  # pre-built SimpleElastix
         "PyYAML",
         "appdirs",
     ], 

--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,8 @@ import setuptools
 
 # optional dependencies to import files via BioFormats, which req Java 8+
 _EXTRAS_IMPORT = [
-    # pre-built Javabridge with Python 3.6, Java 8
-    "javabridge==1.0.18.post21+g4526f53",
+    # Javabridge pre-built on Java 8
+    "javabridge==1.0.19.post4+gbebed64",
     "python-bioformats==1.1.0",
 ]
 


### PR DESCRIPTION
Two key dependencies for MagellanMapper do not currently provide Python wheel packages and are not straightforward to build:
- SimpleElastix, built through Cmake and unable to be compiled through Pip (as far as I know)
- Javabridge, which requires a Java Development Kit to build when installing through Pip

To avoid requiring users to compile these packages themselves, we have provided custom wheels built on all three major OSes. Although we have scripts to build SimpleElastix, the process has consisted of several manual steps for each dependency. To limit the workload, we have built wheels only for Python 3.6 thus far.

Automating these builds would have several advantages:
- Enable more frequent updates to these dependencies as necessary
- Facilitate building for multiple Python versions, relieving this bottleneck in MagellanMapper compatibility with more modern Python versions
- Reduce potential for manual build errors

The automation has been implemented as Bash and Batch scripts to build off of the existing build scripts. As these dependencies are third-party applications to MagellanMapper, which we will likely only build infrequently and as-needed, we did not implement continuous integration builds but could consider doing so in the future.

We have built wheels for Python 3.6-3.9 on Windows, macOS, and Linux. Python 3.9 is still not supported in MagellanMapper as VTK does not yet provide wheels for Python 3.9.
- Windows wheels were built on Windows 10 and are likely compatible with earlier Windows versions, though we have not tested them
- macOS compatibility for SimpleElastix was increased slightly from macOS 10.7 to 10.9 given the lowest version allowed during the SimpleElastix build
- Linux wheels have been built in a Docker image based on Ubuntu 16.04 to provide glibc compatibility back to 2.23

In the process of these updates, we also improved support for the built-in Venv for Python virtual environments, which relieves dependency on Conda. A Batch script is now provided to set up a Venv environment on Windows, and we have added a Dockerfile with MagellanMapper installed in Venv. All of the dependency wheels are now thus built in Venv with Python installed by Pyenv.