### PR TITLE
Window size and position preferences

### DIFF
--- a/docs/release/release_v1.5.md
+++ b/docs/release/release_v1.5.md
@@ -10,6 +10,10 @@
 
 #### GUI
 
+- Window size and position are saved as user prferences
+- The default window size is smaller to fit into 720p displays
+- The default focus is no longer the main image file path to avoid accidental file loading
+
 #### CLI
 
 See the [table of CLI changes](../cli.md#changes-in-magellanmapper-v15) for a summary of all changes in v1.5

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -755,6 +755,8 @@ class Visualization(HasTraits):
         statusbar="_status_bar_msg",
         resizable=True,
         icon=icon_img,
+        # set ID to trigger saving TraitsUI preferences for window size/position
+        id=f"{__name__}.{__qualname__}",
     )
 
     def __init__(self):

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -567,8 +567,10 @@ class Visualization(HasTraits):
                      format_func=lambda x: x)),
         ),
         # give initial focus to text editor that does not trigger any events to
-        # avoid inadvertent actions by the user when the window first displays
-        Item("_roi_feedback", style="custom", show_label=False, has_focus=True),
+        # avoid inadvertent actions by the user when the window first displays;
+        # set width to any small val to get smallest size for the whole panel
+        Item("_roi_feedback", style="custom", show_label=False, has_focus=True,
+             width=100),
         HGroup(
             Item("btn_redraw", show_label=False),
             Item("_btn_save_fig", show_label=False),
@@ -723,8 +725,9 @@ class Visualization(HasTraits):
 
     # tabbed panel with ROI Editor, Atlas Editor, and Mayavi scene
     panel_figs = Tabbed(
+        # set a small width to allow window to be resized down to this size
         Item("_roi_ed_fig", label="ROI Editor", show_label=False,
-             editor=MPLFigureEditor(), width=1000, height=600),
+             editor=MPLFigureEditor(), width=100, height=600),
         Item("_atlas_ed_fig", label="Atlas Editor", show_label=False,
              editor=MPLFigureEditor()),
         Item("scene", label="3D Viewer", show_label=False,
@@ -735,13 +738,17 @@ class Visualization(HasTraits):
     icon_img = (ImageResource(str(config.ICON_PATH))
                 if config.ICON_PATH.exists() else None)
     
-    # set up the GUI layout; control the HSplit width ratio using a width
-    # for this whole view and a width for an item in panel_figs
+    # set up the GUI layout; 
     view = View(
+        # control the HSplit width ratio by setting min widths for an item in
+        # each Tabbed view and initial window total width; panel_figs expands
+        # to fill the remaining space
         HSplit(
             panel_options,
             panel_figs,
         ),
+        # initial window width, which can be resized down to the minimum
+        # widths of each panel in the HSplit
         width=1500,
         handler=vis_handler.VisHandler(),
         title="MagellanMapper",

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -749,7 +749,7 @@ class Visualization(HasTraits):
         ),
         # initial window width, which can be resized down to the minimum
         # widths of each panel in the HSplit
-        width=1500,
+        width=1200,
         handler=vis_handler.VisHandler(),
         title="MagellanMapper",
         statusbar="_status_bar_msg",

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -566,7 +566,9 @@ class Visualization(HasTraits):
                      values=[e.value for e in RegionOptions], cols=2,
                      format_func=lambda x: x)),
         ),
-        Item("_roi_feedback", style="custom", show_label=False),
+        # give initial focus to text editor that does not trigger any events to
+        # avoid inadvertent actions by the user when the window first displays
+        Item("_roi_feedback", style="custom", show_label=False, has_focus=True),
         HGroup(
             Item("btn_redraw", show_label=False),
             Item("_btn_save_fig", show_label=False),

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -727,7 +727,7 @@ class Visualization(HasTraits):
     panel_figs = Tabbed(
         # set a small width to allow window to be resized down to this size
         Item("_roi_ed_fig", label="ROI Editor", show_label=False,
-             editor=MPLFigureEditor(), width=100, height=600),
+             editor=MPLFigureEditor(), width=100),
         Item("_atlas_ed_fig", label="Atlas Editor", show_label=False,
              editor=MPLFigureEditor()),
         Item("scene", label="3D Viewer", show_label=False,
@@ -750,6 +750,8 @@ class Visualization(HasTraits):
         # initial window width, which can be resized down to the minimum
         # widths of each panel in the HSplit
         width=1200,
+        # keeps window top bar within screen in small displays on Windows
+        height=600,
         handler=vis_handler.VisHandler(),
         title="MagellanMapper",
         statusbar="_status_bar_msg",


### PR DESCRIPTION
The TraitsUI library stores and restores window size and position in a preferences database. This PR enables that database by applying an ID to the main GUI View, which triggers saving these preferences (see [docs](https://docs.enthought.com/traitsui/api/traitsui.view.html#traitsui.view.View.ui)). The database is also manually generated since it is not automatically created when the parent directories are not present.

This PR also allows window widths to be decreased more and makes the default width smaller. Previously, the window width could not be decreased below the initial size, which was larger than some screens (1500 px). Now the default size is 1200 px to fit into 720p screens, and the window can be further decreased to a narrow width if desired. The preferences also save the window size to restore it during the next session. Shifting the height parameter to the main View also causes the window top bar to be positioned within the screen on small screens (ie smaller than the minimum window height) rather than above the screen on Windows, allowing the window height to be resized. The window sizing changes fix #38.

Additionally, the default focus after startup is shifted to the feedback area to prevent accidental changes to the main image file path.