### PR TITLE
Support multiple processing tasks in the same command

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -20,6 +20,13 @@ Argument | Sub-argument | Function | Ver Added | Last updated
 `--load` | `blobs=<path> blob_matches=<path>` | Paths to load data. `blobs` are objects detected as blobs. `blob_matches` are co-localized blobs among channels. | v1.4.0 | [v1.4.0](#changes-in-magellanmapper-v14)
 TODO: finish arguments
 
+## Changes in MagellanMapper v1.5
+
+Old | New | Version | Purpose of Change |
+--- | --- | --- | ---
+`--proc <task>` | `--proc <task1>=[sub-task1,...] <task2>` | v1.5.0 | Multiple processing tasks can be given as well as sub-tasks
+Specified in ROI profiles | `--proc preprocess=[rotate,saturate,...]` | v1.5.0 | Pre-processing tasks are integrated as sub-processing tasks; see `config.PreProcessKeys` for task names
+
 ## Changes in MagellanMapper v1.4
 
 Old | New | Version | Purpose of Change |
@@ -56,6 +63,7 @@ None | `--cpus <n>` | v1.3.6 | Specify the maximum number of CPUs to use for mul
 `--no_show` | `--show 0` | v1.3.0 | Show with `1`
 `--padding_2d` | `--plot_labels margin=x,y,z` | v1.3.0 | Grouped with other plot labels controls, adding `margin` as space outside the ROI
 None | `--proc export_raw` | v1.3.2 | Export images to RAW format
+None | `--proc preprocess` | v1.3.0 | Pre-processing tasks using `profiles.PreProcessKeys` specified in ROI profiles
 None | `--plot_labels dpi=<n>` | v1.3.7 | Configure DPI of saved images
 None | `--plot_labels drop_dups=<0|1>` | v1.3.3 | Option to drop duplicates when joining data frames
 `--atlas_labels binary=<color>` | `--plot_labels nan_color=<color>` | v1.3.7 | Group with `--plot_labels` to specify colors for NaN values

--- a/magmap/io/cli.py
+++ b/magmap/io/cli.py
@@ -1157,12 +1157,11 @@ def process_file(path, proc_type, proc_val=None, series=None, subimg_offset=None
     elif proc_type is config.ProcessTypes.PREPROCESS:
         # pre-process a whole image and save to file
         # TODO: consider chunking option for larger images
-        profile = config.get_roi_profile(0)
         out_path = config.prefix
         if not out_path:
             out_path = libmag.insert_before_ext(config.filename, "_preproc")
         transformer.preprocess_img(
-            config.image5d, profile["preprocess"], config.channel, out_path)
+            config.image5d, proc_val, config.channel, out_path)
 
     return stats, fdbk
 

--- a/magmap/io/cli.py
+++ b/magmap/io/cli.py
@@ -189,13 +189,14 @@ def args_to_dict(args, keys_enum, args_dict=None, sep_args="=", sep_vals=",",
             # 1 to num of members
             n = i + 1
             if n > num_enums:
-                print("no further parameters in {} to assign \"{}\" by "
-                      "position, skipping".format(keys_enum, arg))
+                _logger.warn(
+                    "No further parameters in {} to assign \"{}\" by "
+                    "position, skipping".format(keys_enum, arg))
                 continue
             key = keys_enum(n)
         elif len_arg_split < 2:
-            print("parameter {} does not contain a keyword, skipping"
-                  .format(arg))
+            _logger.warn("parameter {} does not contain a keyword, skipping"
+                         .format(arg))
         else:
             # assign based on keyword if its equivalent enum exists
             vals = arg_split[1]
@@ -203,7 +204,8 @@ def args_to_dict(args, keys_enum, args_dict=None, sep_args="=", sep_vals=",",
             try:
                 key = keys_enum[key_str]
             except KeyError:
-                print("unable to find {} in {}".format(key_str, keys_enum))
+                _logger.warn("Unable to find '{}' in {}, skipping".format(
+                    key_str, keys_enum))
                 continue
         if key:
             if isinstance(vals, str):

--- a/magmap/io/libmag.py
+++ b/magmap/io/libmag.py
@@ -1001,10 +1001,11 @@ def get_enum(s, enum_class):
     """
     enum = None
     if s:
-        s_upper = s.upper()
         try:
+            s_upper = s.upper()
             enum = enum_class[s_upper]
-        except KeyError:
+        except (AttributeError, KeyError):
+            # AttributeError if s is not a str; KeyError if not in enum
             pass
     return enum
 

--- a/magmap/io/np_io.py
+++ b/magmap/io/np_io.py
@@ -144,7 +144,7 @@ def _check_np_none(val):
 
 
 def setup_images(path=None, series=None, offset=None, size=None,
-                 proc_mode=None, allow_import=True):
+                 proc_type=None, allow_import=True):
     """Sets up an image and all associated images and metadata.
 
     Paths for related files such as registered images will generally be
@@ -157,8 +157,8 @@ def setup_images(path=None, series=None, offset=None, size=None,
         series (int): Image series number; defaults to None.
         offset (List[int]): Sub-image offset given in z,y,x; defaults to None.
         size (List[int]): Sub-image shape given in z,y,x; defaults to None.
-        proc_mode (str): Processing mode, which should be a key in 
-            :class:`config.ProcessTypes`, case-insensitive; defaults to None.
+        proc_type (Enum): Processing type, which should be a one of
+            :class:`config.ProcessTypes`.
         allow_import (bool): True to allow importing the image if it
             cannot be loaded; defaults to True.
     
@@ -230,7 +230,6 @@ def setup_images(path=None, series=None, offset=None, size=None,
             print("Ignored sub-image file from {} as unable to load"
                   .format(filename_subimg))
 
-    proc_type = libmag.get_enum(proc_mode, config.ProcessTypes)
     if config.load_data[config.LoadData.BLOBS] or proc_type in (
             config.ProcessTypes.LOAD,
             config.ProcessTypes.COLOC_MATCH,

--- a/magmap/io/np_io.py
+++ b/magmap/io/np_io.py
@@ -234,8 +234,7 @@ def setup_images(path=None, series=None, offset=None, size=None,
             config.ProcessTypes.LOAD,
             config.ProcessTypes.COLOC_MATCH,
             config.ProcessTypes.EXPORT_ROIS,
-            config.ProcessTypes.EXPORT_BLOBS,
-            config.ProcessTypes.DETECT):
+            config.ProcessTypes.EXPORT_BLOBS):
         # load a blobs archive
         blobs = detector.Blobs()
         try:

--- a/magmap/settings/config.py
+++ b/magmap/settings/config.py
@@ -216,6 +216,11 @@ class ProcessTypes(Enum):
     EXPORT_PLANES_CHANNELS = auto()  # also export channels to separate files
     EXPORT_RAW = auto()  # export an array as a raw data file
     PREPROCESS = auto()  # pre-process whole image
+
+
+#: dict[Enum, Any]: Processing tasks.
+proc_type = dict.fromkeys(ProcessTypes, None)
+
 # 2D PLOTTING
 
 

--- a/magmap/settings/config.py
+++ b/magmap/settings/config.py
@@ -200,6 +200,14 @@ magnification = 1.0  #: float: objective magnification
 zoom = 1.0  #: float: objective zoom
 
 
+class PreProcessKeys(Enum):
+    """Pre-processing task enumerations."""
+    SATURATE = auto()
+    DENOISE = auto()
+    REMAP = auto()
+    ROTATE = auto()
+
+
 class ProcessTypes(Enum):
     """Whole image processing task enumerations."""
     IMPORT_ONLY = auto()  # imports image stack

--- a/magmap/settings/config.py
+++ b/magmap/settings/config.py
@@ -199,36 +199,23 @@ resolutions = None
 magnification = 1.0  #: float: objective magnification
 zoom = 1.0  #: float: objective zoom
 
-#: :class:`Enum`: Whole image processing task enumerations.
-# ``importonly`` imports an image stack and
-# exits non-interactively. ``load`` loads already
-# processed images and segments. ``extract`` extracts a single plane 
-# using the z-value from the offset and exits. ``export_rois`` 
-# exports ROIs from the current database to serial 2D plots. 
-# ``transpose`` transposes the Numpy image file associated with 
-# ``filename`` with the ``--rescale`` option. ``animated`` generates 
-# an animated GIF with the ``--interval`` and ``--rescale`` options. 
-# ``export_blobs`` exports blob coordinates/radii to compressed CSV file.
-ProcessTypes = Enum(
-    "ProcessTypes", (
-        "IMPORT_ONLY",
-        "DETECT",  # whole image blob detection
-        "DETECT_COLOC",  # detection with colocalization by intensity
-        "COLOC_MATCH",  # colocalization by blob matching
-        "LOAD",
-        "EXTRACT",
-        "EXPORT_ROIS",
-        "TRANSFORM",
-        "ANIMATED",
-        "EXPORT_BLOBS",
-        "EXPORT_PLANES",  # export a 3D+ image to individual planes
-        "EXPORT_PLANES_CHANNELS",  # also export channels to separate files
-        "EXPORT_RAW",  # export an array as a raw data file
-        "PREPROCESS",  # pre-process whole image
-    )
-)
-proc_type = None
 
+class ProcessTypes(Enum):
+    """Whole image processing task enumerations."""
+    IMPORT_ONLY = auto()  # imports image stack
+    DETECT = auto()  # whole image blob detection
+    DETECT_COLOC = auto()  # detection with colocalization by intensity
+    COLOC_MATCH = auto()  # colocalization by blob matching
+    LOAD = auto()  # DEPRECATED: load previously processed images and blobs
+    EXTRACT = auto()  # extract single plane using the z-val from offset
+    EXPORT_ROIS = auto()  # export ROIs from current database to serial 2D plots
+    TRANSFORM = auto()  # transform image (see transformer.transpose_img)
+    ANIMATED = auto()  # generate an animated GIF
+    EXPORT_BLOBS = auto()  # export blob coordinates/radii to compressed CSV
+    EXPORT_PLANES = auto()  # export a 3D+ image to individual planes
+    EXPORT_PLANES_CHANNELS = auto()  # also export channels to separate files
+    EXPORT_RAW = auto()  # export an array as a raw data file
+    PREPROCESS = auto()  # pre-process whole image
 # 2D PLOTTING
 
 

--- a/magmap/settings/profiles.py
+++ b/magmap/settings/profiles.py
@@ -30,14 +30,6 @@ class RegKeys(Enum):
     KNN_N = auto()
 
 
-class PreProcessKeys(Enum):
-    """Pre-processing task enumerations."""
-    SATURATE = auto()
-    DENOISE = auto()
-    REMAP = auto()
-    ROTATE = auto()
-
-
 #: dict: Dictionary mapping the names of Enums used in profiles to their Enum
 # classes for parsing Enums given as strings.
 _PROFILE_ENUMS = {
@@ -45,7 +37,6 @@ _PROFILE_ENUMS = {
     "Cmaps": config.Cmaps,
     "SmoothingModes": config.SmoothingModes,
     "MetricGroups": config.MetricGroups,
-    "PreProcessKeys": PreProcessKeys,
     "LoadIO": config.LoadIO,
 }
 

--- a/magmap/settings/roi_prof.py
+++ b/magmap/settings/roi_prof.py
@@ -69,8 +69,6 @@ class ROIProfile(profiles.SettingsDict):
         self["erosion_threshold"] = 0.2  # erode clumped cells
         # adaptive histogram equalization clipping limit
         self["adapt_hist_lim"] = 0.1
-        # sequence of profiles.PreProcessKeys for outputting a pre-processed img
-        self["preprocess"] = None
 
         # 3D blob detection settings
 


### PR DESCRIPTION
The `--proc` command-line argument has supported only one argument at a time. This PR expands support for multiple tasks during the same command, each given as a separate string. For example, to both detect blobs and perform match-based colocalization, the command can be given as:

```
python run.py <image-path> --proc detect coloc_match
```

The arguments are parsed similarly to other arguments that may contain sub-arguments. This change allows integrating other sub-tasks into this parameter, such as the image preprocessing tasks. Previously, preprocessing needing to be supplied as such:

```
python run.py <image-path> --proc preprocess --roi_profile <profile-with-preprocess-setting>
```

which now simplifies to:

```
python run.py <image-path> --proc preprocess=rotate
```

for a rotation task, for example.