### PR TITLE
Cache full Python environment in CI workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,13 +37,10 @@ jobs:
       - name: Cache pip
         uses: actions/cache@v2
         with:
-          # This path is specific to Ubuntu
-          path: ~/.cache/pip
+          # python environment path from setup-python
+          path: ${{ env.pythonLocation }}
           # Look to see if there is a cache hit for the corresponding requirements file
-          key: ${{ runner.os }}-pip-${{ hashFiles('envs/requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-            ${{ runner.os }}-
+          key: ${{ env.pythonLocation }}-pip-${{ hashFiles('envs/requirements.txt') }}
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip setuptools wheel

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           # python environment path from setup-python
           path: ${{ env.pythonLocation }}
-          # Look to see if there is a cache hit for the corresponding requirements file
+          # check for cache from the corresponding requirements file
           key: ${{ env.pythonLocation }}-pip-${{ hashFiles('envs/requirements.txt') }}
       - name: Install dependencies
         run: |


### PR DESCRIPTION
The CI cache has been storing downloaded Python wheels but not the installation, which can take almost two minutes to complete. To reduce this redundancy, this PR caches and restores the full environment with settings recommended from here: https://medium.com/ai2-blog/python-caching-in-github-actions-e9452698e98d