### PR TITLE
Option to alpha blend overlaid images to highlight overlap and alignment

### DIFF
--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -10,6 +10,7 @@
 
 #### GUI
 
+- "Blend" option in the image adjustment panel to visualize alignment in overlaid images
 - Drag and remove loaded profiles in the Profiles tab table
 
 #### CLI

--- a/magmap/gui/plot_editor.py
+++ b/magmap/gui/plot_editor.py
@@ -24,8 +24,11 @@ if TYPE_CHECKING:
 
 
 class PlotAxImg:
-    """Axes image storage class to contain additional information for
-    display such as brightness and contrast.
+    """Axes image storage class.
+    
+    Tracks settings that may differ between the currently displayed image and
+    input values, such as ``None`` to specify auto-intensity and values for
+    brightness and contrast that are not stored in the image itself.
 
     Attributes:
         ax_img: Displayed Matplotlib image.
@@ -35,6 +38,7 @@ class PlotAxImg:
             ``ax_img.norm.vmax`` for the output vmax.
         brightness: Brightness addend; defaults to 0.0.
         contrast: Contrast factor; defaults to 1.0.
+        alpha: Opacity level; defaults to None.
         img: The original underlying image data,
             copied to allow adjusting the array in ``ax_img`` while
             retaining the original data.
@@ -43,12 +47,18 @@ class PlotAxImg:
     def __init__(
             self, ax_img: "image.AxesImage", vmin: Optional[float] = None,
             vmax: Optional[float] = None):
+        
+        # set from arguments
         self.ax_img = ax_img
         self.vmin = vmin
         self.vmax = vmax
         
+        # additional image attributes
         self.brightness: float = 0.0
         self.contrast: float = 1.0
+        self.alpha: Optional[float] = None
+        
+        # original underlying image data
         self.img: np.ndarray = np.copy(self.ax_img.get_array())
 
 
@@ -397,7 +407,7 @@ class PlotEditor:
                         for p in self._plot_ax_imgs[0]]
             
             # use opacity, brightness, anc contrast from prior images
-            alphas[0] = [p.ax_img.get_alpha() for p in self._plot_ax_imgs[0]]
+            alphas[0] = [p.alpha for p in self._plot_ax_imgs[0]]
             brightnesses[0] = [p.brightness for p in self._plot_ax_imgs[0]]
             contrasts[0] = [p.contrast for p in self._plot_ax_imgs[0]]
         
@@ -428,7 +438,7 @@ class PlotEditor:
                 
                 # get alpha for last corresponding borders plane if available
                 ax_img = libmag.get_if_within(self._plot_ax_imgs, 2 + i, None)
-                alpha = (ax_img[i].ax_img.get_alpha() if ax_img else
+                alpha = (ax_img[i].alpha if ax_img else
                          libmag.get_if_within(config.alphas, 2 + i, 1))
                 alphas.append(alpha)
                 

--- a/magmap/gui/plot_editor.py
+++ b/magmap/gui/plot_editor.py
@@ -7,7 +7,7 @@ view of orthogonal planes.
 """
 
 import textwrap
-from typing import Optional, TYPE_CHECKING
+from typing import List, Optional, TYPE_CHECKING
 
 from matplotlib import patches
 import numpy as np
@@ -39,6 +39,8 @@ class PlotAxImg:
         brightness: Brightness addend; defaults to 0.0.
         contrast: Contrast factor; defaults to 1.0.
         alpha: Opacity level; defaults to None.
+        alpha_blend: Opacity level of the first level in the area of blending
+            between two images; defaults to None.
         img: The original underlying image data,
             copied to allow adjusting the array in ``ax_img`` while
             retaining the original data.
@@ -57,6 +59,7 @@ class PlotAxImg:
         self.brightness: float = 0.0
         self.contrast: float = 1.0
         self.alpha: Optional[float] = None
+        self.alpha_blend: Optional[float] = None
         
         # original underlying image data
         self.img: np.ndarray = np.copy(self.ax_img.get_array())
@@ -393,6 +396,7 @@ class PlotEditor:
         self._channels = [config.channel]
         cmaps = [config.cmaps]
         alphas = [config.alphas[0]]
+        alpha_blends = [None]
         shapes = [self._img3d_shapes[0][1:3]]
         vmaxs = [None]
         vmins = [None]
@@ -408,6 +412,7 @@ class PlotEditor:
             
             # use opacity, brightness, anc contrast from prior images
             alphas[0] = [p.alpha for p in self._plot_ax_imgs[0]]
+            alpha_blends[0] = [p.alpha_blend for p in self._plot_ax_imgs[0]]
             brightnesses[0] = [p.brightness for p in self._plot_ax_imgs[0]]
             contrasts[0] = [p.contrast for p in self._plot_ax_imgs[0]]
         
@@ -419,6 +424,7 @@ class PlotEditor:
             alphas.append(
                 self._ax_img_labels.get_alpha() if self._ax_img_labels
                 else self.alpha)
+            alpha_blends.append(None)
             shapes.append(self._img3d_shapes[1][1:3])
             vmaxs.append(None)
             vmins.append(None)
@@ -441,6 +447,7 @@ class PlotEditor:
                 alpha = (ax_img[i].alpha if ax_img else
                          libmag.get_if_within(config.alphas, 2 + i, 1))
                 alphas.append(alpha)
+                alpha_blends.append(None)
                 
                 shapes.append(self._img3d_shapes[2][1:3])
                 vmaxs.append(None)
@@ -464,7 +471,8 @@ class PlotEditor:
         # reasons
         ax_imgs = plot_support.overlay_images(
             self.axes, self.aspect, self.origin, imgs2d, self._channels, cmaps,
-            alphas, vmins, vmaxs, check_single=(self._ax_img_labels is None))
+            alphas, vmins, vmaxs, check_single=(self._ax_img_labels is None),
+            alpha_blends=alpha_blends)
         if colorbar:
             self.axes.figure.colorbar(ax_imgs[0][0], ax=self.axes)
         self.axes.format_coord = pixel_display.PixelDisplay(
@@ -497,6 +505,9 @@ class PlotEditor:
                     self.change_brightness_contrast(
                         plot_ax_img, libmag.get_if_within(brightnesses[i], j),
                         libmag.get_if_within(contrasts[i], j))
+                plot_ax_img.alpha = libmag.get_if_within(alphas[i], j)
+                plot_ax_img.alpha_blend = libmag.get_if_within(
+                    alpha_blends[i], j)
                 plot_ax_imgs.append(plot_ax_img)
             self._plot_ax_imgs.append(plot_ax_imgs)
         
@@ -694,22 +705,26 @@ class PlotEditor:
             plot_ax_img.contrast = contrast
 
     @staticmethod
-    def update_plot_ax_img_display(plot_ax_img, minimum=np.nan, maximum=np.nan,
-                                   brightness=None, contrast=None, alpha=None):
+    def update_plot_ax_img_display(
+            plot_ax_img: PlotAxImg, minimum: float = np.nan,
+            maximum: float = np.nan, brightness: Optional[float] = None,
+            contrast: Optional[float] = None, alpha: Optional[float] = None,
+            **kwargs) -> Optional[PlotAxImg]:
         """Update plotted image display settings.
 
         Args:
-            plot_ax_img (:obj:`PlotAxImg`): Plotted image.
-            minimum (float): Vmin; can be None for auto setting; defaults
+            plot_ax_img: Plotted image.
+            minimum: Vmin; can be None for auto setting; defaults
                 to ``np.nan`` to ignore.
-            maximum (float): Vmax; can be None for auto setting; defaults
+            maximum: Vmax; can be None for auto setting; defaults
                 to ``np.nan`` to ignore.
-            brightness (float): Brightness addend; defaults to None.
-            contrast (float): Contrast multiplier; defaults to None.
-            alpha (float): Opacity value; defalts to None.
+            brightness: Brightness addend; defaults to None.
+            contrast: Contrast multiplier; defaults to None.
+            alpha: Opacity value; defalts to None.
+            **kwargs: Extra arguments, currently ignored.
         
         Returns:
-            :obj:`PlotAxImg`: The updated axes image plot.
+            The updated axes image plot.
 
         """
         if not plot_ax_img:
@@ -755,29 +770,77 @@ class PlotEditor:
             plot_ax_img.ax_img.set_alpha(alpha)
         return plot_ax_img
 
-    def update_img_display(self, imgi, chl=None, minimum=np.nan,
-                           maximum=np.nan, brightness=None, contrast=None,
-                           alpha=None):
+    def update_alpha_blend(
+            self, imgi: int, alpha_blend: float) -> List[PlotAxImg]:
+        """Update alpha blending between two images.
+
+        Args:
+            imgi: Index of image group. The first two images in this group
+                will be blended.
+            alpha_blend: Alpha opacity level for the blending.
+
+        Returns:
+            List of the updated axes image storage instances.
+
+        """
+        # get the first two channels in the image group
+        plot_ax_imgs = [self.get_displayed_img(imgi, c) for c in (0, 1)]
+        if None in plot_ax_imgs:
+            return plot_ax_imgs
+        
+        # blend the images
+        alpha1, alpha2 = plot_support.alpha_blend_intersection(
+            plot_ax_imgs[0].img, plot_ax_imgs[1].img, alpha_blend)
+        plot_ax_imgs[0].ax_img.set_alpha(alpha1)
+        plot_ax_imgs[1].ax_img.set_alpha(alpha2)
+        
+        # store the alpha blend level while retaining the original stored alpha
+        for p in plot_ax_imgs: p.alpha_blend = alpha_blend
+        return plot_ax_imgs
+
+    def update_img_display(
+            self, imgi: int, chl: Optional[int] = None, minimum: float = np.nan,
+            maximum: float = np.nan, brightness: Optional[float] = None,
+            contrast: Optional[float] = None, alpha: Optional[float] = None,
+            alpha_blend: Optional[float] = None) -> PlotAxImg:
         """Update dislayed image settings.
 
         Args:
-            imgi (int): Index of image.
-            chl (int): Index of channel; defaults to None.
-            minimum (float): Vmin; can be None for auto setting; defaults
+            imgi: Index of image group.
+            chl: Index of channel within the group; defaults to None.
+            minimum: Vmin; can be None for auto setting; defaults
                 to ``np.nan`` to ignore.
-            maximum (float): Vmax; can be None for auto setting; defaults
+            maximum: Vmax; can be None for auto setting; defaults
                 to ``np.nan`` to ignore.
-            brightness (float): Brightness addend; defaults to None.
-            contrast (float): Contrast multiplier; defaults to None.
-            alpha (float): Opacity value; defalts to None.
+            brightness: Brightness addend; defaults to None.
+            contrast: Contrast multiplier; defaults to None.
+            alpha: Opacity value; defaults to None.
+            alpha_blend: Opacity blending value; defaults to None. False
+                turns off alpha blending, resetting the images to their
+                stored alpha values.
         
         Returns:
-            :obj:`PlotAxImg`: The updated axes image plot.
+            The updated axes image plot.
 
         """
-        plot_ax_img = self.get_displayed_img(imgi, chl)
-        plot_ax_img = self.update_plot_ax_img_display(
-            plot_ax_img, minimum, maximum, brightness, contrast, alpha)
+        if alpha_blend is False:
+            # turn off alpha blending, assumed to be applied to first 2
+            # images, and reset them to stored alpha values
+            for c in (0, 1):
+                plot_ax_img = self.get_displayed_img(imgi, c)
+                if plot_ax_img is not None:
+                    plot_ax_img.alpha_blend = None
+                    plot_ax_img = self.update_img_display(
+                        imgi, c, minimum, maximum, brightness, contrast,
+                        plot_ax_img.alpha)
+        elif alpha_blend:
+            # alpha blend the images
+            plot_ax_img = self.update_alpha_blend(imgi, alpha_blend)[0]
+        else:
+            # update the selected image
+            plot_ax_img = self.get_displayed_img(imgi, chl)
+            plot_ax_img = self.update_plot_ax_img_display(
+                plot_ax_img, minimum, maximum, brightness, contrast, alpha)
         self.axes.figure.canvas.draw_idle()
         return plot_ax_img
     

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -382,6 +382,11 @@ class Visualization(HasTraits):
     _imgadj_brightness_high = Float
     _imgadj_contrast = Float
     _imgadj_alpha = Float
+    _imgadj_alpha_blend = Float(0.5)
+    _imgadj_alpha_blend_check = Bool(
+        tooltip="Blend the overlapping parts of imags to shown alignment.\n"
+                "Applied to the first two channels of the main image."
+    )
 
     # Image import panel
 
@@ -704,14 +709,28 @@ class Visualization(HasTraits):
                      mode="slider", format="%.4g")),
             Item("_imgadj_max_auto", label="Auto", editor=BooleanEditor()),
         ),
-        Item("_imgadj_brightness", label="Brightness", editor=RangeEditor(
-                 low_name="_imgadj_brightness_low",
-                 high_name="_imgadj_brightness_high", mode="slider",
-                 format="%.4g")),
-        Item("_imgadj_contrast", label="Contrast", editor=RangeEditor(
-                 low=0.0, high=2.0, mode="slider", format="%.3g")),
-        Item("_imgadj_alpha", label="Opacity", editor=RangeEditor(
+        HGroup(
+            Item("_imgadj_brightness", label="Brightness", editor=RangeEditor(
+                     low_name="_imgadj_brightness_low",
+                     high_name="_imgadj_brightness_high", mode="slider",
+                     format="%.4g"))
+        ),
+        HGroup(
+            Item("_imgadj_contrast", label="Contrast", editor=RangeEditor(
+                     low=0.0, high=2.0, mode="slider", format="%.3g")),
+        ),
+        HGroup(
+            Item("_imgadj_alpha", label="Opacity", editor=RangeEditor(
                  low=0.0, high=1.0, mode="slider", format="%.3g")),
+        ),
+        
+        HGroup(
+            # alpha blending controls
+            Item("_imgadj_alpha_blend_check", label="Blend"),
+            Item("_imgadj_alpha_blend", show_label=False, editor=RangeEditor(
+                 low=0.0, high=1.0, mode="slider", format="%.3g"),
+                 enabled_when="_imgadj_alpha_blend_check"),
+        ),
         label="Adjust Image",
     )
     
@@ -1147,6 +1166,21 @@ class Visualization(HasTraits):
     @on_trait_change("_imgadj_alpha")
     def _adjust_img_alpha(self):
         self._adjust_displayed_imgs(alpha=self._imgadj_alpha)
+
+    @on_trait_change("_imgadj_alpha_blend")
+    def _adjust_img_alpha_blend(self):
+        """Adjust the alpha blending."""
+        self._adjust_displayed_imgs(alpha_blend=self._imgadj_alpha_blend)
+
+    @on_trait_change("_imgadj_alpha_blend_check")
+    def _adjust_img_alpha_blend_check(self):
+        """Toggle alpha bledning."""
+        if self._imgadj_alpha_blend_check:
+            # turn on alpha blending
+            self._adjust_img_alpha_blend()
+        else:
+            # turn off alpha blending and reset alpha values
+            self._adjust_displayed_imgs(alpha_blend=False)
 
     def _adjust_displayed_imgs(self, **kwargs):
         """Adjust image display settings for the currently selected viewer.

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -1027,7 +1027,7 @@ class Visualization(HasTraits):
         # populate controls with intensity settings
         self._imgadj_brightness = plot_ax_img.brightness
         self._imgadj_contrast = plot_ax_img.contrast
-        self._imgadj_alpha = plot_ax_img.ax_img.get_alpha()
+        self._imgadj_alpha = plot_ax_img.alpha
 
         # populate intensity limits, auto-scaling, and current val (if not auto)
         self._adapt_imgadj_limits(plot_ax_img)


### PR DESCRIPTION
Currently, image alignment can be assessed by adjusting the opacity of each image. This reduction in opacity allows the underlying image to be seen but also reduces the visibility of the overlying image, and the two images can be difficult to distinguish even when using different colors. Inspired by [here](https://github.com/InsightSoftwareConsortium/SimpleITK-Notebooks/blob/master/Python/05_Results_Visualization.ipynb), this PR adds an alpha blending model where only the overlapping parts of each image are blending, while the non-overlapping parts are left at full opacity. The non-transparent, non-overlapping parts thus provide high contrast between the overlying and underlying image as well as to the translucent, overlapping parts.

To identify the overlapping regions, this model relies on basic segmentation of the image into foreground and background. The overlapping foreground regions are blended, while the non-overlapping regions consist of foreground from either but not both images or background from both. The background is fully transparent to avoid blocking the underlying image. For segmentation, the model defaults to Otsu's method, but a predefined segmentation mask can also be given.

To expose this blending, the image adjustment panel in the GUI now contains an additional row with a check box to toggle the feature. Turning it on initializes blending for the displayed image with 50-50% blending of each image. A slide allows adjusting the weighting of opacity between the two images (eg 90-10%). Currently, the blending only operates on the first two channels of the main image. The alpha blending is also available in the API but not exposed yet in the CLI.