### PR TITLE
Fix auto intensity image settings

### DIFF
--- a/docs/release/release_v1.5.md
+++ b/docs/release/release_v1.5.md
@@ -20,6 +20,8 @@
 - The default window size is smaller to fit into 720p displays
 - The default focus is no longer the main image file path to avoid accidental file loading
 - Registered image selectors are now more compact
+- Fixed image intensity values and auto-adjustment to persist for each channel while scrolling and switching among channels
+- Fixed to retain opacity settings for borders images while scrolling
 
 #### CLI
 
@@ -104,6 +106,7 @@ See the [table of CLI changes](../cli.md#changes-in-magellanmapper-v15) for a su
 
 - Python-Bioformats has been upgraded to 4.0.5 and uses a custom package that uses the existing Javabridge rather than Python-Javabridge to avoid a higher NumPy version requirement
 - Workaround for failure to install Mayavi because of a newer VTK, now pinned to 9.0.1
+- Matplotlib >= 3.2 is now required
 
 #### R Dependency Changes
 

--- a/magmap/gui/plot_editor.py
+++ b/magmap/gui/plot_editor.py
@@ -403,7 +403,13 @@ class PlotEditor:
                 imgs2d.append(img_add)
                 self._channels.append([0])
                 cmaps.append(self.cmap_borders[channel])
-                alphas.append(libmag.get_if_within(config.alphas, 2 + i, 1))
+                
+                # get alpha for last corresponding borders plane if available
+                ax_img = libmag.get_if_within(self._plot_ax_imgs, 2 + i, None)
+                alpha = (ax_img[i].ax_img.get_alpha() if ax_img else
+                         libmag.get_if_within(config.alphas, 2 + i, 1))
+                alphas.append(alpha)
+                
                 shapes.append(self._img3d_shapes[2][1:3])
                 vmaxs.append(None)
                 vmins.append(None)

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -1005,27 +1005,28 @@ class Visualization(HasTraits):
                 ed = self.atlas_eds[0]
         if ed is None: return
 
-        # get the display settings from the viewer
+        # get the first displayed image from the viewer
         imgi = self._imgadj_names.selections.index(self._imgadj_name)
         plot_ax_img = ed.get_img_display_settings(
-                imgi, chl=int(self._imgadj_chls))
+            imgi, chl=int(self._imgadj_chls))
         if plot_ax_img is None: return
-        norm = plot_ax_img.ax_img.norm
+        
+        # populate controls with intensity settings
         self._imgadj_brightness = plot_ax_img.brightness
         self._imgadj_contrast = plot_ax_img.contrast
         self._imgadj_alpha = plot_ax_img.ax_img.get_alpha()
+
+        # populate intensity limits, auto-scaling, and current val (if not auto)
         self._adapt_imgadj_limits(plot_ax_img)
-        
-        # populate controls with display settings
-        if norm.vmin is None:
+        if plot_ax_img.vmin is None:
             self._imgadj_min_auto = True
         else:
-            self._imgadj_min = norm.vmin
+            self._imgadj_min = plot_ax_img.ax_img.norm.vmin
             self._imgadj_min_auto = False
-        if norm.vmax is None:
+        if plot_ax_img.vmax is None:
             self._imgadj_max_auto = True
         else:
-            self._imgadj_max = norm.vmax
+            self._imgadj_max = plot_ax_img.ax_img.norm.vmax
             self._imgadj_max_auto = False
     
     def _adapt_imgadj_limits(self, plot_ax_img):

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -2701,6 +2701,9 @@ class Visualization(HasTraits):
         self._ignore_roi_offset_change = True
         self.z_offset, self.y_offset, self.x_offset = offset
         self._ignore_roi_offset_change = False
+        
+        # update intensity limits, etc for the current image
+        self.update_imgadj_for_img()
     
     def get_roi_size(self):
         """Get the current ROI size.


### PR DESCRIPTION
Fixes #24 (also mentioned in #22). The image adjustment controls have an "Auto" check box to automatically titrate the intensity setting, but this setting has not worked consistently while scrolling through images. The setting was not enabled by default, instead relying on a globally determined threshold measured during image import, but this value is not available for images loaded without import, such as images in MHD or NIfTI format. Manually adjusted values were overridden when scrolling through images, fixed recently but also disabling auto if set. Intensity limits were also titrated upon opening the image to allow finer control over the expected image intensity range, but the limits are based on the shown plane and did not update when loading other planes.

This PR makes auto the default setting. It also remembers both auto and manual settings while scrolling through the image, and the intensity range limits are updated for each displayed plane. Opacity settings for borders images are also persistent among planes.