### PR TITLE
Fix updating metadata format

### DIFF
--- a/magmap/io/yaml_io.py
+++ b/magmap/io/yaml_io.py
@@ -2,7 +2,6 @@
 # Author: David Young, 2020
 """YAML file format input/output."""
 
-import numpy as np
 import yaml
 
 from magmap.io import libmag
@@ -49,6 +48,9 @@ def load_yaml(path, enums=None):
     Returns:
         List[dict]: Sequence of parsed dictionaries for each document within
         a YAML file.
+    
+    Raises:
+        FileNotFoundError: if ``path`` could not be found or loaded.
 
     """
     def parse_enum_val(val):
@@ -63,18 +65,21 @@ def load_yaml(path, enums=None):
                 # replace with the corresponding Enum class
                 val = enums[val_split[0]][val_split[1]]
         return val
-
-    with open(path) as yaml_file:
-        # load all documents into a generator
-        docs = yaml.load_all(yaml_file, Loader=yaml.FullLoader)
-        data = []
-        for doc in docs:
-            if not doc:
-                # skip empty document
-                continue
-            if enums:
-                doc = _filter_dict(doc, parse_enum_val)
-            data.append(doc)
+    
+    try:
+        with open(path) as yaml_file:
+            # load all documents into a generator
+            docs = yaml.load_all(yaml_file, Loader=yaml.FullLoader)
+            data = []
+            for doc in docs:
+                if not doc:
+                    # skip empty document
+                    continue
+                if enums:
+                    doc = _filter_dict(doc, parse_enum_val)
+                data.append(doc)
+    except (FileNotFoundError, UnicodeDecodeError) as e:
+        raise FileNotFoundError(e)
     return data
 
 

--- a/magmap/settings/profiles.py
+++ b/magmap/settings/profiles.py
@@ -14,6 +14,8 @@ import pprint
 from magmap.io import yaml_io
 from magmap.settings import config
 
+_logger = config.logger.getChild(__name__)
+
 
 class RegKeys(Enum):
     """Register setting enumerations."""
@@ -142,11 +144,14 @@ class SettingsDict(dict):
                     print(mod_path, "profile file not found, skipped")
                     return
             self.timestamps[mod_path] = os.path.getmtime(mod_path)
-            yamls = yaml_io.load_yaml(mod_path, _PROFILE_ENUMS)
-            mods = {}
-            for yaml in yamls:
-                mods.update(yaml)
-            print("loaded {}:\n{}".format(mod_path, mods))
+            try:
+                yamls = yaml_io.load_yaml(mod_path, _PROFILE_ENUMS)
+                mods = {}
+                for yaml in yamls:
+                    mods.update(yaml)
+                _logger.info("Loaded profile from '%s':\n%s", mod_path, mods)
+            except FileNotFoundError:
+                _logger.warn("Unable to load profile from: %s", mod_path)
         else:
             if mod_name == self.DEFAULT_NAME:
                 # update entries from a new instance for default values;
@@ -194,8 +199,8 @@ class SettingsDict(dict):
             self.add_modifier(profile, self.profiles, self.delimiter)
 
         if config.verbose:
-            print("settings for {}:", self[self.NAME_KEY])
-            pprint.pprint(self)
+            _logger.debug("settings for '%s':", self[self.NAME_KEY])
+            _logger.debug(pprint.pprint(self))
 
     def check_file_changed(self):
         """Check whether any profile files have changed since last loaded.


### PR DESCRIPTION
Fixes #34.

This PR fixes loading metadata loaded in the prior, NPZ file format, when loaded directly, using the `--meta` command-line argument. File not found and Unicode errors are integrated directly into the YML load wrapper, and the file resaving as YML format is integrated into the metadata loader. Profiles loaded as YML files also catch load errors.