### PR TITLE
Option to turn off edge distance measuring

### DIFF
--- a/magmap/settings/atlas_prof.py
+++ b/magmap/settings/atlas_prof.py
@@ -227,6 +227,10 @@ class AtlasProfile(profiles.SettingsDict):
         self["overlap_meas_add_lbls"] = None
 
         # METRICS
+        
+        # generate labels border/surface image and measure distances to
+        # anatomical border/surface map
+        self["meas_edge_dists"] = True
 
         # sequence of :class:`config.MetricGroups` enums to measure in
         # addition to basic metrics


### PR DESCRIPTION
Edge distance measuring is not required for the pipelines, but serves as a method of assessment. Allow this metric to be turned off through an atlas profile setting, which can save time during debugging or whenever the metric is not required.

For now, we will leave the option on for consistency with existing pipelines. Could consider turning it off by default since many workflows may not need it.