### PR TITLE
Fix error when unable to find Java home directory

### DIFF
--- a/magmap/io/importer.py
+++ b/magmap/io/importer.py
@@ -30,9 +30,9 @@ import numpy as np
 try:
     import javabridge as jb
     import bioformats as bf
-except (ImportError, ValueError) as e:
-    # Javabridge gives a JVMNotFoundException that extends ValueError if
-    # Java cannot be initialized
+except (ImportError, ValueError, RuntimeError) as e:
+    # Javabridge gives a JVMNotFoundError that extends ValueError if
+    # Java cannot be initialized, or a RuntimeError if Java home dir not found 
     jb = None
     bf = None
     warnings.warn(


### PR DESCRIPTION
Fixes #28. Catch exceptions raised from Javabridge when it cannot find a Java home directory path, such as that set by a `JAVA_HOME` environment variable. Also, fix the docs' reference to the `JVMNoutFoundError` raised when Java cannot be initialized.