### PR TITLE
Update Python-Bioformats dependency version

### DIFF
--- a/bin/build_bf.sh
+++ b/bin/build_bf.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Build script to compile a wheel for Python-Bioformats
+
+HELP="
+Compile a build a wheel for Python-Bioformats.
+
+The repository will be cleaned to its original state, removing all untracked
+files, to ensure that the build does not have stale artifacts.
+
+By default, a forked Python-Bioformats repository will be downloaded.
+
+Arguments:
+  -h: Show help and exit.
+  -d [path]: Python-Bioformats directory.
+  -o [path]: Output directory to copy wheel and source distribution.
+"
+
+bf_dir=""
+out_dir=""
+
+OPTIND=1
+while getopts hd:j:o: opt; do
+  case $opt in
+    h)
+      echo "$HELP"
+      exit 0
+      ;;
+    d)
+      bf_dir="$OPTARG"
+      echo "Changed Python-Python-Bioformats directory to $bf_dir"
+      ;;
+    o)
+      out_dir="$OPTARG"
+      echo "Changed output directory to $out_dir"
+      ;;
+    :)
+      echo "Option -$OPTARG requires an argument"
+      exit 1
+      ;;
+    *)
+      echo "$HELP" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# attempt compatibility with lowest Mac target; Python must have been
+# compiled with at least this target, or setting will be ignored
+export MACOSX_DEPLOYMENT_TARGET=10.9
+
+echo "Initating build of Python-Bioformats..."
+
+# base directory is script's parent directory
+BASE_DIR="$(dirname "$0")/.."
+cd "$BASE_DIR" || { echo "Unable to find folder $BASE_DIR, exiting"; exit 1; }
+base_dir="$PWD"
+if [[ -z "$bf_dir" ]]; then
+  # default to look for repo in parent of base dir
+  bf_dir="${base_dir}/../python-Python-Bioformats"
+elif [[ "$bf_dir" != /* ]]; then
+  # convert relative Python-Bioformats to abs dir path
+  bf_dir="${base_dir}/${bf_dir}"
+fi
+if [[ -n "$out_dir" && "$out_dir" != /* ]]; then
+  # convert relative output to abs dir path
+  out_dir="${base_dir}/${out_dir}"
+fi
+
+# get and/or enter git repo
+if [[ ! -d "$bf_dir" ]]; then
+  # get forked repo that depends on the original Javabridge package rather
+  # than the forked Python-Javabridge version
+  echo "Cloning Python-Python-Bioformats git repo to ${bf_dir}..."
+  git clone https://github.com/yoda-vid/python-bioformats.git "$bf_dir"
+fi
+cd "$bf_dir" || { echo "Unable to find folder $bf_dir, exiting"; exit 1; }
+
+# restore repo dir to pristine state
+git clean -dfx
+
+# build binaries, wheel, and source distribution
+echo "Building Python-Python-Bioformats"
+python setup.py build
+python setup.py bdist_wheel
+python setup.py sdist
+
+if [[ -n "$out_dir" ]]; then
+  # copy wheel and source distribution to output dir
+  if [[ ! -d "$out_dir" ]]; then
+    mkdir "$out_dir"
+  fi
+  cp -v "dist/"*.whl "dist/"*.tar.gz "$out_dir"
+fi
+
+echo "Done building Python-Python-Bioformats"

--- a/docs/release/release_v1.5.md
+++ b/docs/release/release_v1.5.md
@@ -66,7 +66,7 @@ See the [table of CLI changes](../cli.md#changes-in-magellanmapper-v15) for a su
 - Improvements to image import
     - Single plane RAW images can be loaded when importing files from a directory, in addition to multiplane RAW files
     - The known parts of the import image shape are populated even if the full shape is not known
-    - The Bio-Formats library has been updated to support more file formats (from Bio-Formats 5.1.8 to 6.6.0 via Python-Bioformats 1.10 to 4.0.5, respectively)
+    - The Bio-Formats library has been updated to support more file formats (from Bio-Formats 5.1.8 to 6.6.0 via Python-Bioformats 1.1.0 to 4.0.5, respectively)
     - Fixed to disable the import directory button when metadata is insufficient
     - Fixed to create parent directories when importing images
     - Fixed to create default resolutions even when none are specified

--- a/docs/release/release_v1.5.md
+++ b/docs/release/release_v1.5.md
@@ -63,13 +63,15 @@ See the [table of CLI changes](../cli.md#changes-in-magellanmapper-v15) for a su
     - Sub-plots are labeled
     - Image rotation arguments are applied
     - Plane index is only added when exporting multiple planes
-- Single plane RAW images can be loaded when importing files from a directory, in addition to multiplane RAW files
-- The known parts of the import image shape are populated even if the full shape is not known
-- Fixed to disable the import directory button when metadata is insufficient
+- Improvements to image import
+    - Single plane RAW images can be loaded when importing files from a directory, in addition to multiplane RAW files
+    - The known parts of the import image shape are populated even if the full shape is not known
+    - The Bio-Formats library has been updated to support more file formats (from Bio-Formats 5.1.8 to 6.6.0 via Python-Bioformats 1.10 to 4.0.5, respectively)
+    - Fixed to disable the import directory button when metadata is insufficient
+    - Fixed to create parent directories when importing images
+    - Fixed to create default resolutions even when none are specified
 - Fixed to update metadata files when loaded through the `--meta` flag
 - Fixed error when unable to load a profile `.yml` file
-- Fixed to create parent directories when importing images
-- Fixed to create default resolutions even when none are specified
 
 #### Server pipelines
 
@@ -88,6 +90,7 @@ See the [table of CLI changes](../cli.md#changes-in-magellanmapper-v15) for a su
 
 #### Python Dependency Changes
 
+- Python-Bioformats has been upgraded to 4.0.5 and uses a custom package that uses the existing Javabridge rather than Python-Javabridge to avoid a higher NumPy version requirement
 - Workaround for failure to install Mayavi because of a newer VTK, now pinned to 9.0.1
 
 #### R Dependency Changes

--- a/magmap/io/importer.py
+++ b/magmap/io/importer.py
@@ -20,13 +20,18 @@ from time import time
 import glob
 import re
 from xml import etree as et
-import warnings
+
+import numpy as np
+from PIL import Image
+from skimage import color
+from skimage import io
 
 from magmap.io import libmag, np_io, yaml_io
 from magmap.plot import plot_3d
 from magmap.settings import config
 
-import numpy as np
+_logger = config.logger.getChild(__name__)
+
 try:
     import javabridge as jb
     import bioformats as bf
@@ -35,13 +40,10 @@ except (ImportError, ValueError, RuntimeError) as e:
     # Java cannot be initialized, or a RuntimeError if Java home dir not found 
     jb = None
     bf = None
-    warnings.warn(
-        "{} could not be found, so there will be error when attempting to "
-        "import images into Numpy format".format(
-            e.name if isinstance(e, ImportError) else "Java"), UserWarning, 2)
-from PIL import Image
-from skimage import color
-from skimage import io
+    _logger.warn(
+        "%s could not be found, so there will be error when attempting to "
+        "import images into Numpy format",
+        e.name if isinstance(e, ImportError) else "Java")
 
 # pixel type enumeration based on:
 # http://downloads.openmicroscopy.org/bio-formats-cpp/5.1.8/api/classome_1_1xml_1_1model_1_1enums_1_1PixelType.html

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,8 @@ import setuptools
 _EXTRAS_IMPORT = [
     # Javabridge pre-built on Java 8
     "javabridge==1.0.19.post4+gbebed64",
-    "python-bioformats==1.1.0",
+    # Python-Bioformats built to depend on the vanilla (non-forked) Javabridge
+    "python-bioformats==4.0.5.post2+g51eb88a",
 ]
 
 # optional dependencies for Pandas


### PR DESCRIPTION
The Python-Bioformats dependency has been pinned in MagellanMapper to v1.1.0 because of a heap space error encountered with later versions of the package when importing some large image files (see https://github.com/CellProfiler/python-bioformats/issues/95). Since the Bio-Formats library included in this version of the package is relatively old (Bio-Formats v5.1.8 from 2016), this PR updates the package to bring in the current Bio-Formats version (v6.6.0). The library was tested on a large (40GB), multi-series CZI file that previously could not be loaded because of a JPEG-XR not supported error but now loads with this new library.

Python-Bioformats now depends on a fork of the original Javabridge package, named Python-Javabridge, pinned to its latest version. This latest version in turn requires NumPy 1.20, which has [dropped Python 3.6 support](https://docs.scipy.org/doc/scipy/reference/dev/toolchain.html). To maintain Python 3.6 compatibility, we have posted a custom wheel from a fork that uses that original Javabridge. This wheel thus can use the custom Javabridge wheels that we have previously posted to allow installation without a compiler or JDK and continues to work with Python >= 3.6. A simple Bash script used to build the wheel and based on the custom Javabridge wheel script is also included in this PR.