### PR TITLE
Generalize the labels reference lookup for data frames

### DIFF
--- a/magmap/atlas/register.py
+++ b/magmap/atlas/register.py
@@ -1318,7 +1318,7 @@ def volumes_by_id(img_paths, labels_ref_path, suffix=None, unit_factor=None,
     grouping[config.AtlasMetrics.CONDITION.value] = condition
     
     # set up labels reference and labels
-    labels_ref_lookup = ontology.create_aba_reverse_lookup(
+    labels_ref_lookup = ontology.create_ref_lookup(
         ontology.load_labels_ref(labels_ref_path))
     label_ids = make_label_ids_set(
         labels_ref_path, labels_ref_lookup, max_level, combine_sides)
@@ -1513,7 +1513,7 @@ def volumes_by_id_compare(img_paths, labels_ref_paths, unit_factor=None,
     
     # load labels references and label IDs based on the last reference
     labels_ref_paths = libmag.to_seq(labels_ref_paths)
-    labels_ref_lookups = [ontology.create_aba_reverse_lookup(
+    labels_ref_lookups = [ontology.create_ref_lookup(
         ontology.load_labels_ref(p)) for p in labels_ref_paths]
     label_ids = make_label_ids_set(
         labels_ref_paths[-1], labels_ref_lookups[-1], max_level, combine_sides)
@@ -1653,7 +1653,7 @@ def _test_labels_lookup():
     lookup_id = 15565 # short search path
     #lookup_id = 126652058 # last item
     time_dict_start = time()
-    id_dict = ontology.create_aba_reverse_lookup(ref)
+    id_dict = ontology.create_ref_lookup(ref)
     labels_img = sitk_io.load_registered_img(
         config.filename, config.RegNames.IMG_LABELS.value)
     max_labels = np.max(labels_img)
@@ -1713,7 +1713,7 @@ def _test_region_from_id():
         scaling = importer.calc_scaling(img5d.img, labels_img)
         print("loaded experiment image from {}".format(config.filename))
     ref = ontology.load_labels_ref(config.load_labels)
-    id_dict = ontology.create_aba_reverse_lookup(ref)
+    id_dict = ontology.create_ref_lookup(ref)
     middle, img_region, region_ids = ontology.get_region_middle(
         id_dict, 16652, labels_img, scaling)
     atlas_label = ontology.get_label(
@@ -1817,7 +1817,7 @@ def main():
         # export regions IDs to CSV files
         
         ref = ontology.load_labels_ref(config.load_labels)
-        labels_ref_lookup = ontology.create_aba_reverse_lookup(ref)
+        labels_ref_lookup = ontology.create_ref_lookup(ref)
         
         # export region IDs and parents at given level to CSV, using only
         # the atlas' labels if orig colors is true

--- a/magmap/io/export_regions.py
+++ b/magmap/io/export_regions.py
@@ -418,7 +418,7 @@ def make_labels_level_img(img_path, level, prefix=None, show=False):
         img_path, config.RegNames.IMG_LABELS.value, get_sitk=True)
     labels_np = sitk.GetArrayFromImage(labels_sitk)
     ref = ontology.load_labels_ref(config.load_labels)
-    labels_ref_lookup = ontology.create_aba_reverse_lookup(ref)
+    labels_ref_lookup = ontology.create_ref_lookup(ref)
     
     ids = list(labels_ref_lookup.keys())
     for key in ids:

--- a/magmap/io/np_io.py
+++ b/magmap/io/np_io.py
@@ -383,15 +383,8 @@ def setup_images(path=None, series=None, offset=None, size=None,
         try:
             if config.load_labels is not None:
                 # load labels reference file
-                labels_ref = ontology.load_labels_ref(config.load_labels)
-                if isinstance(labels_ref, pd.DataFrame):
-                    # parse CSV files loaded into data frame
-                    config.labels_ref_lookup = ontology.create_lookup_pd(
-                        labels_ref)
-                else:
-                    # parse dict from ABA JSON file
-                    config.labels_ref_lookup = (
-                        ontology.create_aba_reverse_lookup(labels_ref))
+                config.labels_ref_lookup = ontology.create_ref_lookup(
+                    ontology.load_labels_ref(config.load_labels))
         except (FileNotFoundError, KeyError) as e:
             _logger.error(e)
             _logger.error("Skipping labels reference file loading from '%s'",

--- a/magmap/stats/atlas_stats.py
+++ b/magmap/stats/atlas_stats.py
@@ -55,7 +55,7 @@ def plot_region_development(metric, size=None, show=True):
     dfs_nonbr_large = [df[df["Region"] == n] for n in ids_nonbr_large]
     
     # get data frame with region IDs of all non-brain structures removed
-    labels_ref_lookup = ontology.create_aba_reverse_lookup(
+    labels_ref_lookup = ontology.create_ref_lookup(
         ontology.load_labels_ref(config.load_labels))
     ids_nonbr = []
     for n in ids_nonbr_large:


### PR DESCRIPTION
Main image setup supports loading labels reference files given as either CSV (to data frame) or JSON (to dict) format, but many other functions have expected JSON format. Extend support for CSV format by creating a simple wrapper function to convert labels reference files from either data frames or dict to lookup references. Volume stats, region export, and region development now support CSV in addition to JSON reference files.