### PR TITLE
Reg masks

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -31,7 +31,7 @@ Argument | Sub-argument | Function | Ver Added | Last updated
 `--truth_db` | `[mode=<mode>] [path=<path>]` | Truth database; see `config.TruthDBModes` for available modes. | v1.0.0 | v1.0.0
 `--labels` | `[path_ref="""] [level=0] [ID=0] [orig_colors=1] [symmetric_colors=1] [binary=<backround>,<foreground>] [translate_labels=<path>"] [translate_children=0]` | Atlas label settings; see `config.AtlasLabels`. | v1.0.0 | v1.0.0
 `--transform` | `[rotate=0] [flip_vert=0] [flip_horiz=0] [rescale=0]` | Image transformations; see `config.Transforms`. | v1.0.0 | v1.0.0
-`--reg_suffixes` | `[atlas=atlasVolume.mhd] [annotation=annotation.mhd] [borders=<path>]` | Registered image suffixes, eg `/opt/myvolume_atlasVolume.mhd`; see `config.RegSuffixes`. Suffixes can be given as an absolute path to load directly from the path, eg a labels image not registered to the main image. | v1.0.0 | v1.0.0
+`--reg_suffixes` | `[atlas=atlasVolume.mhd] [annotation=annotation.mhd] [borders=<path>]` | Suffixes of registered images to load; see `config.RegSuffixes` for image types. Suffixes are given relative to the main image path; eg, `/opt/myvolume_atlasVolume.mhd` can be given as `--img /opt/myvolume --reg_suffixes atlas=atlasVolume.mhd` to load as the intensity image. Suffixes can be also given as an absolute path to load directly from the path, eg a labels image not registered to the main image. | v1.0.0 | [v1.5.0](#changes-in-magellanmapper-v15)
 `--plot_labels` | `[title=<title>] ...` | Plot labels; see `config.PlotLabels` for available parameters. | v1.0.0 | v1.0.0
 `--set_meta` | `[resolutions=<x,y,z>] [magnification=<n>] [zoom=<n>] [shape=<c,x,y,z,...>] [dtype=<data-type>]` | Metadata to set when importing an image; see `config.MetaKeys`. | v1.0.0 | [v1.3.0](#changes-in-magellanmapper-v13)
 `--plane` | `<xy|xz|yz>` | Transpose to the given planar orientation | v1.0.0 | v1.0.0
@@ -53,7 +53,7 @@ Old | New | Version | Purpose of Change |
 --- | --- | --- | ---
 `--proc <task>` | `--proc <task1>=[sub-task1,...] <task2>` | v1.5.0 | Multiple processing tasks can be given as well as sub-tasks
 Specified in ROI profiles | `--proc preprocess=[rotate,saturate,...]` | v1.5.0 | Pre-processing tasks are integrated as sub-processing tasks; see `config.PreProcessKeys` for task names
-`--reg_suffixes [atlas=<suffix1>] ...` | Unchanged | v1.5.0 | Suffixes can now be given as an absolute path to load directly from the path, eg a labels image not registered to the main image.
+`--reg_suffixes [atlas=<suffix1>] ... [fixed_mask=<suffix2>] [moving_mask=<suffix3>]` | Unchanged | v1.5.0 | Suffixes can now be given as an absolute path to load directly from the path, eg a labels image not registered to the main image. Image masks for registration can also be given as `fixed_mask` and `moving_mask`.
 
 ## Changes in MagellanMapper v1.4
 

--- a/docs/release/release_v1.5.md
+++ b/docs/release/release_v1.5.md
@@ -23,6 +23,8 @@ See the [table of CLI changes](../cli.md#changes-in-magellanmapper-v15) for a su
 
 #### Atlas registration
 
+- Image masks can be set to focus the field for image registration; use the new `--reg_suffixes fixed_mask=<suffix-or-abs-path> moving_mask=<suffix-path>` command-line sub-arguments to load these mask files
+
 #### Cell detection
 
 - Previously saved blobs are no longer loaded prior to re-detection

--- a/magmap/atlas/register.py
+++ b/magmap/atlas/register.py
@@ -307,7 +307,7 @@ def _config_reg_resolutions(grid_spacing_schedule, param_map, ndim):
 
 
 def register_duo(fixed_img, moving_img, path=None, fixed_mask=None,
-                 moving_mask=None):
+                 moving_mask=None, regs=None):
     """Register two images to one another using ``SimpleElastix``.
     
     Args:
@@ -321,12 +321,19 @@ def register_duo(fixed_img, moving_img, path=None, fixed_mask=None,
             to None.
         moving_mask (:obj:`sitk.Image`): Mask for ``moving_img``; defaults
             to None.
+        regs (list[str]): Sequence of atlas profile registration keys to use;
+            the default of None gives all three major registration types,
+            "reg_translation", "reg_affine", "reg_bspline".
     
     Returns:
         :obj:`SimpleITK.Image`, :obj:`sitk.TransformixImageFilter`: Tuple of
         the registered image and a Transformix filter with the registration's
         parameters to reapply them on other images.
     """
+    if regs is None:
+        # default to perform all the major registration types
+        regs = ("reg_translation", "reg_affine", "reg_bspline")
+    
     # basic info from images just prior to SimpleElastix filtering for 
     # registration; to view raw images, show these images rather than merely 
     # turning all iterations to 0 since simply running through the filter 
@@ -347,10 +354,10 @@ def register_duo(fixed_img, moving_img, path=None, fixed_mask=None,
     if moving_mask is not None:
         elastix_img_filter.SetMovingMask(moving_mask)
     
-    # set up parameter maps for translation, affine, and deformable regs
+    # set up parameter maps for the included registration types
     settings = config.atlas_profile
     param_map_vector = sitk.VectorOfParameterMap()
-    for key in ("reg_translation", "reg_affine", "reg_bspline"):
+    for key in regs:
         params = settings[key]
         if not params: continue
         max_iter = params["max_iter"]

--- a/magmap/atlas/register.py
+++ b/magmap/atlas/register.py
@@ -389,8 +389,17 @@ def register_duo(fixed_img, moving_img, path=None, fixed_mask=None,
 
 def register(fixed_file, moving_img_path, show_imgs=True, write_imgs=True,
              name_prefix=None, new_atlas=False):
-    """Register an atlas and associated labels to a sample image 
-    using the SimpleElastix library.
+    """Register an atlas to a sample image using the SimpleElastix library.
+    
+    Loads the images, applies any transformations to the moving image, and
+    registers the moving to the sample images. Applies the identical
+    registration to the associated atlas labels image as well. The specific
+    moving images can be adjusted through
+    :attr:`magmap.settings.config.reg_suffixes`, where the "atlas" image is
+    the intensity image used for registration, "annotation" is the atlas
+    labels, "fixed_mask" is the mask for ``fixed_file`` (optional), and
+    "moving_mask" is the mask for the "atlas" image (optional). If either
+    mask is given, both should be given as required by Elastix.
     
     Uses the first channel in :attr:`config.channel` or the first image channel.
     
@@ -454,9 +463,18 @@ def register(fixed_file, moving_img_path, show_imgs=True, write_imgs=True,
     labels_img = sitk_io.load_registered_img(
         moving_img_path, moving_labels_suffix, get_sitk=True)
 
-    # TODO: implement mask option
+    # get image masks given as registered image suffixes relative to the
+    # fixed image path or prefix
     fixed_mask = None
     moving_mask = None
+    fixed_mask_suffix = config.reg_suffixes[config.RegSuffixes.FIXED_MASK]
+    if fixed_mask_suffix:
+        fixed_mask = sitk_io.load_registered_img(
+            name_prefix, fixed_mask_suffix, get_sitk=True)
+    moving_mask_suffix = config.reg_suffixes[config.RegSuffixes.MOVING_MASK]
+    if moving_mask_suffix:
+        moving_mask = sitk_io.load_registered_img(
+            name_prefix, moving_mask_suffix, get_sitk=True)
 
     # transform and preprocess moving images
 

--- a/magmap/settings/config.py
+++ b/magmap/settings/config.py
@@ -460,12 +460,14 @@ class RegNames(Enum):
     IMG_ATLAS_PRECUR = "atlasVolumePrecur.mhd"
     IMG_LABELS = "annotation.mhd"
     IMG_EXP = "exp.mhd"
+    IMG_EXP_MASK = "expMask.mhd"
     IMG_GROUPED = "grouped.mhd"
     IMG_BORDERS = "borders.mhd"  # TODO: consider removing
     IMG_HEAT_MAP = "heat.mhd"
     IMG_HEAT_COLOC = "heatColoc.mhd"
     IMG_ATLAS_EDGE = "atlasEdge.mhd"
     IMG_ATLAS_LOG = "atlasLoG.mhd"
+    IMG_ATLAS_MASK = "atlasMask.mhd"
     IMG_LABELS_PRECUR = "annotationPrecur.mhd"
     IMG_LABELS_TRUNC = "annotationTrunc.mhd"
     IMG_LABELS_EDGE = "annotationEdge.mhd"
@@ -501,7 +503,11 @@ REGION_ALL = "all"
 # registered image suffix keys for command-line parsing
 RegSuffixes = Enum(
     "RegSuffixes", [
-        "ATLAS", "ANNOTATION", "BORDERS", 
+        "ATLAS",  # intensity image
+        "ANNOTATION",  # labels image
+        "BORDERS",  # label borders image
+        "FIXED_MASK",  # registration fixed image mask
+        "MOVING_MASK",  # registration moving image mask
     ]
 )
 reg_suffixes = dict.fromkeys(RegSuffixes, None)


### PR DESCRIPTION
Image registration may require masks of either the sample image or atlas to focus the registration to specific regions. Elastix and SimpleElastix support image masks (see [example](https://github.com/InsightSoftwareConsortium/ITKElastix/blob/master/examples/ITK_Example03_Masked_3D_Registration.ipynb)), which we integrate here.

Masks are assume to have been generated before registration and saved as files that SimpleElastix can read. The masks can be specified for registration using new registered image suffix types:

```
--reg_suffixes fixed_mask=<suffix> moving_mask=<suffix>
```

The mask suffixes are assumed to be relative to the sample image on the assumption that masks for both the sample and atlas often need to be generated for each sample. The recent reg suffixes PR (#36) allows full, absolute paths to be given for these suffixes to specify an alternative location and filename, however.