### PR TITLE
Adaptive smoothing filter sizes and pre-skeletonization erosion configuration

### DIFF
--- a/magmap/atlas/edge_seg.py
+++ b/magmap/atlas/edge_seg.py
@@ -221,7 +221,8 @@ def erode_labels(labels_img_np, erosion, erosion_frac=None, mirrored=True,
     #eroded = segmenter.labels_to_markers_blob(labels_img_np)
     eroded, df = segmenter.labels_to_markers_erosion(
         labels_to_erode, erosion[profiles.RegKeys.MARKER_EROSION],
-        erosion_frac, erosion[profiles.RegKeys.MARKER_EROSION_MIN])
+        erosion_frac, erosion[profiles.RegKeys.MARKER_EROSION_MIN],
+        skel_eros_filt_size=erosion[profiles.RegKeys.SKELETON_EROSION])
     if is_mirrored:
         # mirror changes onto opposite symmetric half
         eroded = _mirror_imported_labels(

--- a/magmap/atlas/edge_seg.py
+++ b/magmap/atlas/edge_seg.py
@@ -318,10 +318,10 @@ def edge_aware_segmentation(path_atlas, show=True, atlas=True, suffix=None,
             atlas_edge, markers, labels_img_np, **seg_args)
     
     smoothing = config.atlas_profile["smooth"]
+    smoothing_mode = config.atlas_profile["smoothing_mode"]
     if smoothing is not None:
         # smoothing by opening operation based on profile setting
-        atlas_refiner.smooth_labels(
-            labels_seg, smoothing, config.SmoothingModes.opening)
+        atlas_refiner.smooth_labels(labels_seg, smoothing, smoothing_mode)
     
     if mirrorred:
         # mirror back to other half

--- a/magmap/cv/segmenter.py
+++ b/magmap/cv/segmenter.py
@@ -248,7 +248,7 @@ class LabelToMarkerErosion(object):
     @classmethod
     def erode_label(cls, label_id, filter_size, target_frac=None,
                     min_filter_size=1, use_min_filter=False,
-                    skel_eros_filt_size=0):
+                    skel_eros_filt_size=False):
         """Convert a label to a marker as an eroded version of the label.
         
         By default, labels will be eroded with the given ``filter_size`` 
@@ -281,10 +281,10 @@ class LabelToMarkerErosion(object):
                 a smaller filter size would otherwise be required; defaults
                 to False to revert to original, uneroded size if a filter
                 smaller than ``min_filter_size`` would be needed.
-            skel_eros_filt_size (int): Erosion filter size before
+            skel_eros_filt_size (Union[int, bool]): Erosion filter size before
                 skeletonization to balance how much of the labels' extent will
                 be preserved during skeletonization. Increase to reduce the
-                skeletonization. Defaults to 0, which will cause
+                skeletonization. Defaults to False, which will cause
                 skeletonization to be skipped.
         
         Returns:
@@ -317,8 +317,7 @@ class LabelToMarkerErosion(object):
             min_filter_size, use_min_filter, target_frac,
             f"Label ID: {label_id}")
         region_size_filtered = np.sum(filtered)
-
-        if skel_eros_filt_size and np.sum(filtered) > 0:
+        if skel_eros_filt_size is not False and np.sum(filtered) > 0:
             # skeletonize the labels to recover details from erosion;
             # need another labels erosion before skeletonization to avoid
             # preserving too much of the original labels' extent

--- a/magmap/settings/atlas_prof.py
+++ b/magmap/settings/atlas_prof.py
@@ -188,6 +188,11 @@ class AtlasProfile(profiles.SettingsDict):
             # - 0: no minimum, instead using size of 1 even if below vol ratio
             # - n: min size of n if above vol ratio, otherwise reverts to orig
             RegKeys.MARKER_EROSION_MIN: 1,
+            # erosion filter size before skeletonization:
+            # - False: no skeletonization
+            # - None: half of MARKER_EROSION
+            # - n: filter kernel size
+            RegKeys.SKELETON_EROSION: None,
             RegKeys.WATERSHED_MASK_FILTER: (config.SmoothingModes.opening, 2),
         }
         # target eroded size as frac of orig, used when generating interiors

--- a/magmap/settings/atlas_prof.py
+++ b/magmap/settings/atlas_prof.py
@@ -87,8 +87,10 @@ class AtlasProfile(profiles.SettingsDict):
         # start (float): fractions of the total planes (0-1); use -1 to
         # set automatically, None to turn off the entire setting group
 
-        self["smooth"] = None  # smooth labels
-        self["crop_to_labels"] = False  # crop labels and atlas to non-0 labels
+        # type of label smoothing
+        self["smoothing_mode"] = config.SmoothingModes.opening
+        # size of filter for label smoothing
+        self["smooth"] = None
 
         # mirror labels onto the unlabeled hemisphere
         self["labels_mirror"] = {
@@ -192,6 +194,9 @@ class AtlasProfile(profiles.SettingsDict):
         # of regions but not for watershed seeds; can be None
         self["erosion_frac"] = 0.5
         self["erode_labels"] = {"markers": True, "interior": False}
+        
+        # crop labels and atlas to non-0 labels
+        self["crop_to_labels"] = False
 
         # crop labels back to their original background after smoothing
         # (ignored during atlas import if no smoothing), given as the filter
@@ -201,9 +206,6 @@ class AtlasProfile(profiles.SettingsDict):
         
         # crop labels images to foreground of first labels image
         self["crop_to_first_image"] = False
-
-        # type of label smoothing
-        self["smoothing_mode"] = config.SmoothingModes.opening
 
         # combine values from opposite sides when measuring volume stats;
         # default to use raw values for each label and side to generate

--- a/magmap/settings/config.py
+++ b/magmap/settings/config.py
@@ -666,10 +666,18 @@ class HemSides(Enum):
     BOTH = "both"
 
 
-# label smoothing modes
+#: :class:`Enum`: Label smoothing modes.
 SmoothingModes = Enum(
     "SmoothingModes", [
-        "opening", "gaussian", "closing"
+        # morphological opening, which decreases in size for vols < 5000px
+        # and switches to a closing filter if the label would be lost
+        "opening",
+        # morphological filters that adaptively decrease in size if
+        # vol_new:vol_old is < a size ratio
+        "adaptive_opening",  # opening filter
+        "adaptive_erosion",  # erosion filter
+        "gaussian",  # gaussian blur
+        "closing",  # closing morphological filter
     ]
 )
 

--- a/magmap/settings/profiles.py
+++ b/magmap/settings/profiles.py
@@ -23,6 +23,7 @@ class RegKeys(Enum):
     MARKER_EROSION = auto()
     MARKER_EROSION_MIN = auto()
     MARKER_EROSION_USE_MIN = auto()
+    SKELETON_EROSION = auto()
     WATERSHED_MASK_FILTER = auto()
     SAVE_STEPS = auto()
     EDGE_AWARE_REANNOTATION = auto()


### PR DESCRIPTION
This PR generalizes the adaptive erosion filter sizes used for generating watershed marker seeds markers to use these adaptive filter sizes during smoothing by morphological filters. When using this mode, the filters are now smaller when smoothing would lead to excessive changes in size compared with the original volume. This mode can be applied by changing the atlas profile `smoothing_mode` setting to `config.SmoothingModes.adaptive_opening` or `config.SmoothingModes.adaptive_erosion` for opening or erosion filters, respectively.

Additionally, the erosion filter size used prior to skeletonization in the marker generation step can be configured through the atlas profile `RegKeys.SKELETON_EROSION` setting. Sizes can range from 0 up, where 0 means that no erosion is applied, or `False` to turn off skeletonization completely.