### PR TITLE
Add more fallback image registration setups

### DIFF
--- a/clrstats/R/jitter_plot.R
+++ b/clrstats/R/jitter_plot.R
@@ -511,10 +511,9 @@ printDirectly <- function(dev.fn, path.out, plot.size) {
 }
 
 finalizeDevice <- function(dev.fn, path.plot, plot.size) {
-  # Print and reset a device depending on device type and interactivity.
+  # Finalize a device by printing if necessary and resetting a device.
   #
-  # Print to a device if in interactive mode. Reset the device if in
-  # interactive mode or if the device is PDF if non-interactive mode..
+  # Prints to a device if in interactive mode, or simply resets the device.
   #
   # Args:
   #   dev.fn: Output device function.
@@ -524,8 +523,10 @@ finalizeDevice <- function(dev.fn, path.plot, plot.size) {
   if (interactive()) {
     # save plot from interactive (screen) device, including device reset
     printDirectly(dev.fn, path.plot, plot.size)
-  } else if (!is.null(dev.fn) & !identical(dev.fn, pdf)) {
-    # must reset non-pdf devices in non-interactive mode to output the file
+  } else if (!is.null(dev.fn)) {
+    # in non-interactive mode, must reset non-pdf devices to output the file
+    # and pdf devices to avoid stacking them into a multi-page file when
+    # too many devices are open
     resetDevice()
   }
 }

--- a/clrstats/R/volcano_plot.R
+++ b/clrstats/R/volcano_plot.R
@@ -41,13 +41,18 @@ volcanoPlot <- function(stats, meas, interaction, thresh=NULL,
   }
   #print(data.frame(x, size))
   
-  # point colors based on IDs of parents at the level generated for region 
-  # IDs file, using a palette with color for each unique parent
   parents <- stats$Parent
-  parents.unique <- unique(parents)
-  parents.indices <- match(parents, parents.unique)
-  colors <- RColorBrewer::brewer.pal(length(parents.unique), "Paired")
-  colors_parents <- colors[parents.indices]
+  if (length(parents) > 0) {
+    # point colors based on IDs of parents at the level generated for region 
+    # IDs file, using a palette with color for each unique parent
+    parents.unique <- unique(parents)
+    parents.indices <- match(parents, parents.unique)
+    colors <- RColorBrewer::brewer.pal(length(parents.unique), "Paired")
+    colors.parents <- colors[parents.indices]
+  } else {
+    # default to blue color for all points
+    colors.parents <- "blue"
+  }
   
   # base plot -log p vs effect size
   xlab <- "Effects"
@@ -93,7 +98,7 @@ volcanoPlot <- function(stats, meas, interaction, thresh=NULL,
     x, y, xlim=c(-1 * x.max, x.max), 
     main=title, xlab=xlab, 
     ylab="-log10(p)", type="p", las=1, pch=16, cex=(size*size.mult), 
-    col=colors_parents)
+    col=colors.parents)
   abline(v=0, lty="dashed", col=gray(0.5, 0.5))
   
   # label points

--- a/magmap/atlas/register.py
+++ b/magmap/atlas/register.py
@@ -1306,12 +1306,15 @@ def _setup_vols_df(df_path, max_level):
 def volumes_by_id(
         img_paths: Sequence[str], labels_ref_path: Optional[str] = None,
         suffix: Optional[str] = None, unit_factor: Optional[str] = None,
-        groups: Optional[str] = None, max_level: Optional[int] = None,
+        groups: Optional[Dict] = None, max_level: Optional[int] = None,
         combine_sides=True, extra_metrics: Optional[str] = None):
     """Get volumes and additional label metrics for each single labels ID.
     
     Atlas (intensity) and annotation (labels) images can be configured
-    in :attr:`config.reg_suffixes`.
+    in :attr:`magmap.settings.config.reg_suffixes`.
+    :attr:`magmap.settings.config.plot_labels` can be used
+    to configure the condition field with the
+    :attr:`magmap.settings.config.PlotLabels.CONDITION` key.
     
     Args:
         img_paths: Sequence of images.
@@ -1355,6 +1358,10 @@ def volumes_by_id(
         condition = config.suffix.replace("_", "")
         out_path += config.suffix
         out_path_summary += config.suffix
+    cond_arg = config.plot_labels[config.PlotLabels.CONDITION]
+    if cond_arg:
+        # override default condition or from suffix
+        condition = cond_arg
     
     # grouping metadata, which will be combined with groups
     grouping = OrderedDict()

--- a/magmap/settings/config.py
+++ b/magmap/settings/config.py
@@ -281,6 +281,7 @@ class PlotLabels(Enum):
     DPI = auto()  # dots per inch
     NAN_COLOR = auto()  # color for NaN values (Matplotlib or RGBA string)
     TEXT_POS = auto()  # text (annotation) position in x,y
+    CONDITION = auto()  # condition
 
 
 #: dict[Any]: Plot labels set from command-line.

--- a/magmap/settings/config.py
+++ b/magmap/settings/config.py
@@ -246,37 +246,43 @@ Plot2DTypes = Enum(
 )
 plot_2d_type = None
 
+
 # plot label keys for command-line parsing
-PlotLabels = Enum(
-    "PlotLabels", (
-        "TITLE",  # figure title
-        "X_LABEL", "Y_LABEL",  # axes labels
-        "X_UNIT", "Y_UNIT",  # axes units
-        "X_LIM", "Y_LIM",  # (min, max) for x-, y-axes
-        "X_TICK_LABELS", "Y_TICK_LABELS",  # labels for axis tick marks
-        "X_SCALE", "Y_SCALE",  # scaling, eg "log", "linear" (see Matplotlib)
-        "SIZE",  # in x,y 
-        "LAYOUT",  # subplot layout in num of columns, rows
-        "ALPHAS_CHL",  # alphas for main image's channels
-        "X_COL", "Y_COL",  # columns from data frame to plot
-        "GROUP_COL",  # data frame group column
-        "WT_COL",  # weight column
-        "ID_COL",  # ID column
-        "ERR_COL",  # error column(s)
-        "ANNOT_COL",  # annotation column for each point
-        "ZOOM_SHIFT",  # shift plot offset when zooming into ROI
-        "HLINE",  # horizontal line, usually fn for each group
-        "LEGEND_NAMES",  # names to display in legend
-        "PADDING",  # image padding, either as scalar or x,y,z
-        "MARGIN",  # image margin, either as scalar or x,y,z
-        "SCALE_BAR",  # True to include a scale bar
-        "MARKER",  # Matplotlib marker style
-        "DROP_DUPS",  # drop duplicates
-        "DPI",  # dots per inch
-        "NAN_COLOR",  # color for NaN values (Matplotlib or RGBA string)
-        "TEXT_POS",  # text (annotation) position in x,y
-    )
-)
+class PlotLabels(Enum):
+    TITLE = auto()  # figure title
+    X_LABEL = auto()  # axis labels
+    Y_LABEL = auto()
+    X_UNIT = auto()  # axis units
+    Y_UNIT = auto()
+    X_LIM = auto()  # (min, max) for axis
+    Y_LIM = auto()
+    X_TICK_LABELS = auto()  # labels for axis tick marks
+    Y_TICK_LABELS = auto()
+    X_SCALE = auto()  # scaling, eg "log", "linear" (see Matplotlib)
+    Y_SCALE = auto()
+    SIZE = auto()  # in x,y
+    LAYOUT = auto()  # subplot layout in num of columns, rows
+    ALPHAS_CHL = auto()  # alphas for main image's channels
+    X_COL = auto()  # column from data frame to plot
+    Y_COL = auto()
+    GROUP_COL = auto()  # data frame group column
+    WT_COL = auto()  # weight column
+    ID_COL = auto()  # ID column
+    ERR_COL = auto()  # error column(s)
+    ANNOT_COL = auto()  # annotation column for each point
+    ZOOM_SHIFT = auto()  # shift plot offset when zooming into ROI
+    HLINE = auto()  # horizontal line, usually fn for each group
+    LEGEND_NAMES = auto()  # names to display in legend
+    PADDING = auto()  # image padding, either as scalar or x,y,z
+    MARGIN = auto()  # image margin, either as scalar or x,y,z
+    SCALE_BAR = auto()  # True to include a scale bar
+    MARKER = auto()  # Matplotlib marker style
+    DROP_DUPS = auto()  # drop duplicates
+    DPI = auto()  # dots per inch
+    NAN_COLOR = auto()  # color for NaN values (Matplotlib or RGBA string)
+    TEXT_POS = auto()  # text (annotation) position in x,y
+
+
 #: dict[Any]: Plot labels set from command-line.
 plot_labels = dict.fromkeys(PlotLabels, None)
 plot_labels[PlotLabels.SCALE_BAR] = True


### PR DESCRIPTION
Image registration provides a fallback in case the registration does not complete, typically because Elastix does not find enough overlap between the fixed and moving image. The fallback matches the world info (ie spacing, direction, and origin) between the two images in case the underlying images are close enough to match, but their metadata is shifting them apart.

PR #36 inadvertently introduced a change where the spacing was excluded from this world info match, but occasionally this change is necessary to find the appropriate match. This PR extends this behavior by keeping one fallback registration where direction and origin are matched but spacing is left the same, then adding another fallback where all world info is changed. As a final fallback, the atlas is now simply returned as-is if no registration could be completed.

The PR also includes additional small fixes to stats on registered images, including catching exceptions when measuring image overlap for the DSC measurement if Elastix does not find the images to occupy the same space.