### PR TITLE
Import raw single planes

### DIFF
--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -2918,7 +2918,8 @@ class Visualization(HasTraits):
                     "and edit if necessary.")
             else:
                 self._update_import_feedback(
-                    "Please enter at least image output and data type "
+                    "No image files were auto-detected but may be in a RAW "
+                    "format. Please enter at least image output and data type "
                     "before importing.")
         
         for suffix in (config.SUFFIX_IMAGE5D, config.SUFFIX_META,

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -2949,7 +2949,6 @@ class Visualization(HasTraits):
                 base_path = os.path.join(
                     os.path.dirname(self._import_browser),
                     importer.DEFAULT_IMG_STACK_NAME)
-                self._import_btn_enabled = True
             
             elif self._import_browser:
                 # gather files matching the pattern of the selected file to import

--- a/magmap/io/importer.py
+++ b/magmap/io/importer.py
@@ -1097,11 +1097,14 @@ def setup_import_dir(path):
     
     # set shape and data type based on first loadable image in first channel
     chl_files = tuple(chl_paths.values())[0]
+    shape = [1, len(chl_files), 0, 0, len(chl_paths.keys())]
     img = None
     for chl_file in chl_files:
         try:
             # load standard image types; does not read RAW files
             img = io.imread(chl_file)
+            shape[2:4] = img.shape[:2]
+            md[config.MetaKeys.DTYPE] = img.dtype.str
             break
         except ValueError:
             _logger.info(
@@ -1109,11 +1112,7 @@ def setup_import_dir(path):
     if img is None:
         _logger.warn(
             "Could not find image files in the directory: %s", path)
-    else:
-        # store shape and data type
-        md[config.MetaKeys.SHAPE] = [
-            1, len(chl_files), *img.shape[:2], len(chl_paths.keys())]
-        md[config.MetaKeys.DTYPE] = img.dtype.str
+    md[config.MetaKeys.SHAPE] = shape
     return chl_paths, md
 
 


### PR DESCRIPTION
RAW file import has been supported for multi-plane image files, but not yet for directories of single-plane image files. This PR extends RAW support to these individual files. It removes the assumption that these files can be read as standard image file types and allows the user to proceed with import after filling out shape and data type information if these cannot be extracted automatically. Even if the full shape cannot be determined automatically, the channels and number of planes is auto-populated based on the files in the directory.

Additionally, this PR fixes an issue where the import button was enabled after setting up import from a directory but shape and data type information were not complete.