### PR TITLE
Fix persistence of more image adjustment settings: brightness, contrast, and opacity

### DIFF
--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -1122,11 +1122,15 @@ class Visualization(HasTraits):
 
     @on_trait_change("_imgadj_brightness")
     def _adjust_img_brightness(self):
-        self._adjust_displayed_imgs(brightness=self._imgadj_brightness)
+        # include contrast to restore its value while adjusting the original img
+        self._adjust_displayed_imgs(
+            brightness=self._imgadj_brightness, contrast=self._imgadj_contrast)
 
     @on_trait_change("_imgadj_contrast")
     def _adjust_img_contrast(self):
-        self._adjust_displayed_imgs(contrast=self._imgadj_contrast)
+        # include brightness to restore its value while adjusting the orig img
+        self._adjust_displayed_imgs(
+            brightness=self._imgadj_brightness, contrast=self._imgadj_contrast)
 
     @on_trait_change("_imgadj_alpha")
     def _adjust_img_alpha(self):

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -278,7 +278,8 @@ class Visualization(HasTraits):
     _labels_img_name = Str
     _labels_img_names = Instance(TraitsList)
     
-    _labels_ref_path = File  # labels ontology reference path
+    _labels_ref_path = Str  # labels ontology reference path
+    _labels_ref_btn = Button("Browse")  # button to select ref file
     _reload_btn = Button("Reload")  # button to reload images
     
     # ROI selection
@@ -494,8 +495,8 @@ class Visualization(HasTraits):
                      editor=CheckListEditor(
                          name="object._labels_img_names.selections",
                          format_func=lambda x: x)),
-                Item("_labels_ref_path", label="Reference", style="simple",
-                     editor=FileEditor(entries=10, allow_dir=False)),
+                Item("_labels_ref_path", label="Reference", style="simple"),
+                Item("_labels_ref_btn", show_label=False),
             ),
             label="Registered Images",
         ),
@@ -1796,6 +1797,16 @@ class Visualization(HasTraits):
         
         # re-setup image
         self.update_filename(self._filename, reset=False)
+    
+    @on_trait_change("_labels_ref_btn")
+    def _labels_ref_path_updated(self):
+        """Open a Pyface file dialog with path set to current image directory.
+        """
+        open_dialog = FileDialog(
+            action="open", default_path=os.path.dirname(self._filename))
+        if open_dialog.open() == OK:
+            # get user selected path
+            self._labels_ref_path = open_dialog.path
     
     @on_trait_change("_channel")
     def update_channel(self):


### PR DESCRIPTION
PR #76 fixed persistence of both auto and manual intensity settings in the image adjustment panel, but opacity, brightness, and contrast settings are still reset when scrolling through images. This PR makes these settings persistent while scrolling through a given image.

Additionally, the brightness and contrast settings have conflicted with one another, where adjusting one caused the other setting to be ignored. The brightness and contrast settings both operate on the original image, meaning that they need to know any changes to the other setting to reapply it when making any adjustments. This PR fixes the settings by applying both brightness and contrast together with any change to one value.