### PR TITLE
Save more DSC metrics when in the merge atlas segmentations task

### DIFF
--- a/magmap/atlas/atlas_refiner.py
+++ b/magmap/atlas/atlas_refiner.py
@@ -26,6 +26,8 @@ from magmap.plot import plot_3d, plot_support
 from magmap.settings import config
 from magmap.settings import profiles
 
+_logger = config.logger.getChild(__name__)
+
 
 def _get_bbox(img_np, threshold=10):
     """Get the bounding box for the largest object within an image.
@@ -1513,8 +1515,9 @@ def measure_atlas_refinement(
 
     """
     # DSC and total volumes of atlas and labels
-    print("\nDSC after import:")
     overlap_meas_add = config.atlas_profile["overlap_meas_add_lbls"]
+    lbls_msg = f" (plus {overlap_meas_add})" if overlap_meas_add else ""
+    _logger.info(f"\nMeasuring overlap of atlas and combined labels{lbls_msg}:")
     dsc, atlas_mask, labels_mask = measure_overlap_combined_labels(
         img_atlas, img_labels, overlap_meas_add, return_masks=True)
     metrics[config.AtlasMetrics.DSC_ATLAS_LABELS] = [dsc]
@@ -1530,7 +1533,7 @@ def measure_atlas_refinement(
         thresh_atlas, img_atlas.GetSpacing()[::-1])
     metrics[config.SmoothingMetrics.COMPACTNESS] = [compactness]
 
-    print("\nWhole atlas stats:")
+    _logger.info("\nWhole atlas stats:")
     df = df_io.dict_to_data_frame(metrics, path, show=" ")
     return df  
 
@@ -1612,7 +1615,7 @@ def measure_overlap_labels(labels_img1, labels_img2):
     overlap_filter = sitk.LabelOverlapMeasuresImageFilter()
     overlap_filter.Execute(labels_img1, labels_img2)
     mean_region_dsc = overlap_filter.GetDiceCoefficient()
-    print("Mean label-by-label DSC: {}".format(mean_region_dsc))
+    _logger.info("Mean label overlap DSC: {}".format(mean_region_dsc))
     return mean_region_dsc
 
 

--- a/magmap/atlas/edge_seg.py
+++ b/magmap/atlas/edge_seg.py
@@ -355,8 +355,6 @@ def edge_aware_segmentation(path_atlas, show=True, atlas=True, suffix=None,
     labels_sitk_seg = sitk_io.replace_sitk_with_numpy(labels_sitk, labels_seg)
     
     # show DSCs for labels
-    print("\nMeasuring overlap of atlas and combined watershed labels:")
-    atlas_refiner.measure_overlap_combined_labels(atlas_sitk, labels_sitk_seg)
     print("Measuring overlap of individual original and watershed labels:")
     atlas_refiner.measure_overlap_labels(labels_sitk, labels_sitk_seg)
     print("\nMeasuring overlap of combined original and watershed labels:")
@@ -374,7 +372,7 @@ def edge_aware_segmentation(path_atlas, show=True, atlas=True, suffix=None,
     df_metrics_path = libmag.combine_paths(
         mod_path, config.PATH_ATLAS_IMPORT_METRICS)
     atlas_refiner.measure_atlas_refinement(
-        metrics, atlas_sitk, labels_sitk, df_metrics_path)
+        metrics, atlas_sitk, labels_sitk_seg, df_metrics_path)
 
     # show and write image to same directory as atlas with appropriate suffix
     sitk_io.write_reg_images(

--- a/magmap/settings/config.py
+++ b/magmap/settings/config.py
@@ -649,6 +649,8 @@ class AtlasMetrics(Enum):
     DSC_ATLAS_SAMPLE = "DSC_atlas_sample"
     DSC_ATLAS_SAMPLE_CUR = "DSC_atlas_sample_curated"
     DSC_SAMPLE_LABELS = "DSC_sample_labels"
+    DSC_LABELS_ORIG_NEW_COMBINED = "DSC_labels_orig_new_combined"
+    DSC_LABELS_ORIG_NEW_INDIV = "DSC_labels_orig_new_individual"
     SIMILARITY_METRIC = "Similarity_metric"
     LAT_UNLBL_VOL = "Lateral_unlabeled_volume"
     LAT_UNLBL_PLANES = "Lateral_unlabeled_planes"


### PR DESCRIPTION
DSC metrics between the original and new labels are measured and printed to console during the `merge_atlas_segs` tasks but not saved to file. Now that metrics from this task are saved (#54), this PR saves these labels-specific metrics as well. Additionally, the atlas to labels DSC metric already saved is fixed to use the new rather than the original labels.