### PR TITLE
Log unhandled exceptions

### DIFF
--- a/docs/release/release_v1.4.md
+++ b/docs/release/release_v1.4.md
@@ -134,6 +134,7 @@ Code base and docs
 - Python APIs
     - Previously Python APIs compatible with both Python 2 and 3 have been used when possible, but much of the package requires Python 3, and testing has been on Python >= 3.6
     - For a more consistent and modern codebase, we are initiating use of Python 3 APIs such as `pathlib` and specifically 3.6+ features such as f-strings
+- Unhandled exceptions are now logged (saved to a temp file if caught before logging is set up)
 - More links to external packages in API docs
 - Instructions on building the API docs
 - `Blobs` and `Image5d` are being migrated to class structures for better encapsulation and additional metadata


### PR DESCRIPTION
Catch unhandled exceptions globally through the except hook. Log these exceptions to file, ideally using the existing logger file handler. In case this handler does not exist, also output to a standard Python temporary file path, which avoids the need to load libraries to identify the user app directory.