### PR TITLE
Liberalize reg suffixes

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -31,7 +31,7 @@ Argument | Sub-argument | Function | Ver Added | Last updated
 `--truth_db` | `[mode=<mode>] [path=<path>]` | Truth database; see `config.TruthDBModes` for available modes. | v1.0.0 | v1.0.0
 `--labels` | `[path_ref="""] [level=0] [ID=0] [orig_colors=1] [symmetric_colors=1] [binary=<backround>,<foreground>] [translate_labels=<path>"] [translate_children=0]` | Atlas label settings; see `config.AtlasLabels`. | v1.0.0 | v1.0.0
 `--transform` | `[rotate=0] [flip_vert=0] [flip_horiz=0] [rescale=0]` | Image transformations; see `config.Transforms`. | v1.0.0 | v1.0.0
-`--reg_suffixes` | `[atlas=atlasVolume.mhd] [annotation=annotation.mhd] [borders=<path>]` | Registered image suffixes, eg `/opt/myvolume_atlasVolume.mhd`; see `config.RegSuffixes`. | v1.0.0 | v1.0.0
+`--reg_suffixes` | `[atlas=atlasVolume.mhd] [annotation=annotation.mhd] [borders=<path>]` | Registered image suffixes, eg `/opt/myvolume_atlasVolume.mhd`; see `config.RegSuffixes`. Suffixes can be given as an absolute path to load directly from the path, eg a labels image not registered to the main image. | v1.0.0 | v1.0.0
 `--plot_labels` | `[title=<title>] ...` | Plot labels; see `config.PlotLabels` for available parameters. | v1.0.0 | v1.0.0
 `--set_meta` | `[resolutions=<x,y,z>] [magnification=<n>] [zoom=<n>] [shape=<c,x,y,z,...>] [dtype=<data-type>]` | Metadata to set when importing an image; see `config.MetaKeys`. | v1.0.0 | [v1.3.0](#changes-in-magellanmapper-v13)
 `--plane` | `<xy|xz|yz>` | Transpose to the given planar orientation | v1.0.0 | v1.0.0
@@ -53,6 +53,7 @@ Old | New | Version | Purpose of Change |
 --- | --- | --- | ---
 `--proc <task>` | `--proc <task1>=[sub-task1,...] <task2>` | v1.5.0 | Multiple processing tasks can be given as well as sub-tasks
 Specified in ROI profiles | `--proc preprocess=[rotate,saturate,...]` | v1.5.0 | Pre-processing tasks are integrated as sub-processing tasks; see `config.PreProcessKeys` for task names
+`--reg_suffixes [atlas=<suffix1>] ...` | Unchanged | v1.5.0 | Suffixes can now be given as an absolute path to load directly from the path, eg a labels image not registered to the main image.
 
 ## Changes in MagellanMapper v1.4
 

--- a/magmap/io/np_io.py
+++ b/magmap/io/np_io.py
@@ -199,6 +199,11 @@ def setup_images(path=None, series=None, offset=None, size=None,
     filename_base = importer.filename_to_base(path, series)
     subimg_base = None
     blobs = None
+    
+    # registered images set to load
+    atlas_suffix = config.reg_suffixes[config.RegSuffixes.ATLAS]
+    annotation_suffix = config.reg_suffixes[config.RegSuffixes.ANNOTATION]
+    borders_suffix = config.reg_suffixes[config.RegSuffixes.BORDERS]
 
     if load_subimage and not config.save_subimg:
         # load a saved sub-image file if available and not set to save one
@@ -265,7 +270,7 @@ def setup_images(path=None, series=None, offset=None, size=None,
                 # blobs expected but not found
                 raise e2
     
-    if path and config.image5d is None:
+    if path and config.image5d is None and not atlas_suffix:
         # load or import the main image stack
         print("Loading main image")
         try:
@@ -325,7 +330,6 @@ def setup_images(path=None, series=None, offset=None, size=None,
         importer.assign_metadata(config.metadatas[0])
     
     # main image is currently required since many parameters depend on it
-    atlas_suffix = config.reg_suffixes[config.RegSuffixes.ATLAS]
     if atlas_suffix is None and config.image5d is None:
         # fallback to atlas if main image not already loaded
         atlas_suffix = config.RegNames.IMG_ATLAS.value
@@ -344,7 +348,6 @@ def setup_images(path=None, series=None, offset=None, size=None,
         except FileNotFoundError as e:
             print(e)
     
-    annotation_suffix = config.reg_suffixes[config.RegSuffixes.ANNOTATION]
     if annotation_suffix is not None:
         try:
             # load labels image
@@ -381,7 +384,6 @@ def setup_images(path=None, series=None, offset=None, size=None,
             _logger.error("Skipping labels reference file loading from '%s'",
                           config.load_labels)
     
-    borders_suffix = config.reg_suffixes[config.RegSuffixes.BORDERS]
     if borders_suffix is not None:
         # load borders image, which can also be another labels image
         try:

--- a/magmap/io/sitk_io.py
+++ b/magmap/io/sitk_io.py
@@ -85,7 +85,7 @@ def match_world_info(source, target):
           "direction from {} to {}"
           .format(target.GetSpacing(), spacing, target.GetOrigin(), origin,
                   target.GetDirection(), direction))
-    target.SetSpacing(spacing)
+    # target.SetSpacing(spacing)
     target.SetOrigin(origin)
     target.SetDirection(direction)
 
@@ -154,9 +154,10 @@ def _load_reg_img_to_combine(path, reg_name, img_nps):
 
 
 def read_sitk_files(filename_sitk, reg_names=None, return_sitk=False):
-    """Read an image file through SimpleITK and export to Numpy array format,
-    with support for combining multiple registered image files into a single
-    image.
+    """Read image files through SimpleITK.
+    
+    Supports identifying files based on registered suffixes and combining
+    multiple registered image files into a single image.
     
     Also sets up spacing from the first loaded image in
     :attr:`magmap.settings.config.resolutions` if not already set.
@@ -228,26 +229,30 @@ def load_registered_img(img_path, reg_name, get_sitk=False, return_path=False):
     """Load atlas-based image that has been registered to another image.
     
     Args:
-        img_path: Path as had been given to generate the registered images, 
-            with the parent path of the registered images and base name of 
-            the original image.
-        reg_name: Atlas image suffix to open.
-        get_sitk: True if the image should be returned as a SimpleITK image; 
-            defaults to False, in which case the corresponding Numpy array will 
-            be extracted instead.
+        img_path (str): Path as had been given to generate the registered
+            images, with the parent path of the registered images and base name 
+            of the original image.
+        reg_name (str): Atlas image suffix to open. Can be an absolute path,
+            which will be used directly, ignoring ``img_path``.
+        get_sitk (bool): True if the image should be returned as a SimpleITK
+            image; defaults to False, in which case the corresponding Numpy
+            array will be extracted instead.
         return_path (bool): True to return the path from which the image
             was loaded; defaults to False.
     
     Returns:
-        :obj:`np.ndarray`: The atlas-based image as a Numpy array, or a
-        :obj:`sitk.Image` object if ``get_sitk`` is True. Also returns the
+        :class:`numpy.ndarray`: The atlas-based image as a Numpy array, or a
+        :class:`sitk.Image` object if ``get_sitk`` is True. Also returns the
         loaded path if ``return_path`` is True.
     
     Raises:
         ``FileNotFoundError`` if the path cannot be found.
     """
-    # prioritize registered image extension matched to that of main image
-    reg_img_path = reg_out_path(img_path, reg_name, True)
+    reg_img_path = reg_name
+    if not os.path.isabs(reg_name):
+        # use suffix given as an absolute path directly; otherwise, get
+        # registered image extension matched to that of main image
+        reg_img_path = reg_out_path(img_path, reg_name, True)
     reg_img, reg_img_path = read_sitk(reg_img_path)
     if reg_img is None:
         # fallback to loading barren reg_name from img_path's dir


### PR DESCRIPTION
MagellanMapper uses "registered image suffixes" for two main purposes:
- Convenience when loading images that have been registered to another image, where the various registered images each have a different suffix (eg `atlasVolume` for the atlas intensity image registered to a sample image, `annotation` for the registered atlas labels image)
- Overlaying different types of images, such as the `atlas` type for the intensity image and `annotation` type for the labels image

These suffixes are accessed through the `--reg_suffixes` command-line flag or the "Intensity" and "Labels" selection controls in the "Registered Images" section of the GUI. Registered images are identified by a base image path to which these suffixes are appended. Filenames given in the GUI are deconstructed if possible to these base and suffix components, and starting in v1.4, the same occurs for files given by command-line.

Occasionally, users may wish to load a labels image not registered to the main image, which the registered suffixes does not support. As a way to specify a non-registered path while still using the registered suffixes to load certain file types such as labels, this PR allows registered suffixes to be given as absolute paths and loaded directly, without modifying the path.

Also, an image loaded as a registered "atlas" (intensity) image takes precedence over the main intensity image, but this main image will still be loaded even if the registered atlas image is set. This loading allows any metadata from the main image to be loaded, but loading the main image could also trigger an image import or load unintended metadata. As a simplification, this PR skips loading the main image if a registered intensity image is specified.

Many of the atlas-related functions have assumed that certain registered suffixes are used, but we are slowly making these suffixes customizable through the CLI flag. This PR adds supports for this customization in the edge detection task.