### PR TITLE
Support alternate column names in labels reference files

### DIFF
--- a/magmap/io/np_io.py
+++ b/magmap/io/np_io.py
@@ -378,8 +378,10 @@ def setup_images(path=None, series=None, offset=None, size=None,
                     # parse dict from ABA JSON file
                     config.labels_ref_lookup = (
                         ontology.create_aba_reverse_lookup(labels_ref))
-        except FileNotFoundError as e:
+        except (FileNotFoundError, KeyError) as e:
             _logger.error(e)
+            _logger.error("Skipping labels reference file loading from '%s'",
+                          config.load_labels)
     
     borders_suffix = config.reg_suffixes[config.RegSuffixes.BORDERS]
     if borders_suffix is not None:


### PR DESCRIPTION
Addresses issue mentioned in #26 when loading the `region_ids.csv` file included with the E18.5 atlas in the sample data.

The ID and region name columns in labels reference files have assumed the values in the Allen ontology/structure graph files. Support alternate keys using the `AtlasMetrics` enums used for output stats. Catch key errors when loading these files to avoid crash on startup when unable to parse the files.