### PR TITLE
Output smoothing metrics when merging segmentations and toggle smoothing metrics

### DIFF
--- a/docs/release/release_v1.5.md
+++ b/docs/release/release_v1.5.md
@@ -19,7 +19,8 @@ See the [table of CLI changes](../cli.md#changes-in-magellanmapper-v15) for a su
 
 #### Atlas refinement
 
-- The atlas profile `meas_edge_dists` entry can be used to turn off edge distance measuring
+- Smoothing metrics are output during the `--register merge_atlas_segs` task
+- The atlas profile settings `meas_edge_dists` and `meas_smoothing` turn off these metrics to save time during atlas generation, and the profile `fewerstats` turns off both these settings
 
 #### Atlas registration
 

--- a/magmap/atlas/edge_seg.py
+++ b/magmap/atlas/edge_seg.py
@@ -320,8 +320,19 @@ def edge_aware_segmentation(path_atlas, show=True, atlas=True, suffix=None,
     smoothing = config.atlas_profile["smooth"]
     if smoothing is not None:
         # smoothing by opening operation based on profile setting
-        atlas_refiner.smooth_labels(
-            labels_seg, smoothing, config.SmoothingModes.opening)
+        meas_smoothing = config.atlas_profile["meas_smoothing"]
+        df_aggr, df_raw = atlas_refiner.smooth_labels(
+            labels_seg, smoothing, config.SmoothingModes.opening,
+            meas_smoothing, labels_sitk.GetSpacing()[::-1])
+        df_base_path = os.path.splitext(mod_path)[0]
+        if df_raw is not None:
+            # write raw smoothing metrics
+            df_io.data_frames_to_csv(
+                df_raw, f"{df_base_path}_{config.PATH_SMOOTHING_RAW_METRICS}")
+        if df_aggr is not None:
+            # write aggregated smoothing metrics
+            df_io.data_frames_to_csv(
+                df_aggr, f"{df_base_path}_{config.PATH_SMOOTHING_METRICS}")
     
     if mirrorred:
         # mirror back to other half

--- a/magmap/atlas/register.py
+++ b/magmap/atlas/register.py
@@ -1752,6 +1752,11 @@ def main():
     """Handle registration processing tasks as specified in 
     :attr:`magmap.config.register_type`.
     """
+    if hasattr(sitk.ProcessObject, "SetGlobalDefaultThreader"):
+        # manually set threader for SimpleITK >= 2 to avoid potential hangs
+        # during Python multiprocessing; set by default in SimpleITK 2.1
+        sitk.ProcessObject.SetGlobalDefaultThreader("Platform")
+    
     # name prefix to use a different name from the input files, such as when 
     # registering transposed/scaled images but outputting paths corresponding 
     # to the original image

--- a/magmap/io/sitk_io.py
+++ b/magmap/io/sitk_io.py
@@ -6,6 +6,7 @@ Manage import and export of :class:`simpleitk.Image` objects.
 """
 import os
 import shutil
+from typing import Optional, Tuple, Union
 
 import numpy as np
 import SimpleITK as sitk
@@ -225,25 +226,29 @@ def read_sitk_files(filename_sitk, reg_names=None, return_sitk=False):
     return img_np
 
 
-def load_registered_img(img_path, reg_name, get_sitk=False, return_path=False):
+def load_registered_img(
+        img_path: str, reg_name: str, get_sitk: bool = False,
+        return_path: bool = False
+) -> Union[Union[np.ndarray, sitk.Image],
+           Tuple[Union[np.ndarray, sitk.Image], str]]:
     """Load atlas-based image that has been registered to another image.
     
     Args:
-        img_path (str): Path as had been given to generate the registered
+        img_path: Path as had been given to generate the registered
             images, with the parent path of the registered images and base name 
             of the original image.
-        reg_name (str): Atlas image suffix to open. Can be an absolute path,
+        reg_name: Atlas image suffix to open. Can be an absolute path,
             which will be used directly, ignoring ``img_path``.
-        get_sitk (bool): True if the image should be returned as a SimpleITK
+        get_sitk: True if the image should be returned as a SimpleITK
             image; defaults to False, in which case the corresponding Numpy
             array will be extracted instead.
-        return_path (bool): True to return the path from which the image
+        return_path: True to return the path from which the image
             was loaded; defaults to False.
     
     Returns:
-        :class:`numpy.ndarray`: The atlas-based image as a Numpy array, or a
-        :class:`sitk.Image` object if ``get_sitk`` is True. Also returns the
-        loaded path if ``return_path`` is True.
+        The atlas-based image as a Numpy array, or a :class:`sitk.Image`
+        object if ``get_sitk`` is True. Also returns the loaded path if
+        ``return_path`` is True.
     
     Raises:
         ``FileNotFoundError`` if the path cannot be found.

--- a/magmap/settings/atlas_prof.py
+++ b/magmap/settings/atlas_prof.py
@@ -761,6 +761,12 @@ class AtlasProfile(profiles.SettingsDict):
                 # "extra_metric_groups": (config.MetricGroups.SHAPES,),
                 "extra_metric_groups": (config.MetricGroups.POINT_CLOUD,),
             },
+            
+            # skip metrics
+            "fewerstats": {
+                "meas_smoothing": False,
+                "meas_edge_dists": False,
+            },
 
             # measure interior-border stats
             "interiorlabels": {

--- a/magmap/settings/atlas_prof.py
+++ b/magmap/settings/atlas_prof.py
@@ -228,6 +228,9 @@ class AtlasProfile(profiles.SettingsDict):
 
         # METRICS
         
+        # measure smoothing quality metrics during label smoothing
+        self["meas_smoothing"] = True
+        
         # generate labels border/surface image and measure distances to
         # anatomical border/surface map
         self["meas_edge_dists"] = True


### PR DESCRIPTION
Addresses #51. Smoothing metrics have been measured when smoothing during atlas import, but not when smoothing after edge-aware reannotation (the `--register merge_atlas_segs` task). This PR extends those metrics to that task.

If metrics aren't needed, they can now also be toggled through an atlas profile setting, `meas_smoothing`. This PR adds a new profiled named `fewerstats` to turn off as many metrics as possible, right now just `meas_smoothing` and `meas_edge_dists`.

Also fixes #52. The metric may hang when using SimpleITK/SimpleElastix 2.0 because of apparent changes in how Python multiprocessing is handled. This PR sets SimpleITK to use the "Platform" threader to fix this hang on SimpleITK 2.0. The setting is not applied in earlier SimpleITK version since the setting does not exist. It is also not necessary in the forthcoming SimpleITK 2.1 because it already sets it but does not appear to conflict, so the setting is still applied here for simplicity.