### PR TITLE
Open files by Apple Events

### DIFF
--- a/bin/setup_pyinstaller.spec
+++ b/bin/setup_pyinstaller.spec
@@ -138,4 +138,20 @@ app = BUNDLE(
     info_plist={
         # support dark theme
         "NSRequiresAquaSystemAppearance": False,
+        
+        # open files passed as magmap:<path>[?query]
+        # TODO: implement file handling
+        "CFBundleURLTypes": [{
+            "CFBundleURLName": f"{config.APP_NAME}_{config.URI_SCHEME}",
+            "CFBundleTypeRole": "Viewer",
+            "CFBundleURLSchemes": [config.URI_SCHEME],
+        }],
+        
+        # open files passed through file browser or drag-n-drop
+        # TODO: implement drag-n-drop file handling
+        "CFBundleDocumentTypes": [{
+            "CFBundleTypeName": f"{config.APP_NAME}_NPY",
+            "CFBundleTypeExtensions": ["npy"],
+            "CFBundleTypeRole": "Viewer",
+        }],
     })

--- a/bin/setup_pyinstaller.spec
+++ b/bin/setup_pyinstaller.spec
@@ -154,8 +154,9 @@ app = BUNDLE(
         # open files passed through file browser or drag-n-drop
         # TODO: implement drag-n-drop file handling
         "CFBundleDocumentTypes": [{
-            "CFBundleTypeName": f"{config.APP_NAME}_NPY",
-            "CFBundleTypeExtensions": ["npy"],
+            "CFBundleTypeName": f"{config.APP_NAME}_FileTypes",
+            "CFBundleTypeExtensions": [
+                "npy", "mhd", "mha", "nii", "nii.gz", "nrrd", "nhdr"],
             "CFBundleTypeRole": "Viewer",
         }],
     })

--- a/bin/setup_pyinstaller.spec
+++ b/bin/setup_pyinstaller.spec
@@ -139,6 +139,10 @@ app = BUNDLE(
         # support dark theme
         "NSRequiresAquaSystemAppearance": False,
         
+        # set identifier and name
+        "CFBundleIdentifier": config.DNS_REVERSE,
+        "CFBundleName": config.APP_NAME,
+        
         # open files passed as magmap:<path>[?query]
         # TODO: implement file handling
         "CFBundleURLTypes": [{

--- a/magmap/gui/event_handlers.py
+++ b/magmap/gui/event_handlers.py
@@ -1,0 +1,53 @@
+# PyQt event handlers
+"""Handlers for PyQt events."""
+
+from PyQt5.QtCore import QObject, QEvent
+
+from magmap.settings import config
+
+_logger = config.logger.getChild(__name__)
+
+
+class FileOpenHandler(QObject):
+    """Handle file opening events.
+    
+    These events are triggered by Apple Events through the PyInstaller
+    bootloader.
+    
+    Attributes:
+        fn_open_image (func): Function to open an image, taking the image path.
+    
+    """
+    def __init__(self, fn_open_image, parent=None):
+        """Create a new instance of the file open handler.
+        
+        Args:
+            fn_open_image (func): Function to open an image.
+            parent (:class:`PyQt5.QtCore.QObject`): Parent object.
+        
+        """
+        super().__init__(parent=parent)
+        self.fn_open_image = fn_open_image
+
+    def eventFilter(self, watched, event):
+        """Handle open file events.
+        
+        Args:
+            watched (:class:`PyQt5.QtCore.QObject`): Watched object. 
+            event (:class:`PyQt5.QtCore.QEvent`): Event oject.
+
+        Returns:
+            bool: True if the event was filtered out; otherwise the return
+            output from the base class.
+
+        """
+        if event.type() == QEvent.FileOpen:
+            _logger.debug("File open event:", event.url())
+            url = event.url().toString()
+            scheme = "file://"
+            if url.startswith(scheme):
+                # remove file scheme and trigger file opening
+                url = url[len(scheme):]
+                self.fn_open_image(url)
+                return True
+        return super().eventFilter(watched, event)

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -1765,20 +1765,13 @@ class Visualization(HasTraits):
             self._ignore_filename = False
             return
         
-        # load image if possible without allowing import
-        filename, offset, size, reg_suffixes = importer.deconstruct_np_filename(
+        # load image if possible without allowing import, deconstructing
+        # filename from the selected imported image
+        filename, offset, size, reg_suffixes = importer.deconstruct_img_name(
             self._filename)
         if filename is not None:
-            config.filename = filename
-            print("Changed filename to", config.filename)
-            if offset is not None and size is not None:
-                config.subimg_offsets = [offset]
-                config.subimg_sizes = [size]
-                print("Change sub-image offset to {}, size to {}"
-                      .format(config.subimg_offsets, config.subimg_sizes))
-            # TODO: consider loading processed images, blobs, etc
-            if reg_suffixes:
-                config.reg_suffixes.update(reg_suffixes)
+            importer.parse_deconstructed_name(
+                filename, offset, size, reg_suffixes)
             np_io.setup_images(
                 config.filename, offset=offset, size=size, allow_import=False)
             self._setup_for_image()

--- a/magmap/io/cli.py
+++ b/magmap/io/cli.py
@@ -747,13 +747,21 @@ def process_tasks():
             for series in config.series_list:
                 # process files for each series, typically a tile within a
                 # microscopy image set or a single whole image
-                offset = (config.subimg_offsets[0] if config.subimg_offsets
-                          else None)
-                size = config.subimg_sizes[0] if config.subimg_sizes else None
+                filename, offset, size, reg_suffixes = \
+                    importer.deconstruct_img_name(config.filename)
+                set_subimg, _ = importer.parse_deconstructed_name(
+                    filename, offset, size, reg_suffixes)
+                if not set_subimg:
+                    # sub-image parameters set in filename takes precedence for
+                    # the loaded image, but fall back to user-supplied args
+                    offset = (config.subimg_offsets[0] if config.subimg_offsets
+                              else None)
+                    size = (config.subimg_sizes[0] if config.subimg_sizes
+                            else None)
                 np_io.setup_images(
-                    config.filename, series, offset, size, config.proc_type)
+                    filename, series, offset, size, config.proc_type)
                 process_file(
-                    config.filename, config.proc_type, series, offset, size,
+                    filename, config.proc_type, series, offset, size,
                     config.roi_offsets[0] if config.roi_offsets else None,
                     config.roi_sizes[0] if config.roi_sizes else None)
         else:

--- a/magmap/io/importer.py
+++ b/magmap/io/importer.py
@@ -79,6 +79,7 @@ _KEY_ANY_CHANNEL = "1+"  # 1+ channel files
 
 _logger = config.logger.getChild(__name__)
 
+
 def is_javabridge_loaded():
     """Check if Javabridge and Python-Bioformats have been loaded.
     
@@ -287,7 +288,7 @@ def filename_to_base(filename, series=None, modifier=""):
     return path
 
 
-def deconstruct_np_filename(np_filename, sep="_", keep_subimg=False):
+def deconstruct_img_name(np_filename, sep="_", keep_subimg=False):
     """Deconstruct Numpy or registered image filename to the original name
     from which it was based.
 
@@ -360,6 +361,37 @@ def deconstruct_np_filename(np_filename, sep="_", keep_subimg=False):
         # default to returning path as-is
         base_path = np_filename
     return base_path, offset, size, reg_suffixes
+
+
+def parse_deconstructed_name(filename, offset, size, reg_suffixes):
+    """Parse deconstructed image name into :module:`config` settings.
+    
+    Args:
+        filename (str): Deconstructed image path.
+        offset (tuple[int, int, int]): Deconstructed sub-image offset.
+        size (tuple[int, int, int]): Deconstructed sub-image size.
+        reg_suffixes (dict): Registered image suffixes.
+
+    Returns:
+        bool, bool: True if the sub-image parameters were set, True if the
+        registered suffixes were set.
+
+    """
+    config.filename = filename
+    _logger.debug("Changed filename to", config.filename)
+    set_subimg = offset is not None and size is not None
+    if set_subimg:
+        config.subimg_offsets = [offset]
+        config.subimg_sizes = [size]
+        _logger.debug("Change sub-image offset to {}, size to {}"
+                      .format(config.subimg_offsets, config.subimg_sizes))
+    # TODO: consider loading processed images, blobs, etc
+    set_reg_suffixes = False
+    if reg_suffixes:
+        config.reg_suffixes.update(reg_suffixes)
+        set_reg_suffixes = True
+        _logger.debug("Update registered image suffixes to:", reg_suffixes)
+    return set_subimg, set_reg_suffixes
 
 
 def save_image_info(filename_info_npz, names, sizes, resolutions, 

--- a/magmap/io/sqlite.py
+++ b/magmap/io/sqlite.py
@@ -211,7 +211,7 @@ def get_exp_name(path):
         while preserving the sub-image string.
 
     """
-    path_decon = importer.deconstruct_np_filename(
+    path_decon = importer.deconstruct_img_name(
         path, keep_subimg=True)[0]
     if path_decon:
         path_decon = os.path.splitext(os.path.basename(path_decon))[0]

--- a/magmap/settings/config.py
+++ b/magmap/settings/config.py
@@ -45,6 +45,8 @@ from magmap.settings import logs
 APP_NAME = "MagellanMapper"
 #: str: Uniform Resource Identifier scheme.
 URI_SCHEME = "magmap"
+#: str: Reverse Domain Name System identifier.
+DNS_REVERSE = f"io.github.sanderslab.{APP_NAME}"
 #: float: Threshold for positive values for float comparison.
 POS_THRESH = 0.001
 #: int: Number of CPUs for multiprocessing tasks; defaults to None to

--- a/magmap/settings/config.py
+++ b/magmap/settings/config.py
@@ -43,6 +43,8 @@ from magmap.settings import logs
 
 #: str: Application name.
 APP_NAME = "MagellanMapper"
+#: str: Uniform Resource Identifier scheme.
+URI_SCHEME = "magmap"
 #: float: Threshold for positive values for float comparison.
 POS_THRESH = 0.001
 #: int: Number of CPUs for multiprocessing tasks; defaults to None to


### PR DESCRIPTION
Detect Apple Events in PyInstaller builds when the app to open image files in the current window or a new app instance.

This PR provides two additional functionalities:

1. PyInstaller builds detect open document Apple Events such as those from Finder or dragging and dropping a file onto the app icon. These events are passed to the app on its startup as a command-line argument. While MagellanMapper interprets these leading arguments as image paths, those given through Finder are typically full image paths (eg `myvolume_image5d.npy`), rather than the original-based image paths (eg `myvolume.czi` or `myvolume.`) that the app normally expects. Apply the same image path deconstruction used within the GUI to identify and open these images given as command-line arguments, including those passed by Finder to the app on startup.

1. When these Apple Events are passed to an app that is already open, they can be handled by `PyQt5.QtCore.QEvent`. File open events are now detected and passed to the running app. If the app does not yet have an image set, the image is simply loaded into the existing app. If the app has already loaded an image, a new app instance is spawned to load this image. This new instance avoids overwriting any current image changes and allows comparison between two images in separate app instances.

To allow more file formats to be loaded through these events, additional file type extensions such as `.mhd` and `.nii.gz` have been added to the .app bundle. Theoretically any file type supported through SimpleITK can be added here.

Note that currently the PyInstaller bootloader swallows up these events when the app is built in `--onedir` mode. We recover these events using a patched PyInstaller bootloader: https://github.com/yoda-vid/pyinstaller/commit/355c8a6393921e4998468d7e7f111c4e12317b6a .