### PR TITLE
Add profile previews and basic settings sub-panel

### DIFF
--- a/magmap/gui/vis_handler.py
+++ b/magmap/gui/vis_handler.py
@@ -79,6 +79,7 @@ class VisHandler(Handler):
                 for k, v in db.items():
                     if k.startswith("magmap"):
                         _logger.debug("TraitsUI preferences for %s: %s", k, v)
+                        break
             db.close()
         
         # WORKAROUND: TraitsUI icon does not work in Mac; use PyQt directly to
@@ -162,6 +163,24 @@ class VisHandler(Handler):
         # Enums auto-increment from 1
         tab_widgets = info.ui.control.findChildren(QtWidgets.QTabWidget)
         tab_widgets[1].setCurrentIndex(info.object.select_controls_tab - 1)
+
+    def object__profiles_reset_prefs_changed(self, info):
+        """Reset preferences."""
+        if not info.object._profiles_reset_prefs: return
+        
+        # reset window prefs stored in TraitsUI; these prefs only appear to be
+        # stored on window close, so this reset has no impact except for
+        # opening new windows during this session
+        db = info.ui.get_ui_db("w")
+        if db is not None:
+            for k, v in db.items():
+                if k.startswith("magmap"):
+                    del db[k]
+                    _logger.debug("Reset TraitsUI preferences")
+                    info.object.update_status_bar_msg("Preferences were reset")
+                    break
+            db.close()
+        info.object._profiles_reset_prefs = False
 
 
 class ViewerTabs(Enum):

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -56,7 +56,6 @@ from mayavi.core.ui.mayavi_scene import MayaviScene
 import vtk
 
 import run
-import setup as mag_setup
 from magmap.atlas import ontology
 from magmap.cv import colocalizer, cv_nd, detector, segmenter, verifier
 from magmap.gui import atlas_editor, import_threads, roi_editor, vis_3d, \
@@ -829,12 +828,7 @@ class Visualization(HasTraits):
         self._init_profiles()
         
         # set up settings controls
-        ver = mag_setup.config["version"]
-        git_commit = libmag.get_git_commit(os.path.dirname(run.__file__))
-        if git_commit:
-            # add git short hash if available
-            ver = f"{ver}-{git_commit[:8]}"
-        self._profiles_ver = ver
+        self._profiles_ver = libmag.get_version(True)
         self._profiles_reset_prefs = False
 
         # set up image import

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -2909,7 +2909,7 @@ class Visualization(HasTraits):
 
         # set up all profiles
         cli.setup_roi_profiles(roi_profs)
-        cli.setup_atlas_profiles(grid_profs)
+        cli.setup_atlas_profiles(atlas_profs)
         cli.setup_grid_search_profiles(grid_profs)
 
     def _init_profiles(self):

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -125,8 +125,8 @@ class SegmentsArrayAdapter(TabularAdapter):
 
 class ProfileCats(Enum):
     """Profile categories enumeration."""
-    ROI = "ROI"
-    ATLAS = "Atlas"
+    ROI = "ROI profiles"
+    ATLAS = "Atlas profiles"
     GRID = "Grid Search"
 
 
@@ -137,8 +137,8 @@ class TraitsList(HasTraits):
 
 class ProfilesArrayAdapter(TabularAdapter):
     """Profiles TraitsUI table adapter."""
-    columns = [("Type", 0), ("Name", 1), ("Channel", 2)]
-    widths = {0: 0.2, 1: 0.7, 2: 0.1}
+    columns = [("Category", 0), ("Profile", 1), ("Channel", 2)]
+    widths = {0: 0.3, 1: 0.6, 2: 0.1}
 
     def get_width(self, object, trait, column):
         """Specify column widths."""
@@ -335,13 +335,15 @@ class Visualization(HasTraits):
     _profiles_cats = List
     _profiles_names = Instance(TraitsList)
     _profiles_name = Str
-    _profiles_chls = List
+    _profiles_chls = List(
+        tooltip="Channels to apply the selected profile"
+    )
     _profiles_table = TabularEditor(
         adapter=ProfilesArrayAdapter(), editable=True, auto_resize_rows=True,
         stretch_last_section=False)
     _profiles = List  # profiles table list
-    _profiles_add_btn = Button("Add profile")
-    _profiles_load_btn = Button("Load profiles")
+    _profiles_add_btn = Button("Add")
+    _profiles_load_btn = Button("Rescan")
     _profiles_ver = Str
     _profiles_reset_prefs_btn = Button("Reset preferences")
     _profiles_reset_prefs = Bool  # trigger resetting prefs in handler
@@ -618,19 +620,19 @@ class Visualization(HasTraits):
     panel_profiles = VGroup(
         VGroup(
             HGroup(
-                Item("_profiles_cats", style="simple", label="Profile",
+                Item("_profiles_cats", style="simple", show_label=False,
                      editor=CheckListEditor(
                          values=[e.value for e in ProfileCats], cols=1,
                          format_func=lambda x: x)),
-                Item("_profiles_name", label="Name",
+                Item("_profiles_chls", label="Chls", style="custom",
+                     editor=CheckListEditor(
+                         name="object._channel_names.selections", cols=8)),
+            ),
+            HGroup(
+                Item("_profiles_name", show_label=False,
                      editor=CheckListEditor(
                          name="object._profiles_names.selections",
                          format_func=lambda x: x)),
-            ),
-            Item("_profiles_chls", label="Channels", style="custom",
-                 editor=CheckListEditor(
-                     name="object._channel_names.selections", cols=8)),
-            HGroup(
                 Item("_profiles_add_btn", show_label=False),
                 Item("_profiles_load_btn", show_label=False),
             ),

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -2859,8 +2859,7 @@ class Visualization(HasTraits):
 
         if prof:
             # add profiles and matching configuration files
-            prof_names = list(prof.profiles.keys())
-            prof_names.extend(prof.get_files())
+            prof_names = [*prof.profiles.keys(), *prof.get_files()]
         else:
             # clear profile names
             prof_names = []
@@ -2868,7 +2867,8 @@ class Visualization(HasTraits):
         # even though the item will appear to be selected by default
         self._profiles_names = TraitsList()
         self._profiles_names.selections = prof_names
-        self._profiles_name = prof_names[0]
+        if prof_names:
+            self._profiles_name = prof_names[0]
 
     @on_trait_change("_profiles_add_btn")
     def _add_profile(self):

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -2879,12 +2879,6 @@ class Visualization(HasTraits):
             print("profile to add", prof)
             self._profiles.append(prof)
 
-    @on_trait_change("_profiles_load_btn")
-    def _load_profiles(self):
-        """Load profiles based on profiles added to the table."""
-        # update profile names list
-        self._update_profiles_names()
-        
         print("profiles from table:\n", self._profiles)
         if not self._profiles:
             # no profiles in the table to load
@@ -2911,6 +2905,11 @@ class Visualization(HasTraits):
         cli.setup_roi_profiles(roi_profs)
         cli.setup_atlas_profiles(atlas_profs)
         cli.setup_grid_search_profiles(grid_profs)
+
+    @on_trait_change("_profiles_load_btn")
+    def _load_profiles(self):
+        """Reload available profiles."""
+        self._update_profiles_names()
 
     def _init_profiles(self):
         """Initialize the profiles table based on the currently loaded profiles.

--- a/magmap/io/cli.py
+++ b/magmap/io/cli.py
@@ -222,6 +222,9 @@ def process_cli_args():
     """
     parser = argparse.ArgumentParser(
         description="Setup environment for MagellanMapper")
+    parser.add_argument(
+        "--version", action="store_true",
+        help="Show version information and exit")
 
     # image specification arguments
     
@@ -408,6 +411,11 @@ def process_cli_args():
     sys.stdout = logs.LogWriter(config.logger.info)
     sys.stderr = logs.LogWriter(config.logger.error)
     
+    if args.version:
+        # print version info and exit
+        _logger.info(f"{config.APP_NAME}-{libmag.get_version(True)}")
+        shutdown()
+
     # log the app launch path
     path_launch = (sys._MEIPASS if getattr(sys, "frozen", False)
                    and hasattr(sys, "_MEIPASS") else sys.argv[0])

--- a/magmap/io/libmag.py
+++ b/magmap/io/libmag.py
@@ -7,7 +7,7 @@ import os
 import pathlib
 import shutil
 import warnings
-from typing import Union
+from typing import Optional, Union
 
 import numpy as np
 from skimage import exposure
@@ -1134,6 +1134,32 @@ def scale_slice(sl, scale, size):
     start = 0 if scaled[0] is None else scaled[0]
     end = size if scaled[1] is None else scaled[1]
     return np.linspace(start, end, sl.stop - sl.start, dtype=int)
+
+
+def get_git_commit(repo_dir: str) -> Optional[str]:
+    """Get git commit hash.
+    
+    Args:
+        repo_dir: Path to repository root directory.
+
+    Returns:
+        Commit hash, or None if not found.
+
+    """
+    # get HEAD file from .git folder
+    git_dir = pathlib.Path(repo_dir) / ".git"
+    head_path = git_dir / "HEAD"
+    if not head_path.is_file(): return None
+    
+    # get ref path from HEAD file
+    with head_path.open("r") as head_file:
+        ref = head_file.readline().split(" ")[-1].strip()
+    ref_path = git_dir / ref
+    if not ref_path.is_file(): return None
+    
+    # get hash from ref file
+    with ref_path.open("r") as ref_file:
+        return ref_file.readline().strip()
 
 
 if __name__ == "__main__":

--- a/magmap/io/libmag.py
+++ b/magmap/io/libmag.py
@@ -6,8 +6,15 @@
 import os
 import pathlib
 import shutil
-import warnings
+import sys
 from typing import Optional, Union
+import warnings
+
+if sys.version_info >= (3, 8):
+    # included with Python >= 3.8
+    from importlib import metadata
+else:
+    import importlib_metadata as metadata
 
 import numpy as np
 from skimage import exposure
@@ -1160,6 +1167,30 @@ def get_git_commit(repo_dir: str) -> Optional[str]:
     # get hash from ref file
     with ref_path.open("r") as ref_file:
         return ref_file.readline().strip()
+
+
+def get_version(git: bool = False) -> str:
+    """Get package version from installed metadata.
+    
+    Args:
+        git: True to add a short hash of the current Git commit.
+
+    Returns:
+        The version string. If ``git`` is True, the current Git commit
+        is appended as ``<ver>-<short-hash>``.
+
+    """
+    # get version from installed metadata; note that this version may differ
+    # from the imported version:
+    # https://packaging.python.org/guides/single-sourcing-package-version/
+    ver = metadata.version(config.APP_NAME.lower())
+    if git:
+        git_commit = get_git_commit(
+            str(pathlib.Path(__file__).parent.parent.parent))
+        if git_commit:
+            # add git short hash if available
+            ver = f"{ver}-{git_commit[:8]}"
+    return ver
 
 
 if __name__ == "__main__":

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,8 @@ config = {
         "simpleitk==2.0.2rc2.dev785+g8ac4f",  # pre-built SimpleElastix
         "PyYAML",
         "appdirs",
+        # part of stdlib in Python >= 3.8
+        "importlib-metadata >= 1.0 ; python_version < '3.8'",
     ], 
     "extras_require": {
         "import": _EXTRAS_IMPORT, 


### PR DESCRIPTION
The profiles tab contains dropdown selectors for ROI, atlas, and grid search profiles, but currently it provides little guidance on selecting a profile without having to look into the source code. This PR adds profile previews, where selecting a profile shows the profile contents in a new text area. The profile is simply the dictionary pretty-formatted to show the settings keys and value pairs.

Previously loading new profiles required pressing the "Load profiles" button, which may be unintuitive since the "Add profile" could also be interpreted to fully add it. This PR removes the "Load profiles" step so that pressing the "Add" button adds it to the table and sets it up. The "Load profiles" button is renamed to "Rescan" and now serves only to rescan the `profiles` directory to find any new profiles. This button may not be necessary since the directory is rescanned each time a new profile category is selected, but it makes the operation explicit and allows rescanning for the currently selected category. The profile selectors are also reorganized to clarify that the profile category selector is separate from individual profiles.

This PR also adds a new section at the bottom of the panel for software settings/preferences. Currently it has only two fields, with one showing the current version including a Git commit hash if available for developmental versions. The other field is a preferences reset button, which clears preferences saved by TraitsUI, currently only window size/position. This addition is in preparation for additional preferences such as profiles, files, etc.