### PR TITLE
Export image stacks to multiple figures, support Windows

### DIFF
--- a/magmap/atlas/atlas_refiner.py
+++ b/magmap/atlas/atlas_refiner.py
@@ -18,7 +18,7 @@ from skimage import transform
 from magmap.atlas import labels_meta
 from magmap.cv import chunking, cv_nd, segmenter
 from magmap.io import df_io, export_stack, importer, libmag, np_io, sitk_io
-from magmap.plot import plot_3d, plot_support
+from magmap.plot import colormaps, plot_3d, plot_support
 from magmap.settings import atlas_prof, config, profiles
 
 _logger = config.logger.getChild(__name__)
@@ -323,8 +323,9 @@ def _curate_labels(img, img_ref, mirror=None, edge=None, expand=None,
         # of lower planes with signal in the reference image
         save_steps = edge[profiles.RegKeys.SAVE_STEPS]
         if save_steps:
-            # load original labels and setup colormaps
-            np_io.setup_images()
+            # set up colormaps for intensity image and original labels
+            colormaps.setup_cmaps()
+            config.cmap_labels = colormaps.setup_labels_cmap(label_ids_orig)
         extend_edge(
             img_np, img_ref_np, config.atlas_profile["atlas_threshold"],
             None, edgei, edge["surr_size"], edge["smoothing_size"],

--- a/magmap/io/export_stack.py
+++ b/magmap/io/export_stack.py
@@ -591,17 +591,21 @@ def stack_to_img(paths, roi_offset, roi_size, series=None, subimg_offset=None,
                 path_base, fig_dict["imgs"], config.delay, config.savefig,
                 suffix)
         else:
+            # generate single figure with axis and plane index in filename
             if collage:
                 # output filename as a collage of images
                 if not os.path.isdir(path_base):
                     path_base = os.path.dirname(path_base)
                 path_base = os.path.join(path_base, "collage")
+            
+            # insert mod as suffix, then add any additional suffix
             # TODO: config.prefix likely conflicts with intended image setup
-            out_path = libmag.make_out_path(path_base, suffix=suffix)
             mod = "_plane_{}{}".format(
                 plot_support.get_plane_axis(config.plane), planei)
+            out_path = libmag.make_out_path(path_base, suffix=mod)
+            out_path = libmag.insert_before_ext(out_path, suffix)
             plot_support.save_fig(
-                out_path, config.savefig, mod, fig_dict["fig"])
+                out_path, config.savefig, fig=fig_dict["fig"])
 
 
 def reg_planes_to_img(imgs, path=None, ax=None):

--- a/magmap/io/export_stack.py
+++ b/magmap/io/export_stack.py
@@ -473,6 +473,16 @@ def stack_to_img(paths, roi_offset, roi_size, series=None, subimg_offset=None,
                 labels_imgs=(config.labels_img, config.borders_img), 
                 multiplane=animated, 
                 fit=(size is None or ncols * nrows == 1))
+            
+            # add sub-plot title unless groups given as empty string
+            title = None
+            if config.groups:
+                title = libmag.get_if_within(config.groups, n)
+            elif num_paths > 1:
+                title = os.path.basename(path_sub)
+            if title:
+                ax.title.set_text(title)
+    
     path_base = paths[0]
     if animated:
         # generate animated image (eg animated GIF or movie file)
@@ -492,10 +502,11 @@ def stack_to_img(paths, roi_offset, roi_size, series=None, subimg_offset=None,
             if not os.path.isdir(path_base):
                 path_base = os.path.dirname(path_base)
             path_base = os.path.join(path_base, "collage")
+        # TODO: config.prefix likely conflicts with intended image setup
+        out_path = libmag.make_out_path(path_base, suffix=suffix)
         mod = "_plane_{}{}".format(
             plot_support.get_plane_axis(config.plane), planei)
-        if suffix: path_base = libmag.insert_before_ext(path_base, suffix)
-        plot_support.save_fig(path_base, config.savefig, mod)
+        plot_support.save_fig(out_path, config.savefig, mod)
 
 
 def reg_planes_to_img(imgs, path=None, ax=None):

--- a/magmap/io/export_stack.py
+++ b/magmap/io/export_stack.py
@@ -12,6 +12,7 @@ import numpy as np
 from skimage import transform
 from skimage import io
 from matplotlib import animation
+from matplotlib.image import AxesImage
 from scipy import ndimage
 
 from magmap.cv import chunking, cv_nd
@@ -259,14 +260,15 @@ class StackPlaneIO(chunking.SharedArrsContainer):
             pool.join()
 
         if fit and plotted_imgs:
-            # fit frame to first plane's first available image
-            ax_img = None
-            for ax_img in plotted_imgs[0]:
-                # images may be None if alpha set to 0
-                if ax_img is not None: break
-            if ax_img is not None:
-                plot_support.fit_frame_to_image(
-                    ax_img.figure, ax_img.get_array().shape, self.aspect)
+            # fit each figure to its first available image
+            for ax_img in plotted_imgs:
+                # images may be flattened AxesImage, array of AxesImage and
+                # Text, or None if alpha set to 0
+                if ax_img and libmag.is_seq(ax_img):
+                    ax_img = ax_img[0]
+                if ax_img and isinstance(ax_img, AxesImage):
+                    plot_support.fit_frame_to_image(
+                        ax_img.figure, ax_img.get_array().shape, self.aspect)
         
         return plotted_imgs
 

--- a/magmap/io/np_io.py
+++ b/magmap/io/np_io.py
@@ -148,7 +148,7 @@ def _check_np_none(val):
     return None if val is None or np.all(np.equal(val, None)) else val
 
 
-def setup_images(path=None, series=None, offset=None, size=None,
+def setup_images(path, series=None, offset=None, size=None,
                  proc_type=None, allow_import=True):
     """Sets up an image and all associated images and metadata.
 

--- a/magmap/stats/atlas_stats.py
+++ b/magmap/stats/atlas_stats.py
@@ -488,10 +488,11 @@ def plot_clusters_by_label(path, z, suffix=None, show=True, scaling=None):
     else:
         # default to black background
         img = np.zeros_like(config.labels_img)[None]
-    export_stack.stack_to_ax_imgs(
-        ax, img, mod_path, slice_vals=(z, ), 
-        labels_imgs=(config.labels_img, config.borders_img), 
-        fit=False)
+    stacker = export_stack.setup_stack(
+        img, mod_path, slice_vals=(z, z + 1), 
+        labels_imgs=(config.labels_img, config.borders_img))
+    stacker.build_stack(
+        ax, config.plot_labels[config.PlotLabels.SCALE_BAR])
     # export_stack.reg_planes_to_img(
     #     (np.zeros(config.labels_img.shape[1:], dtype=int),
     #      config.labels_img[z]), ax=ax)


### PR DESCRIPTION
The `--proc extract` tasks exports an individual plane to a single file, while the `--proc animated` tasks exports multiple planes (eg the whole image stack) to an animated format such as and animated GIF or MP4 file. This PR extends the former task by allowing multiple planes to be extracted to separate files.

This addition comes in handy when building a collage of image from multiple images. Previously, each image is loaded, with one plane extracted per image and collected into a collage. To export multiple collages, eg for different planes in each image, the images must be reloaded for each plane. This update extracts all planes for each image, greatly reducing load time.

The multiprocessing that handles this tasks has also been extended as in #60 to support spawned multiprocessing, which is required for Windows. Since multiprocessing is often not even required, it is now turned off when no image rescaling is set.