### PR TITLE
Fix importing images to non-existing parent directories and without resolutions

### DIFF
--- a/magmap/io/importer.py
+++ b/magmap/io/importer.py
@@ -997,6 +997,8 @@ def import_multiplane_images(chl_paths, prefix, import_md, series=None,
                         # open output file as memmap to directly write to disk,
                         # much faster than outputting to RAM first; supports
                         # NPY directly, unlike np.memmap
+                        os.makedirs(
+                            os.path.dirname(filename_image5d), exist_ok=True)
                         image5d = np.lib.format.open_memmap(
                             filename_image5d, mode="w+", dtype=img.dtype,
                             shape=shape)
@@ -1179,6 +1181,8 @@ def import_planes_to_stack(chl_paths, prefix, import_md, rgb_to_grayscale=True,
                 shape = [1, len(chl_files), *img.shape]
                 if num_chls > 1:
                     shape.append(num_chls)
+                os.makedirs(
+                    os.path.dirname(filename_image5d_npz), exist_ok=True)
                 img5d = np.lib.format.open_memmap(
                     filename_image5d_npz, mode="w+", dtype=img.dtype,
                     shape=tuple(shape))

--- a/magmap/io/np_io.py
+++ b/magmap/io/np_io.py
@@ -178,6 +178,13 @@ def setup_images(path=None, series=None, offset=None, size=None,
             if val is not None:
                 # explicitly set metadata takes precedence over extracted vals
                 import_md[key] = val
+        
+        res = import_md[config.MetaKeys.RESOLUTIONS]
+        if res is None:
+            # default to 1 for x,y,z since image resolutions are required
+            res = [1] * 3
+            import_md[config.MetaKeys.RESOLUTIONS] = res
+            _logger.warn("No image resolutions found. Defaulting to: %s", res)
     
     # LOAD MAIN IMAGE
     


### PR DESCRIPTION
Fixes #43. This PR creates parent directories for output files of both single- and multi-plane file imports. This change prevents an error when outputting files to a new directory.

The PR also sets default resolutions of 1 for each physical dimension if no resolutions are set during import since resolutions are assumed to exist throughout MagellanMapper, and the default values of None lead to errors. These resolutions changes have been added to the image setup function since the GUI already handles default resolutions separately. An alternative would be to set the resolutions in the import functions themselves, but handling them earlier makes fewer assumptions in the importer.