### PR TITLE
Use shared memory arrays for spawned multiprocessing

### DIFF
--- a/docs/release/release_v1.4.md
+++ b/docs/release/release_v1.4.md
@@ -1,5 +1,46 @@
 # MagellanMapper v1.4 Release Notes
 
+## MagellanMapper v1.4.1
+
+### Highlights
+
+### Changes
+
+#### Installation
+
+#### GUI
+
+#### CLI
+
+#### Atlas refinement
+
+- Multiprocessing in Windows (`spawn` start mode) is now supported, including the `--register import_atlas`, `make_edge_images`, `merge_atlas_segs`, `vol_stats`, and `make_density_images` tasks
+- Lateral extension is slightly faster by not using multiprocessing since it had to be started for each plane
+
+#### Atlas registration
+
+#### Cell detection
+
+#### Volumetric image processing
+
+#### I/O
+
+#### Server pipelines
+
+#### Python stats and plots
+
+#### R stats and plots
+
+#### Code base and docs
+
+### Dependency Updates
+
+#### Python Dependency Changes
+
+#### R Dependency Changes
+
+#### Server dependency Changes
+
 ## MagellanMapper v1.4.0
 
 ### Highlights

--- a/magmap/atlas/atlas_refiner.py
+++ b/magmap/atlas/atlas_refiner.py
@@ -616,7 +616,8 @@ def extend_edge(region, region_ref, threshold, plane_region, planei,
                           "wt_lat", wt_lat_frac)
                 markers, _ = segmenter.labels_to_markers_erosion(
                     plane_add, filt_size, -1, filt_size_min,
-                    marker_erosion_use_min, wt_dists=wt_dists)
+                    marker_erosion_use_min, wt_dists=wt_dists,
+                    multiprocess=False)
                 plane_add = segmenter.segment_from_labels(
                     edges_region[planei], markers, plane_add)
                 # make resulting plane the new template for smoother

--- a/magmap/atlas/transformer.py
+++ b/magmap/atlas/transformer.py
@@ -5,6 +5,7 @@ and image transposition.
 """
 
 from time import time
+from typing import Sequence
 
 import numpy as np
 from skimage import transform
@@ -116,15 +117,17 @@ def make_modifier_resized(target_size):
     return "resized({},{},{})".format(*target_size)
 
 
-def get_transposed_image_path(img_path, scale=None, target_size=None):
-    """Get path, modified for any transposition by :func:``transpose_npy`` 
-    naming conventions.
+def get_transposed_image_path(
+        img_path: str, scale: float = None, target_size: Sequence[int] = None
+) -> str:
+    """Get path modified for any transposition.
     
     Args:
         img_path: Unmodified image path.
-        scale: Scaling factor; defaults to None, which ignores scaling.
-        target_size: Target size, typically given by a register profile; 
-            defaults to None, which ignores target size.
+        scale: Scaling factor, which takes precedence over ``target_size``;
+            defaults to None.
+        target_size: Target size in ``x, y, z``, typically given by an atlas
+            profile; defaults to None.
     
     Returns:
         Modified path for the given transposition, or ``img_path`` unmodified 
@@ -134,7 +137,6 @@ def get_transposed_image_path(img_path, scale=None, target_size=None):
     if scale is not None or target_size is not None:
         # use scaled image for pixel comparison, retrieving 
         # saved scaling as of v.0.6.0
-        modifier = None
         if scale is not None:
             # scale takes priority as command-line argument
             modifier = make_modifier_scale(scale)

--- a/magmap/cv/chunking.py
+++ b/magmap/cv/chunking.py
@@ -8,12 +8,8 @@ from typing import Callable, Optional, Sequence, Tuple
 import numpy as np
 
 from magmap.settings import config
-from magmap.cv import detector
 from magmap.io import libmag
 
-#: int: Factor to multiply by scaling for maximum number of pixels per
-# sub ROI for overlap.
-OVERLAP_FACTOR = 5
 
 
 def set_mp_start_method(val=None):
@@ -79,17 +75,6 @@ def get_mp_pool(
     return mp.Pool(
         processes=config.cpus, maxtasksperchild=max_tasks,
         initializer=initializer, initargs=initargs)
-
-
-def calc_overlap():
-    """Calculate overlap based on scaling factor and :const:``OVERLAP_FACTOR``.
-    
-    Returns:
-        Overlap as an array in the same shape and order as in 
-        :attr:``detector.resolutions``.
-    """
-    return np.ceil(np.multiply(detector.calc_scaling_factor(),
-                               OVERLAP_FACTOR)).astype(int)
 
 
 def _num_units(size, max_pixels):

--- a/magmap/cv/chunking.py
+++ b/magmap/cv/chunking.py
@@ -3,6 +3,7 @@
 """Divides a region into smaller chunks and reassembles it."""
 
 import multiprocessing as mp
+from typing import Callable, Optional, Tuple
 
 import numpy as np
 
@@ -53,14 +54,21 @@ def is_fork():
     return mp.get_start_method(False) == "fork"
 
 
-def get_mp_pool():
+def get_mp_pool(
+        initializer: Optional[Callable] = None,
+        initargs: Optional[Tuple] = None) -> mp.Pool:
     """Get a multiprocessing ``Pool`` object, configured based on ``config``
     settings.
     
+    Args:
+        initializer: Function to be called on initialization for each process;
+            defaults to None.
+        initargs: Arguments to ``initializer``; defaults to None.
+        
+    
     Returns:
-        :obj:`multiprocessing.Pool`: Pool object with number of processes
-        and max tasks per process determined by command-line and the main
-        (first) ROI profile settings.
+        Pool object with number of processes and max tasks per process
+        determined by command-line and the main (first) ROI profile settings.
 
     """
     prof = config.get_roi_profile(0)
@@ -68,7 +76,9 @@ def get_mp_pool():
     print("Setting up multiprocessing pool with {} processes (None uses all "
           "available)\nand max tasks of {} before replacing processes (None "
           "does not replace processes)".format(config.cpus, max_tasks))
-    return mp.Pool(processes=config.cpus, maxtasksperchild=max_tasks)
+    return mp.Pool(
+        processes=config.cpus, maxtasksperchild=max_tasks,
+        initializer=initializer, initargs=initargs)
 
 
 def calc_overlap():

--- a/magmap/cv/chunking.py
+++ b/magmap/cv/chunking.py
@@ -362,31 +362,3 @@ def merge_blobs(blob_rois):
     else:
         blobs_all = None
     return blobs_all
-
-
-def main():
-    """Test splitting and remerging."""
-    config.resolutions = [[6.6, 1.1, 1.1]]
-    roi = np.arange(5 * 4 * 4)
-    roi = roi.reshape((5, 4, 4))
-    print("roi:\n{}".format(roi))
-    overlap = calc_overlap()
-    sub_roi_slices, sub_rois_offsets = stack_splitter(roi.shape, [1, 2, 2])
-    print("sub_rois shape: {}".format(sub_roi_slices.shape))
-    print("sub_rois:\n{}".format(sub_roi_slices))
-    print("overlap: {}".format(overlap))
-    print("sub_rois_offsets:\n{}".format(sub_rois_offsets))
-    for z in range(sub_roi_slices.shape[0]):
-        for y in range(sub_roi_slices.shape[1]):
-            for x in range(sub_roi_slices.shape[2]):
-                coord = (z, y, x)
-                sub_roi_slices[coord] = roi[sub_roi_slices[coord]]
-    merged = merge_split_stack(sub_roi_slices, overlap)
-    print("merged:\n{}".format(merged))
-    print("merged shape: {}".format(merged.shape))
-    print("test roi == merged: {}".format(np.all(roi == merged)))
-
-
-if __name__ == "__main__":
-    print("Starting chunking...")
-    main()

--- a/magmap/cv/detector.py
+++ b/magmap/cv/detector.py
@@ -3,12 +3,18 @@
 """Detects features within a 3D image stack.
 
 Prunes duplicates and verifies detections against truth sets.
+
+Attributes:
+    CONFIRMATION: Dictionary of blob confirmation flags.
+    OVERLAP_FACTOR: Pixel number multiplier for overlaps between adjacent ROIs.
+
 """
 
 from enum import Enum
 import math
 import pprint
 from time import time
+from typing import Dict, Optional
 
 import numpy as np
 from skimage.feature import blob_log
@@ -19,12 +25,15 @@ from magmap.plot import plot_3d
 from magmap.settings import config
 
 # blob confirmation flags
-CONFIRMATION = {
+CONFIRMATION: Dict[int, str] = {
     -1: "unverified",
     0: "no",
     1: "yes",
     2: "maybe"
 }
+
+# pixel number multiplier by scaling for max overlapping pixels per ROI
+OVERLAP_FACTOR: int = 5
 
 
 class Blobs:
@@ -201,6 +210,22 @@ def calc_scaling_factor():
             "Must load resolutions from file or set a resolution")
     factor = np.divide(1.0, config.resolutions[0])
     return factor
+
+
+def calc_overlap(factor: Optional[int] = None):
+    """Calculate overlap based on scaling factor and a factor.
+    
+    Args:
+        factor: Overlap factor; defaults to None to use :const:``OVERLAP_FACTOR``
+
+    Returns:
+        Overlap as an array in the same shape and order as in 
+        :attr:``resolutions``.
+    
+    """
+    if factor is None:
+        factor = OVERLAP_FACTOR
+    return np.ceil(np.multiply(calc_scaling_factor(), factor)).astype(int)
 
 
 def _blob_surroundings(blob, roi, padding, plane=False):

--- a/magmap/cv/segmenter.py
+++ b/magmap/cv/segmenter.py
@@ -223,7 +223,7 @@ def labels_to_markers_blob(labels_img):
     return markers
 
 
-class LabelToMarkerErosion(object):
+class LabelToMarkerErosion(chunking.SharedLabelsImg):
     """Convert a label to an eroded marker for multiprocessing
     
     Uses class methods as an encapsulated way to use in forked multiprocessing
@@ -233,30 +233,8 @@ class LabelToMarkerErosion(object):
     Attributes:
         labels_img: Integer labels images as a Numpy array.
         wt_dists: Array of distances by which to weight the filter size.
-        labels_img_shared: ``labels_img`` as a shared array.
-        labels_img_shape: Shape of ``labels_img_shared``.
-        labels_img_dtype: Data type of ``labels_img_shared``.
     """
-    labels_img: np.ndarray = None
     wt_dists: np.ndarray = None
-    
-    labels_img_shared: sharedctypes.RawArray = None
-    labels_img_shape: Tuple = None
-    labels_img_dtype: np.dtype = None
-    
-    @classmethod
-    def setup_labels_img_shared(cls, img, shape, dtype):
-        """Set up shared labels image for reconstructing as ndarray.
-        
-        Args:
-            img: Labels image as a shared array.
-            shape: Shape of the image.
-            dtype: Data type of the image.
-
-        """
-        cls.labels_img_shared = img
-        cls.labels_img_shape = shape
-        cls.labels_img_dtype = dtype
     
     @classmethod
     def set_labels_img(cls, labels_img: np.ndarray, wt_dists: np.ndarray):
@@ -345,11 +323,7 @@ class LabelToMarkerErosion(object):
                 available.
         
         """
-        if cls.labels_img is None:
-            # convert shared raw array to Numpy array for labels image
-            cls.labels_img = np.frombuffer(
-                cls.labels_img_shared, cls.labels_img_dtype).reshape(
-                cls.labels_img_shape)
+        cls.convert_shared_labels_img()
 
         if (wt is None and cls.wt_dists is not None and
                 cls.labels_img is not None):
@@ -388,12 +362,6 @@ class LabelToMarkerErosion(object):
         stats_eros = (label_id, region_size, region_size_filtered,
                       chosen_selem_size)
         return stats_eros, slices, filtered
-
-
-def _init_labels_to_markers(*args):
-    """Initialize labels to markers class attributes in spawned multiprocessing.
-    """
-    LabelToMarkerErosion.setup_labels_img_shared(*args)
 
 
 def labels_to_markers_erosion(labels_img, filter_size=8, target_frac=None,
@@ -453,13 +421,7 @@ def labels_to_markers_erosion(labels_img, filter_size=8, target_frac=None,
         LabelToMarkerErosion.set_labels_img(labels_img, wt_dists)
     else:
         # set up labels image as a shared array for spawned mode
-        initializer = _init_labels_to_markers
-        initargs = (
-            sharedctypes.RawArray(np.ctypeslib.as_ctypes_type(
-                labels_img.dtype), labels_img.flatten()),
-            labels_img.shape,
-            labels_img.dtype,
-        )
+        initializer, initargs = LabelToMarkerErosion.build_pool_init(labels_img)
     
     pool = chunking.get_mp_pool(initializer, initargs)
     pool_results = []

--- a/magmap/cv/segmenter.py
+++ b/magmap/cv/segmenter.py
@@ -223,7 +223,7 @@ def labels_to_markers_blob(labels_img):
     return markers
 
 
-class LabelToMarkerErosion(chunking.SharedLabelsImg):
+class LabelToMarkerErosion(chunking.SharedArrsContainer):
     """Convert a label to an eroded marker for multiprocessing
     
     Uses class methods as an encapsulated way to use in forked multiprocessing
@@ -234,6 +234,7 @@ class LabelToMarkerErosion(chunking.SharedLabelsImg):
         labels_img: Integer labels images as a Numpy array.
         wt_dists: Array of distances by which to weight the filter size.
     """
+    labels_img: np.ndarray = None
     wt_dists: np.ndarray = None
     
     @classmethod
@@ -323,7 +324,8 @@ class LabelToMarkerErosion(chunking.SharedLabelsImg):
                 available.
         
         """
-        cls.convert_shared_labels_img()
+        if cls.labels_img is None:
+            cls.labels_img = cls.convert_shared_arr(config.RegNames.IMG_LABELS)
 
         if (wt is None and cls.wt_dists is not None and
                 cls.labels_img is not None):
@@ -421,7 +423,8 @@ def labels_to_markers_erosion(labels_img, filter_size=8, target_frac=None,
         LabelToMarkerErosion.set_labels_img(labels_img, wt_dists)
     else:
         # set up labels image as a shared array for spawned mode
-        initializer, initargs = LabelToMarkerErosion.build_pool_init(labels_img)
+        initializer, initargs = LabelToMarkerErosion.build_pool_init({
+            config.RegNames.IMG_LABELS: labels_img})
     
     pool = chunking.get_mp_pool(initializer, initargs)
     pool_results = []

--- a/magmap/cv/stack_detect.py
+++ b/magmap/cv/stack_detect.py
@@ -276,7 +276,7 @@ def setup_blocks(settings, shape):
             np.multiply(scaling_factor, denoise_size)).astype(int)
 
     # overlap sub-ROIs to minimize edge effects
-    overlap_base = chunking.calc_overlap()
+    overlap_base = detector.calc_overlap()
     tol = np.multiply(overlap_base, settings["prune_tol_factor"]).astype(int)
     overlap_padding = np.copy(tol)
     overlap = np.copy(overlap_base)

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -55,8 +55,7 @@ import vtk
 
 import run
 from magmap.atlas import ontology
-from magmap.cv import chunking, colocalizer, cv_nd, detector, segmenter,\
-    verifier
+from magmap.cv import colocalizer, cv_nd, detector, segmenter, verifier
 from magmap.gui import atlas_editor, import_threads, roi_editor, vis_3d, \
     vis_handler
 from magmap.io import cli, importer, libmag, naming, np_io, sitk_io, sqlite
@@ -1913,7 +1912,7 @@ class Visualization(HasTraits):
             if ColocalizeOptions.MATCHES.value in self._colocalize:
                 # match blobs between two channels
                 verify_tol = np.multiply(
-                    chunking.calc_overlap(),
+                    detector.calc_overlap(),
                     config.roi_profile["verify_tol_factor"])
                 matches = colocalizer.colocalize_blobs_match(
                     segs_all, np.zeros(3, dtype=int), roi_size, verify_tol,
@@ -2637,7 +2636,7 @@ class Visualization(HasTraits):
         """
         if border is not None and np.array_equal(border, self._DEFAULT_BORDER):
             return border
-        return chunking.calc_overlap()[::-1]
+        return detector.calc_overlap()[::-1]
     
     def _set_border(self, reset=False):
         """Sets the border as an (x, y, z) Numpy array, changing the final

--- a/magmap/io/df_io.py
+++ b/magmap/io/df_io.py
@@ -8,6 +8,7 @@ Attributes:
 
 from enum import Enum
 import os
+from typing import Dict, List, Optional, Union
 import warnings
 
 import numpy as np
@@ -555,8 +556,11 @@ def print_data_frame(df, sep=" ", index=False, header=True, show=True):
     return df_str
 
 
-def dict_to_data_frame(to_import, path=None, sort_cols=None, show=None,
-                       records_cols=None):
+def dict_to_data_frame(
+        to_import: Union[Dict, List[List]], path: str = None,
+        sort_cols: Union[str, List[str]] = None,
+        show: Optional[Union[bool, str]] = None,
+        records_cols: Optional[Union[list, tuple]] = None) -> pd.DataFrame:
     """Import dictionary to data frame with additional options.
     
     Supports conversion of Enum column names to their values. Also, allows
@@ -565,25 +569,25 @@ def dict_to_data_frame(to_import, path=None, sort_cols=None, show=None,
     :meth:`data_frames_to_csv`.
     
     Args:
-        to_import (Union[dict, list[list]]): Dictionary to import. May
+        to_import: Dictionary to import. May
             also be list of lists to import as records if ``records_cols``
             is given. If column name are enums, they will be converted to
             their values.
-        path (str): Output path to export data frame to CSV file; defaults to
+        path: Output path to export data frame to CSV file; defaults to
             None for no export.
-        sort_cols (Union[str, list[str]]): Column as a string or list of
+        sort_cols: Column as a string or list of
             columns by which to sort; defaults to None for no sorting.
-        show (Union[bool, str]): True or " " to print the data frame with a
+        show: True or " " to print the data frame with a
             space-separated table, or can provide an alternate separator.
             Defaults to None to not print the data frame.
-        records_cols (Union[list, tuple]): Import from records, where
+        records_cols: Import from records, where
             ``to_import`` is a list of rows rather than a dictionary, using
             this sequence of record column names instead of dictionary keys;
             defaults to None.
             
     
     Returns:
-        :class:`pandas.DataFrame`: The imported data frame.
+        The imported data frame.
     
     """
     if records_cols:
@@ -606,7 +610,10 @@ def dict_to_data_frame(to_import, path=None, sort_cols=None, show=None,
     return df
 
 
-def data_frames_to_csv(data_frames, path=None, sort_cols=None, show=None):
+def data_frames_to_csv(
+        data_frames: List[pd.DataFrame], path: str = None,
+        sort_cols: Optional[str] = None,
+        show: Optional[Union[str, bool]] = None, index: bool = False):
     """Combine and export multiple data frames to CSV file.
     
     Args:
@@ -619,6 +626,7 @@ def data_frames_to_csv(data_frames, path=None, sort_cols=None, show=None):
         show: True or " " to print the data frame with a space-separated 
             table, or can provide an alternate separator. Defaults to None 
             to not print the data frame.
+        index: True to include the index; defaults to False.
     
     Returns:
         The combined data frame.
@@ -636,7 +644,7 @@ def data_frames_to_csv(data_frames, path=None, sort_cols=None, show=None):
         combined = pd.concat(combined)
     if sort_cols is not None:
         combined = combined.sort_values(sort_cols)
-    combined.to_csv(path, index=False, na_rep="NaN")
+    combined.to_csv(path, index=index, na_rep="NaN")
     if show is not None:
         print_data_frame(combined, show)
     if path:

--- a/magmap/io/df_io.py
+++ b/magmap/io/df_io.py
@@ -770,7 +770,11 @@ def main():
 
     if df_task is config.DFTasks.MERGE_CSVS:
         # merge multiple CSV files into single CSV file
-        merge_csvs(config.filenames, config.prefix)
+        prefix = config.prefix
+        if not prefix:
+            # fallback to default filename based on first path
+            prefix = f"{os.path.splitext(config.filename)[0]}_merged"
+        merge_csvs(config.filenames, prefix)
 
     elif df_task is config.DFTasks.MERGE_CSVS_COLS:
         # join multiple CSV files based on a given index column into single

--- a/magmap/io/np_io.py
+++ b/magmap/io/np_io.py
@@ -3,6 +3,7 @@
 """Import/export for Numpy-based archives such as ``.npy`` and ``.npz`` formats.
 """
 import os
+from typing import Optional, Sequence, Tuple
 
 import numpy as np
 import pandas as pd
@@ -62,30 +63,35 @@ def img_to_blobs_path(path):
     return libmag.combine_paths(path, config.SUFFIX_BLOBS)
 
 
-def find_scaling(img_path, scaled_shape=None, scale=None):
+def find_scaling(
+        img_path: str, scaled_shape: Optional[Sequence[int]] = None,
+        scale: float = None, load_size: Optional[Sequence[int]] = None
+) -> Tuple[Sequence[float], Sequence[float]]:
     """Find scaling between two images.
     
     Scaling can be computed to translate blob coordinates into another
     space, such as a heat map for a downsampled image.
     
     Args:
-        img_path (str): Base path to image.
-        scaled_shape (List): Shape of image to calculate scaling factor if
+        img_path: Base path to image.
+        scaled_shape: Shape of image to calculate scaling factor if
             this factor cannot be found from a transposed file's metadata;
             defaults to None.
-        scale (int, float): Scalar scaling factor, used to find a
+        scale: Scalar scaling factor, used to find a
             rescaled file; defaults to None. To find a resized file instead,
             set an atlas profile with the resizing factor.
+        load_size: Size of image to load in ``x, y, z``, typically given by an
+            atlas profile and used to identify the path of the scaled
+            image to load; defaults to None.
 
     Returns:
-        list[float], list[float]: Sequence of scaling factors to a scaled
+        Tuple of sequence of scaling factors to a scaled
         or resized image, or None if not loaded or given, and the resolutions
         of the full-sized image found based on ``img_path``.
 
     """
     # get scaling and resolutions from blob space to that of a down/upsampled
     # image space
-    load_size = config.atlas_profile["target_size"]
     img_path_transposed = transformer.get_transposed_image_path(
         img_path, scale, load_size)
     scaling = None

--- a/magmap/stats/clustering.py
+++ b/magmap/stats/clustering.py
@@ -122,7 +122,9 @@ def plot_knns(img_paths, suffix=None, show=False, names=None):
         labels_img_np = sitk_io.load_registered_img(
             mod_path, config.RegNames.IMG_LABELS.value)
         blobs = detector.Blobs().load_blobs(np_io.img_to_blobs_path(img_path))
-        scaling, res = np_io.find_scaling(img_path, labels_img_np.shape)
+        scaling, res = np_io.find_scaling(
+            img_path, labels_img_np.shape,
+            load_size=config.atlas_profile["target_size"])
         if blobs is None:
             libmag.warn("unable to load nuclei coordinates for", img_path)
             continue
@@ -260,7 +262,9 @@ def cluster_blobs(img_path, suffix=None):
     labels_img_np = sitk_io.load_registered_img(
         mod_path, config.RegNames.IMG_LABELS.value)
     blobs = detector.Blobs().load_blobs(np_io.img_to_blobs_path(img_path))
-    scaling, res = np_io.find_scaling(img_path, labels_img_np.shape)
+    scaling, res = np_io.find_scaling(
+        img_path, labels_img_np.shape,
+        load_size=config.atlas_profile["target_size"])
     if blobs is None:
         libmag.warn("unable to load nuclei coordinates")
         return

--- a/magmap/stats/vols.py
+++ b/magmap/stats/vols.py
@@ -313,9 +313,9 @@ class MeasureLabel(chunking.SharedArrsContainer):
                 in :attr:``labels_img_np`` for which to measure variation.
             extra_metrics: Sequence of additional metric groups to measure;
                 defaults to None.
-             df: Pandas data frame with a row for each sub-region; defaults
+            df: Pandas data frame with a row for each sub-region; defaults
                 to None.
-             spacing: Sequence of image spacing for each pixel in the images;
+            spacing: Sequence of image spacing for each pixel in the images;
                 defaults to None.
         
         Returns:

--- a/magmap/tests/test_chunking.py
+++ b/magmap/tests/test_chunking.py
@@ -1,0 +1,70 @@
+"""Unit testing for the chunking module"""
+
+import unittest
+from typing import Sequence
+
+import numpy as np
+
+from magmap.cv import chunking
+from magmap.settings import config
+
+
+class TestChunking(unittest.TestCase):
+    
+    @staticmethod
+    def stack_split_remerge(
+            roi: np.ndarray, max_pixels: Sequence[int], overlap: Sequence[int]
+    ) -> np.ndarray:
+        """Split and remerge a stack.
+        
+        Args:
+            roi: Region of interest.
+            max_pixels: Maximum pixels along each dimension.
+            overlap: Number of overlapping pixels along each dimension, to
+                be added to ``max_pixels`` if possible.
+
+        Returns:
+            The remerged stack
+
+        """
+        sub_roi_slices, sub_rois_offsets = chunking.stack_splitter(
+            roi.shape, max_pixels, overlap)
+        print("sub_rois shape: {}".format(sub_roi_slices.shape))
+        print("sub_roi_slices:\n{}".format(sub_roi_slices))
+        print("overlap: {}".format(overlap))
+        print("sub_rois_offsets:\n{}".format(sub_rois_offsets))
+        for z in range(sub_roi_slices.shape[0]):
+            for y in range(sub_roi_slices.shape[1]):
+                for x in range(sub_roi_slices.shape[2]):
+                    coord = (z, y, x)
+                    sub_roi_slices[coord] = roi[sub_roi_slices[coord]]
+                    print(coord, "shape:", sub_roi_slices[coord].shape, sub_roi_slices[coord])
+        # print("sub_rois:\n{}".format(sub_roi_slices))
+        merged = chunking.merge_split_stack(sub_roi_slices, max_pixels, overlap)
+        print("merged:\n{}".format(merged))
+        return merged
+    
+    def test_stack_splitter(self):
+        """Test splitting and remerging."""
+        roi = np.arange(5 * 4 * 4).reshape((5, 4, 4))
+        print("roi:\n{}".format(roi))
+        max_pixels = [1, 3, 3]
+        
+        merged = self.stack_split_remerge(roi, max_pixels, np.array((0, 1, 1)))
+        np.testing.assert_array_equal(roi, merged)
+
+        merged = self.stack_split_remerge(roi, max_pixels, np.array((0, 1, 2)))
+        np.testing.assert_array_equal(roi, merged)
+
+        merged = self.stack_split_remerge(roi, max_pixels, np.array((1, 1, 2)))
+        np.testing.assert_array_equal(roi, merged)
+        
+        # test overlap generated based on resolutions
+        config.resolutions = [[6.6, 1.1, 1.1]]
+        merged = self.stack_split_remerge(
+            roi, max_pixels, chunking.calc_overlap(2))
+        np.testing.assert_array_equal(roi, merged)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/magmap/tests/test_chunking.py
+++ b/magmap/tests/test_chunking.py
@@ -5,7 +5,7 @@ from typing import Sequence
 
 import numpy as np
 
-from magmap.cv import chunking
+from magmap.cv import chunking, detector
 from magmap.settings import config
 
 
@@ -62,7 +62,7 @@ class TestChunking(unittest.TestCase):
         # test overlap generated based on resolutions
         config.resolutions = [[6.6, 1.1, 1.1]]
         merged = self.stack_split_remerge(
-            roi, max_pixels, chunking.calc_overlap(2))
+            roi, max_pixels, detector.calc_overlap(2))
         np.testing.assert_array_equal(roi, merged)
 
 


### PR DESCRIPTION
Multiprocessing in MagellanMapper has assumed the forked start method, where objects present before the fork are available to each child process. Python on Windows only supports the spawn start method, however, where objects need to be shared through other means such as pickling or shared memory arrays. PR #59 introduced support for Windows in the labels erosion to markers task through pickling, but pickling can be slow enough to obviate the performance improvements of multiprocessing in other tasks such as converting labels to edges.

This PR uses shared memory arrays instead of pickling to share large objects. A new class handles conversion to and from the shared array for NumPy arrays, which the classes used for multiprocessing can extend to convert their arrays if not present through forking. Lateral extension now uses this shared instead of pickling. Performance is similar, however, presumably because the multiprocessing needs to be restarted multiple times, once for each plane. The same function used during the `merge_atlas_stats` erosion is at least slightly faster when using shared arrays, presumably because multiprocessing and shared array setup is only done once for the full volume.

Using this class, support for spawned multiprocessing (ie Windows, #58) is added to the `vol_stats` task, and the `fewerstats` atlas profile no longer needs to be used for the `make_edge_images` and `merge_atlas_stats` tasks.