### PR TITLE
Option to specify the plane range or ROI when exporting raw planes

### DIFF
--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -26,6 +26,8 @@
 
 #### I/O
 
+- The `--proc export_planes` task can export a subset of image planes specified by `--slice`, or an ROI specified by `--offset` and `--size`
+
 #### Server pipelines
 
 #### Python stats and plots

--- a/magmap/io/export_stack.py
+++ b/magmap/io/export_stack.py
@@ -656,9 +656,10 @@ def export_planes(
     each channels into separate files, without processing through Matplotlib.
     Supports image rotation set in :attr:`magmap.settings.config.transform`.
     
-    By default, all z-planes are exported. The planar orientation can be
-    configured through :attr:`config.plane`, and the plane indices through
-    :attr:`config.slice_vals`.
+    By default, all z-planes are exported, with plane indices specified through
+    :attr:`config.slice_vals`. Alternatively, regions of interest can be
+    specified by :attr:`config.roi_offset` and :attr:`config.roi_size`.
+    The planar orientation can be configured through :attr:`config.plane`.
 
     Args:
         image5d: Image in ``t,z,y,x[,c]`` format.
@@ -681,11 +682,13 @@ def export_planes(
     multichannel, channels = plot_3d.setup_channels(roi, channel, 3)
     rotate = config.transform[config.Transforms.ROTATE]
     roi = cv_nd.rotate90(roi, rotate, multichannel=multichannel)
-    stacker = setup_stack(roi[np.newaxis, :], slice_vals=config.slice_vals)
+    stacker = setup_stack(
+        roi[np.newaxis, :], offset=config.roi_offset, roi_size=config.roi_size,
+        slice_vals=config.slice_vals,
+        rescale=config.transform[config.Transforms.RESCALE])
     roi = stacker.images[0]
     
     num_planes = len(roi)
-    num_digits = len(str(num_planes))
     img_sl = stacker.img_slice
     for i, plane in enumerate(roi):
         # add plane to output path


### PR DESCRIPTION
The `--proc export_planes` task exports raw, unfiltered image planes, in contrast to `--proc extract`, which exports planes that have been overlaid and processed through Matplotlib. The export planes task has thus far been limited to exported individual planes for an entire volumetric image.

This PR adds the ability to specify the range of planes to export or an ROI to export as planes within it. The plane range can be specified using the `--slice start,stop,step` command-line argument, and the ROI through the `--offset x,y,z --size x,y,z` syntax. These options mimic the range and ROI settings used for extracting processed planes and uses the same underlying machinery.

We at some point may need to change the task names to distinguish them better!