### PR TITLE
Provide more error feedback during image import in the GUI

### DIFF
--- a/docs/release/release_v1.5.md
+++ b/docs/release/release_v1.5.md
@@ -75,6 +75,8 @@ See the [table of CLI changes](../cli.md#changes-in-magellanmapper-v15) for a su
     - Plane index is only added when exporting multiple planes
 - Improvements to image import
     - Single plane RAW images can be loaded when importing files from a directory, in addition to multiplane RAW files
+    - Skips single plane files that give errors (eg non-image files in the input directory)
+    - Provides import error feedback in the GUI
     - The known parts of the import image shape are populated even if the full shape is not known
     - The Bio-Formats library has been updated to support more file formats (from Bio-Formats 5.1.8 to 6.6.0 via Python-Bioformats 1.1.0 to 4.0.5, respectively)
     - Fixed to disable the import directory button when metadata is insufficient

--- a/magmap/gui/import_threads.py
+++ b/magmap/gui/import_threads.py
@@ -6,6 +6,8 @@ from magmap.gui import visualizer
 from magmap.io import importer
 from magmap.settings import config
 
+_logger = config.logger.getChild(__name__)
+
 
 class SetupImportThread(QtCore.QThread):
     """Thread for setting up file import by extracting image metadata.
@@ -81,6 +83,14 @@ class ImportThread(QtCore.QThread):
                 img5d = importer.import_multiplane_images(
                     self.chl_paths, self.prefix, self.import_md, config.series,
                     fn_feedback=self.fn_feedback)
+        
+        except Exception as e:
+            # provide feedback for any errors during import
+            self.fn_feedback(f"Error during import:\n{e}")
+            if config.log_path:
+                self.fn_feedback(f"See log for more info: {config.log_path}\n")
+            _logger.exception(e)
+        
         finally:
             if img5d is not None:
                 # set up the image for immediate use within MagellanMapper

--- a/magmap/io/cli.py
+++ b/magmap/io/cli.py
@@ -413,7 +413,7 @@ def process_cli_args():
             log_path = os.path.join(
                 config.user_app_dirs.user_data_dir, "out.log")
         # log to file
-        logs.add_file_handler(config.logger, log_path)
+        config.log_path = logs.add_file_handler(config.logger, log_path)
     
     # redirect standard out/error to logging
     sys.stdout = logs.LogWriter(config.logger.info)

--- a/magmap/settings/config.py
+++ b/magmap/settings/config.py
@@ -65,6 +65,9 @@ verbose = False
 #: :class:`logging.Logger`: Root logger for the application.
 logger = logs.setup_logger()
 
+#: Path to log file.
+log_path: Optional[pathlib.Path] = None
+
 
 # IMAGE FILES
 

--- a/magmap/settings/logs.py
+++ b/magmap/settings/logs.py
@@ -98,7 +98,8 @@ def update_log_level(logger, level):
     return logger
 
 
-def add_file_handler(logger, path, backups=5):
+def add_file_handler(
+        logger: logging.Logger, path: str, backups: int = 5) -> pathlib.Path:
     """Add a rotating log file handler with a new log file.
     
     Rotates the file each time this function is called for the given number
@@ -107,17 +108,18 @@ def add_file_handler(logger, path, backups=5):
     creating a log filed named with an incremented number (eg ``out1.log``).
     
     Args:
-        logger (:class:`logging.Logger`): Logger to update.
-        path (str): Path to log. Increments to ``path<n>.<ext>`` if the
+        logger: Logger to update.
+        path: Path to log. Increments to ``path<n>.<ext>`` if the
             file at ``path`` cannot be rotated.
-        backups (int): Number of backups to maintain; defaults to 5.
+        backups: Number of backups to maintain; defaults to 5.
 
     Returns:
-        :class:`logging.Logger`: The logger for chained calls.
+        The log output path.
 
     """
     # check if log file already exists
     pathl = pathlib.Path(path)
+    path_log = pathl
     roll = pathl.is_file()
     
     # create a rotations file handler to manage number of backups while
@@ -129,8 +131,8 @@ def add_file_handler(logger, path, backups=5):
         try:
             # if the existing file at path cannot be rotated, increment the
             # filename to create a new series of rotating log files
-            path_log = (pathl if i == 0 else
-                        f"{pathl.parent / pathl.stem}{i}{pathl.suffix}")
+            path_log = pathl if i == 0 else pathlib.Path(
+                f"{pathl.parent / pathl.stem}{i}{pathl.suffix}")
             logger.debug(f"Trying logger path: {path_log}")
             handler_file = handlers.RotatingFileHandler(
                 path_log, backupCount=backups)
@@ -150,4 +152,4 @@ def add_file_handler(logger, path, backups=5):
         "%(asctime)s - %(name)s - %(levelname)s - %(message)s"))
     logger.addHandler(handler_file)
     
-    return logger
+    return path_log


### PR DESCRIPTION
Errors that occur during image import have shown only limited feedback in the GUI, requiring the user to view the console or the log file to see more detailed error messages (see #82). For those using the installer version, the log file is not intuitive to locate. This PR provides more feedback in the GUI by reporting any error messages in the import feedback text area along with the path to the log file for more detailed info such as the stack trace.

A common source of import errors is importing a directory that may contain other, non-image files. This PR now simply skips individual file planes that give an error. To report the log path after errors that stop the import, the path is now stored in `config` after setting up the log path with any file rotation.