### PR TITLE
Support rotation of exported image planes

### DIFF
--- a/magmap/cv/cv_nd.py
+++ b/magmap/cv/cv_nd.py
@@ -3,6 +3,8 @@
 """Computer vision library functions for n-dimensions.
 """
 
+from typing import Optional, Sequence
+
 import numpy as np
 from scipy import interpolate
 from scipy import ndimage
@@ -125,6 +127,44 @@ def rotate_nd(img_np, angle, axis=0, order=1, resize=False):
             slices[axis] = i
             rotated[tuple(slices)] = img
     return rotated
+
+
+def rotate90(roi: np.ndarray, rotate: int,
+             axes: Optional[Sequence[int]] = None,
+             multichannel: bool = False) -> np.ndarray:
+    """Rotate an image by increments of 90 degrees.
+    
+    Serves as a wrapper for :meth:`numpy.rot90` with default rotation in
+    the xy plane.
+    
+    Args:
+        roi: Image as a 3D+/-channel array. Can be None to return as-is.
+        rotate: Number of times to rotate 90 degrees.
+        axes: Sequence of two axes defining the plane to rotate; defaults to
+            None to use ``[-2, -1]``, the 2nd to last and last axes.
+        multichannel: True if the image is multichannel; defaults to False.
+            Only used if ``axes`` contains negative axis indices.
+
+    Returns:
+        Rotated image.
+
+    """
+    if rotate is None:
+        return roi
+    if axes is None:
+        # default to using the last 2 axes (xy plane)
+        ax = [-2, -1]
+    else:
+        ax = list(axes)
+    for i, a in enumerate(ax):
+        if a < 0:
+            # wrap neg axes to the end of the axes
+            ax[i] += roi.ndim
+            if multichannel:
+                # skip the channel axis
+                ax[i] -= 1
+    roi = np.rot90(roi, libmag.get_if_within(rotate, 0), ax)
+    return roi
 
 
 def affine_nd(img_np, axis_along, axis_shift, shift, bounds, axis_attach=None, 

--- a/magmap/io/cli.py
+++ b/magmap/io/cli.py
@@ -619,10 +619,10 @@ def process_cli_args():
             config.notify_attach = args.notify[2]
             print("Set notification attachment path to {}"
                   .format(config.notify_attach))
-    if args.prefix:
+    if args.prefix is not None:
         config.prefix = args.prefix
         print("Set path prefix to {}".format(config.prefix))
-    if args.suffix:
+    if args.suffix is not None:
         config.suffix = args.suffix
         print("Set path suffix to {}".format(config.suffix))
     

--- a/magmap/io/export_stack.py
+++ b/magmap/io/export_stack.py
@@ -556,13 +556,16 @@ def export_planes(image5d, ext, channel=None, separate_chls=False):
     # set up image and apply any rotation
     roi = image5d[0]
     multichannel, channels = plot_3d.setup_channels(roi, channel, 3)
-    num_digits = len(str(len(roi)))
     rotate = config.transform[config.Transforms.ROTATE]
     roi = cv_nd.rotate90(roi, rotate, multichannel=multichannel)
     
+    num_planes = len(roi)
+    num_digits = len(str(num_planes))
     for i, plane in enumerate(roi):
-        path = os.path.join(output_dir, "{}_{:0{}d}".format(
-            basename, i, num_digits))
+        # add plane to output path if more than one output file
+        out_name = basename if num_planes <= 1 else "{}_{:0{}d}".format(
+            basename, i, num_digits)
+        path = os.path.join(output_dir, out_name)
         if separate_chls and multichannel:
             for chl in channels:
                 # save each channel as separate file

--- a/magmap/plot/plot_support.py
+++ b/magmap/plot/plot_support.py
@@ -13,6 +13,7 @@ from matplotlib import gridspec
 from matplotlib import pyplot as plt
 from skimage import transform
 
+from magmap.cv import cv_nd
 from magmap.plot import colormaps
 from magmap.settings import config
 from magmap.io import libmag
@@ -190,13 +191,7 @@ def imshow_multichannel(ax, img2d, channel, cmaps, aspect, alpha=None,
 
     # transform image based on config parameters
     rotate = config.transform[config.Transforms.ROTATE]
-    if rotate is not None:
-        last_axis = img2d.ndim - 1
-        if multichannel:
-            last_axis -= 1
-        # use first rotation value
-        img2d = np.rot90(
-            img2d, libmag.get_if_within(rotate, 0), (last_axis - 1, last_axis))
+    img2d = cv_nd.rotate90(img2d, rotate, multichannel=multichannel)
 
     for chl in channels:
         img2d_show = img2d[..., chl] if multichannel else img2d


### PR DESCRIPTION
The image plane export task (`--proc export_planes`) outputs planes directly, without supporting any of the transformation CLI arguments or profile settings. The function for displaying multichannel images in Matplotlib figures supports the `--transform rotate` argument for  90 degree image rotations. This PR generalizes this support into a wrapper function for 90 degree rotation that defaults to rotation in the xy-plane to use in image plane export.

Additionally, it streamlines exported filenames to not add a plane index when exporting a single plane, such as for 2D images. To turn off the filename suffix (`_export[_i]`) entirely, the CLI `--suffix` argument (and same for `--prefix`) is fixed to accept empty strings.