### PR TITLE
Read TIF files directly with lazy loading through Tifffile

### DIFF
--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -26,6 +26,7 @@
 
 #### I/O
 
+- Some TIF files can be loaded directly, without importing the file first (#90)
 - The `--proc export_planes` task can export a subset of image planes specified by `--slice`, or an ROI specified by `--offset` and `--size`
 
 #### Server pipelines

--- a/environment.yml
+++ b/environment.yml
@@ -21,6 +21,8 @@ dependencies:
   - importlib_resources  # required for pyface
   - traitsui
   - appdirs
+  - tifffile
+  - zarr
   - pip:
     - --extra-index-url https://pypi.fury.io/dd8/
     - matplotlib-scalebar

--- a/environment.yml
+++ b/environment.yml
@@ -22,7 +22,6 @@ dependencies:
   - traitsui
   - appdirs
   - tifffile
-  - zarr
   - pip:
     - --extra-index-url https://pypi.fury.io/dd8/
     - matplotlib-scalebar

--- a/envs/environment_light.yml
+++ b/envs/environment_light.yml
@@ -10,6 +10,8 @@ dependencies:
   - scikit-image
   - scikit-learn
   - appdirs
+  - tifffile
+  - zarr
   - pip:
     - --extra-index-url https://pypi.fury.io/dd8/
     - simpleitk==2.0.2rc2.dev785+g8ac4f

--- a/envs/environment_light.yml
+++ b/envs/environment_light.yml
@@ -11,7 +11,6 @@ dependencies:
   - scikit-learn
   - appdirs
   - tifffile
-  - zarr
   - pip:
     - --extra-index-url https://pypi.fury.io/dd8/
     - simpleitk==2.0.2rc2.dev785+g8ac4f

--- a/magmap/io/cli.py
+++ b/magmap/io/cli.py
@@ -1200,7 +1200,7 @@ def process_file(
 
     elif proc_type is config.ProcessTypes.EXPORT_TIF:
         # export the main image as a TIF files for each channel
-        np_io.write_tif_file(config.image5d, config.filename)
+        np_io.write_tif(config.image5d, config.filename)
 
     elif proc_type is config.ProcessTypes.PREPROCESS:
         # pre-process a whole image and save to file

--- a/magmap/io/importer.py
+++ b/magmap/io/importer.py
@@ -139,6 +139,9 @@ def parse_ome(filename):
         names: array of names of seriess within the file.
         sizes: array of tuples with dimensions for each series. Dimensions
             will be given as (time, z, y, x, channels).
+    
+    Deprecated: 1.6.0
+        Use :meth:`parse_ome_raw` instead.
     """
     time_start = time()
     metadata = bf.get_omexml_metadata(filename)

--- a/magmap/io/np_io.py
+++ b/magmap/io/np_io.py
@@ -503,7 +503,7 @@ def write_raw_file(arr, path):
     print("Finished writing", path)
 
 
-def write_tif_file(
+def write_tif(
         image5d: np.ndarray, path: Union[str, pathlib.Path], **kwargs: Any):
     """Write a NumPy array to TIF files.
     

--- a/magmap/io/np_io.py
+++ b/magmap/io/np_io.py
@@ -8,7 +8,6 @@ from typing import Any, Dict, Optional, Sequence, Tuple, Union
 
 import numpy as np
 import tifffile
-import zarr
 
 from magmap.atlas import labels_meta, ontology, transformer
 from magmap.cv import detector

--- a/magmap/io/np_io.py
+++ b/magmap/io/np_io.py
@@ -290,7 +290,8 @@ def setup_images(path, series=None, offset=None, size=None,
         # load or import the main image stack
         print("Loading main image")
         try:
-            if path.endswith(sitk_io.EXTS_3D):
+            path_lower = path.lower()
+            if path_lower.endswith(sitk_io.EXTS_3D):
                 # attempt to format supported by SimpleITK and prepend time axis
                 config.image5d = sitk_io.read_sitk_files(path)[None]
                 config.img5d.img = config.image5d

--- a/magmap/io/np_io.py
+++ b/magmap/io/np_io.py
@@ -532,9 +532,8 @@ def read_tif(
     axes = tif.series[0].axes
     if tif.ome_metadata:
         # read OME-XML metadata
-        names, sizes, res, magnification, zoom, pixel_type = \
-            importer.parse_ome_raw(tif.ome_metadata)
-        res = np.array(res)
+        names, sizes, md = importer.parse_ome_raw(tif.ome_metadata)
+        res = np.array(md[config.MetaKeys.RESOLUTIONS])
         print(tif.ome_metadata)
     else:
         # parse resolutions

--- a/magmap/io/np_io.py
+++ b/magmap/io/np_io.py
@@ -298,6 +298,10 @@ def setup_images(path, series=None, offset=None, size=None,
                 config.img5d.img = config.image5d
                 config.img5d.path_img = path
                 config.img5d.img_io = config.LoadIO.SITK
+            elif path_lower.endswith((".tif", ".tiff")):
+                # load TIF file directly
+                _, config.resolutions = read_tif(path, config.img5d)
+                config.image5d = config.img5d.img
             else:
                 # load or import from MagellanMapper Numpy format
                 import_only = proc_type is config.ProcessTypes.IMPORT_ONLY

--- a/magmap/settings/config.py
+++ b/magmap/settings/config.py
@@ -127,6 +127,7 @@ class LoadIO(Enum):
     """Enumerations for I/O load packages."""
     NP = auto()
     SITK = auto()
+    TIFFFILE = auto()
 
 
 #: :obj:`LoadIO`: I/O source for image5d array.

--- a/magmap/settings/config.py
+++ b/magmap/settings/config.py
@@ -185,16 +185,20 @@ cmap_labels = None
 
 # MICROSCOPY
 
-# metadata keys for command-line parsing
-MetaKeys = Enum(
-    "MetaKeys", (
-        "RESOLUTIONS",  # image resolutions in x,y,z
-        "MAGNIFICATION",  # objective magnification
-        "ZOOM",  # objective zoom
-        "SHAPE",  # output image shape
-        "DTYPE",  # data type as a string
-    )
-)
+class MetaKeys(Enum):
+    """Metadata keys for command-line parsing."""
+    #: Image resolutions in XYZ.
+    RESOLUTIONS = auto()
+    #: Objective magnification.
+    MAGNIFICATION = auto()
+    #: Objective zoom.
+    ZOOM = auto()
+    #: Image shape.
+    SHAPE = auto()
+    #: Data type as a string.
+    DTYPE = auto()
+
+
 #: Dictionary of metadata for image import.
 meta_dict: Dict[MetaKeys, Any] = dict.fromkeys(MetaKeys, None)
 

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,6 @@ config = {
         # part of stdlib in Python >= 3.8
         "importlib-metadata >= 1.0 ; python_version < '3.8'",
         "tifffile",
-        "zarr",
     ], 
     "extras_require": {
         "import": _EXTRAS_IMPORT, 

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ config = {
         # part of stdlib in Python >= 3.8
         "importlib-metadata >= 1.0 ; python_version < '3.8'",
         "tifffile",
+        "zarr",
     ], 
     "extras_require": {
         "import": _EXTRAS_IMPORT, 

--- a/stitch/mesospim_to_tif.py
+++ b/stitch/mesospim_to_tif.py
@@ -73,7 +73,7 @@ def main():
         # export imported file to TIF file
         print(f"Exporting file from '{path}' to '{filename_out}'")
         config.prefix = prefix_orig
-        np_io.write_tif_file(
+        np_io.write_tif(
             config.image5d,
             pathlib.Path(path).parent / filename_out, imagej=True)
 


### PR DESCRIPTION
We have required importing image files to convert them to NumPy format, which allows lazy loading large files through memory mapping. This loading allows large files to be loaded with limited RAM, but it also requires the extra time and file space for the file import. The main goals of this PR are to provide a mechanism to lazy load common image files (ie TIFs) while requiring neither prior import nor a major overhaul of image arrays.

As a way to bypass this import requirement for at least some image files, this PR uses the Tifffile library to memory map certain TIF images, loading them similarly to NumPy archives but without this import step. This loading supports TIFs that Tifffile can memory map, which are those with [contiguous arrays](https://forum.image.sc/t/dealing-with-bigtiff-files-open-edit-save-etc/23385/6). I have tested ImageJ hyperstacks exported through the standard ImageJ TIFF writer and BigTIFF and OME-TIFFs exported from Tifffile itself. Testing on OME-TIFFs exported from Bio-Formats in ImageJ do not appear to allow memory mapping, however.