### PR TITLE
Registered image selector fixes

### DIFF
--- a/magmap/io/importer.py
+++ b/magmap/io/importer.py
@@ -349,7 +349,7 @@ def deconstruct_img_name(np_filename, sep="_", keep_subimg=False):
             suffix = suffix.value
             suffix_noext = libmag.get_filename_without_ext(suffix)
             suffixi = np_filename.rfind(suffix_noext)
-            if suffixi != -1 and os.path.splitext(np_filename)[0].endswith(
+            if suffixi != -1 and libmag.splitext(np_filename)[0].endswith(
                     suffix_noext):
                 # strip suffix and any ending separator to get base path
                 filename = np_filename[:suffixi]

--- a/magmap/io/libmag.py
+++ b/magmap/io/libmag.py
@@ -240,9 +240,8 @@ def match_ext(path, path_to_match):
     return path_to_match
 
 
-def get_filename_without_ext(path):
-    """Get filename without extension with support for extensions with
-    multiple periods through :meth:`splitext`.
+def get_filename_without_ext(path: str) -> str:
+    """Wrapper to :meth:`splitext` for getting only the filename.
     
     Args:
         path: Full path.
@@ -252,7 +251,7 @@ def get_filename_without_ext(path):
         no extension exists.
     """
     name = os.path.basename(path)
-    name_split = os.path.splitext(name)
+    name_split = splitext(name)
     if len(name_split) > 1: return name_split[0]
     return name
 


### PR DESCRIPTION
This PR makes several fixes/updates to the "Registered Images" selectors in the GUI:
- Supports finding suffixes with known multiple extensions (eg `.nii.gz`; fixes #63; also fixes a scenario related to #26)
- Hides the extension while remembering it for loading/saving images
- Fixes loading images in the GUI while displaying an image with a registered intensity image set