### PR TITLE
Edit loaded profiles in the profiles table

### DIFF
--- a/docs/release/release_v1.5.md
+++ b/docs/release/release_v1.5.md
@@ -1,5 +1,46 @@
 # MagellanMapper v1.5 Release Notes
 
+## MagellanMapper v1.5.1
+
+### Highlights
+
+### Changes
+
+#### Installation
+
+#### GUI
+
+- Drag and remove loaded profiles in the Profiles tab table
+
+#### CLI
+
+#### Atlas refinement
+
+#### Atlas registration
+
+#### Cell detection
+
+#### Volumetric image processing
+
+#### I/O
+
+#### Server pipelines
+
+#### Python stats and plots
+
+#### R stats and plots
+
+#### Code base and docs
+
+### Dependency Updates
+
+#### Python Dependency Changes
+
+#### R Dependency Changes
+
+#### Server dependency Changes
+
+
 ## MagellanMapper v1.5.0
 
 ### Highlights

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -347,8 +347,16 @@ class Visualization(HasTraits):
         adapter=ProfilesArrayAdapter(), editable=True, auto_resize_rows=True,
         stretch_last_section=False, drag_move=True)
     _profiles = List  # profiles table list
-    _profiles_add_btn = Button("Add")
-    _profiles_load_btn = Button("Rescan")
+    _profiles_add_btn = Button(
+        "Add",
+        tooltip="Click to add the selected profile for the checked channels.\n"
+                "Press Backspace/Delete key to remove the selected table row.\n"
+                "Drag rows to rearrange the order of loaded profiles."
+    )
+    _profiles_load_btn = Button(
+        "Rescan",
+        tooltip="Rescan the 'profiles' folder for YAML files"
+    )
     _profiles_preview = Str  # preview the selected profile
     _profiles_combined = Str  # combined profiles for selected category
     _profiles_ver = Str

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -345,7 +345,7 @@ class Visualization(HasTraits):
     )
     _profiles_table = TabularEditor(
         adapter=ProfilesArrayAdapter(), editable=True, auto_resize_rows=True,
-        stretch_last_section=False)
+        stretch_last_section=False, drag_move=True)
     _profiles = List  # profiles table list
     _profiles_add_btn = Button("Add")
     _profiles_load_btn = Button("Rescan")


### PR DESCRIPTION
The Profiles tab contains a table showing the currently loaded tables. Although profile entries can be removed by pressing Backspace/Delete on the selected row, the loaded profiles are not updated.

This PR adds a handler so that removing rows triggers updating all loaded profiles. The table is also now configured to allow dragging rows to rearrange the order of entries. These moves likewise trigger reloading the profiles automatically.