### PR TITLE
Buttons to open help documentation in external browser

### DIFF
--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -12,6 +12,7 @@
 
 - "Blend" option in the image adjustment panel to visualize alignment in overlaid images
 - Drag and remove loaded profiles in the Profiles tab table
+- "Help" buttons added to open the online documentation (#109)
 
 #### CLI
 
@@ -23,8 +24,8 @@
 
 #### Cell detection
 
-- Auto-scrolls to the selected annotation
-- `ctrl+[n]+click` to add a channel now sets the channel directly to `n` rather than to the `n`th seleted channel
+- Auto-scrolls to the selected annotation (#109)
+- `ctrl+[n]+click` to add a channel now sets the channel directly to `n` rather than to the `n`th seleted channel (#109)
 - Fixed blob segmentation for newer versions of Scikit-image (#91)
 
 #### Volumetric image processing
@@ -38,6 +39,8 @@
 #### Server pipelines
 
 #### Python stats and plots
+
+- Fixed alignment of headers and columns in data frames printed to console (#109)
 
 #### R stats and plots
 

--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -23,6 +23,8 @@
 
 #### Cell detection
 
+- Auto-scrolls to the selected annotation
+- `ctrl+[n]+click` to add a channel now sets the channel directly to `n` rather than to the `n`th seleted channel
 - Fixed blob segmentation for newer versions of Scikit-image (#91)
 
 #### Volumetric image processing

--- a/docs/viewers.md
+++ b/docs/viewers.md
@@ -19,14 +19,14 @@ The multi-level 2D plotter is geared toward simplifying annotation for nuclei or
 
 | To Do...        | Shortcut            |
 | ---------------- | :------------------: |
-| Add a circle | `Ctrl+click` at the desired location |
+| Add a circle | `Ctrl+click` at the desired location <p>`Ctrl+1+click` to set channel 1 (replace with desired channel) |
 | Move the circle's position | `shift+click` and drag (note that the original position will remain as a solid circle) |
 | Resize the circle's radius | `Alt+click` (`option+click` on Mac) and drag |
 | Copy the circle | `"c"+click` |
 | Duplicate a circle to the same position in another z-plane | `"v"+click` on the corresponding position in the z-plane to which the circle will be duplicated |
 | Cut the circle | `"x"+click` |
 | Delete the circle | `"d"+click` |
-| Cycle between the 3 nuclei detection flags | Click within the dotted circles; incorrect (red), correct (green), or questionable (yellow) |
+| Cycle between the 3 nuclei detection flags | `click` within the dotted circles. Red = incorrect, green = correct, and yellow = questionable. <p>`"r"+click` to cycle in reverse order. |
 
 
 ## Atlas Editor

--- a/docs/viewers.md
+++ b/docs/viewers.md
@@ -6,19 +6,27 @@ The tabbed pane on the right of the graphical interface provides several  image 
 
 The multi-level 2D plotter is geared toward simplifying annotation for nuclei or other objects. Select the `ROI Editor` tab to view the editor. Press the `Redraw` button to redraw the editor at the selected ROI. To detect and display nuclei in the ROI, select the `Detect` tab and press the `Detect` button.
 
+### Navigation
+
 | To Do...        | Shortcut            |
 | ---------------- | :------------------: |
-| Cycle between the 3 nuclei detection flags | Click within the dotted circles; incorrect (red), correct (green), or questionable (yellow) |
-| Move the circle's position | `shift+click` and drag (note that the original position will remain as a solid circle) |
-| Resize the circle's radius | `Alt+click` (`option+click` on Mac) and drag |
-| Copy the circle | `"c"+click` |
-| Duplicate a circle to the same position in anothe z-plane | `"v"+click` on the corresponding position in the z-plane to which the circle will be duplicated |
-| Cut the circle | `"x"+click` |
-| Delete the circle | `"d"+click` |
 | Increase/decrease the overview plots' z-plane | Arrow `up/right` to increase and `down/left` to decrease |
 | Jump to a z-plane in the overview plots corresponding to an ROI plane | `Right-click` on the the corresponding ROI plane |
 | Preview the ROI at a certain position | `Left-click` in the overview plot |
 | Redraw the editor at the chosen ROI settings | Double `right-click` in any overview plot |
+
+### Annotations
+
+| To Do...        | Shortcut            |
+| ---------------- | :------------------: |
+| Add a circle | `Ctrl+click` at the desired location |
+| Move the circle's position | `shift+click` and drag (note that the original position will remain as a solid circle) |
+| Resize the circle's radius | `Alt+click` (`option+click` on Mac) and drag |
+| Copy the circle | `"c"+click` |
+| Duplicate a circle to the same position in another z-plane | `"v"+click` on the corresponding position in the z-plane to which the circle will be duplicated |
+| Cut the circle | `"x"+click` |
+| Delete the circle | `"d"+click` |
+| Cycle between the 3 nuclei detection flags | Click within the dotted circles; incorrect (red), correct (green), or questionable (yellow) |
 
 
 ## Atlas Editor

--- a/magmap/gui/roi_editor.py
+++ b/magmap/gui/roi_editor.py
@@ -743,24 +743,26 @@ class ROIEditor(plot_support.ImageSyncMixin):
                 # for some reason becomes none if previous event was
                 # ctrl combo and this event is control
                 pass
+            
             elif event.key == "control" or event.key.startswith("ctrl"):
+                # add a circle
                 blob_channel = None
                 if channel:
+                    # default to using the first selected channel
                     blob_channel = channel[0]
-                    num_chls = len(channel)
-                    if num_chls > 1:
-                        chl_matches = re.search(regex_key_chl, event.key)
-                        if chl_matches:
-                            # ctrl+n to specify the n-th channel
-                            chl = int(chl_matches[0])
-                            if chl < num_chls:
-                                blob_channel = channel[chl]
-                            else:
-                                print("selected channel index {} not within"
-                                      " range up to index {}"
-                                      .format(chl, num_chls - 1))
-                                return
+                    chl_matches = re.search(regex_key_chl, event.key)
+                    if chl_matches:
+                        # ctrl+n to specify channel n
+                        chl = int(chl_matches[0])
+                        if chl in channel:
+                            blob_channel = chl
+                        else:
+                            self.fn_status_bar(
+                                f"Selected channel, {chl}, must be in "
+                                f"{channel}")
+                            return
                 try:
+                    # add the circle patch
                     axi = subplots.index(inax)
                     if (axi != -1 and self._z_planes_padding <= axi
                             < z_planes - self._z_planes_padding):
@@ -779,7 +781,9 @@ class ROIEditor(plot_support.ImageSyncMixin):
                     print(e)
                     print("not on a plot to select a point")
                 fig.canvas.draw_idle()
+            
             elif event.key == "v":
+                # paste a circle
                 _circle_last_picked_len = len(self._circle_last_picked)
                 if _circle_last_picked_len < 1:
                     print("No previously picked circle to paste")

--- a/magmap/gui/roi_editor.py
+++ b/magmap/gui/roi_editor.py
@@ -197,7 +197,7 @@ class DraggableCircle:
         if (event.mouseevent.key in ("control", "shift", "alt")
                 or event.artist != self.circle):
             return
-        #print("color: {}".format(self.facecolori))
+        #print("color: {}".format(self._facecolori))
         if event.mouseevent.key == "x":
             # "cut" segment
             self.picked.append((self, self.CUT))
@@ -234,7 +234,9 @@ class DraggableCircle:
             self.segment[4] = i
             self.fn_update_seg(self.segment, seg_old)
             print("picked segment: {}".format(self.segment))
-        self.circle.figure.canvas.draw()
+        if self.circle.figure:
+            # redraw if figure is still attached
+            self.circle.figure.canvas.draw()
 
     def disconnect(self):
         """Disconnect event listeners.

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -25,7 +25,7 @@ matplotlib.use("Qt5Agg")  # explicitly use PyQt5 for custom GUI events
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg
 from matplotlib import figure
 import numpy as np
-from PyQt5 import QtWidgets, QtCore
+from PyQt5 import Qt, QtWidgets, QtCore
 
 # adjust for HiDPI screens before QGuiApplication is created, necessary
 # on Windows and Linux (not needed but no apparent affect on MacOS)
@@ -304,6 +304,7 @@ class Visualization(HasTraits):
 
     btn_redraw = Button("Redraw")
     _btn_save_fig = Button("Save Figure")
+    _roi_btn_help = Button("Help")
     roi = None  # combine with roi_array?
     _rois_selections = Instance(ListSelections)
     rois_check_list = Str
@@ -602,6 +603,7 @@ class Visualization(HasTraits):
         HGroup(
             Item("btn_redraw", show_label=False),
             Item("_btn_save_fig", show_label=False),
+            Item("_roi_btn_help", show_label=False),
         ),
         label="ROI",
     )
@@ -1948,6 +1950,11 @@ class Visualization(HasTraits):
     def _redraw_fired(self):
         """Respond to redraw button presses."""
         self.redraw_selected_viewer()
+    
+    @on_trait_change("_roi_btn_help")
+    def _help_roi(self):
+        """Respond to ROI panel help button presses."""
+        Qt.QDesktopServices.openUrl(QtCore.QUrl(config.DOCS_URL_VIEWER))
     
     def redraw_selected_viewer(self, clear=True):
         """Redraw the selected viewer.

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -365,6 +365,7 @@ class Visualization(HasTraits):
     _profiles_combined = Str  # combined profiles for selected category
     _profiles_ver = Str
     _profiles_reset_prefs_btn = Button("Reset preferences")
+    _profiles_btn_help = Button("Help")
     _profiles_reset_prefs = Bool  # trigger resetting prefs in handler
 
     # Image adjustment panel
@@ -686,7 +687,10 @@ class Visualization(HasTraits):
                 Item("_profiles_ver", style="readonly",
                      label="MagellanMapper version:"),
             ),
-            Item("_profiles_reset_prefs_btn", show_label=False),
+            HGroup(
+                Item("_profiles_reset_prefs_btn", show_label=False),
+                Item("_profiles_btn_help", show_label=False),
+            ),
             label="Settings",
         ),
         label="Profiles",
@@ -1951,10 +1955,27 @@ class Visualization(HasTraits):
         """Respond to redraw button presses."""
         self.redraw_selected_viewer()
     
+    @staticmethod
+    def _open_help_docs(suffix: str = ""):
+        """Open help documentation in the default web browser.
+        
+        Args:
+            suffix: Name of page within the main documentation; defaults to
+                an empty string to open the docs homepage.
+
+        """
+        Qt.QDesktopServices.openUrl(QtCore.QUrl(
+            f"{config.DocsURLs.DOCS_URL.value}/{suffix}"))
+    
     @on_trait_change("_roi_btn_help")
     def _help_roi(self):
         """Respond to ROI panel help button presses."""
-        Qt.QDesktopServices.openUrl(QtCore.QUrl(config.DOCS_URL_VIEWER))
+        self._open_help_docs(config.DocsURLs.DOCS_URL_VIEWER.value)
+
+    @on_trait_change("_profiles_btn_help")
+    def _help_profiles(self):
+        """Respond to profiles panel help button presses."""
+        self._open_help_docs(config.DocsURLs.DOCS_URL_SETTINGS.value)
     
     def redraw_selected_viewer(self, clear=True):
         """Redraw the selected viewer.

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -327,11 +327,12 @@ class Visualization(HasTraits):
     )
     segs_pts = None
     segs_selected = List  # indices
+    _segs_row_scroll = Int()  # row index to scroll the table
     # multi-select to allow updating with a list, but segment updater keeps
     # selections to single when updating them
     segs_table = TabularEditor(
         adapter=SegmentsArrayAdapter(), multi_select=True, 
-        selected_row="segs_selected")
+        selected_row="segs_selected", scroll_to_row="_segs_row_scroll")
     segs_in_mask = None  # boolean mask for segments in the ROI
     segs_cmap = None
     segs_feedback = Str("Segments output")
@@ -2902,6 +2903,9 @@ class Visualization(HasTraits):
                 self.segments = np.concatenate((self.segments, segs))
             self.segs_selected.append(len(self.segments) - 1)
             print("added segment to table: {}".format(seg))
+        
+        # scroll to first selected row
+        self._segs_row_scroll = min(self.segs_selected)
         return seg
     
     @property

--- a/magmap/io/df_io.py
+++ b/magmap/io/df_io.py
@@ -558,7 +558,8 @@ def print_data_frame(df, sep=" ", index=False, header=True, show=True):
     else:
         df_str = df.to_csv(sep=sep, index=index, header=header, na_rep="NaN")
     if show:
-        print(df_str)
+        # show on a new line to align headers with columns in logger
+        print(f"\n{df_str}")
     return df_str
 
 

--- a/magmap/settings/config.py
+++ b/magmap/settings/config.py
@@ -37,10 +37,17 @@ APP_NAME = "MagellanMapper"
 URI_SCHEME = "magmap"
 #: str: Reverse Domain Name System identifier.
 DNS_REVERSE = f"io.github.sanderslab.{APP_NAME}"
-#: Docs URL.
-DOCS_URL: str = "https://magellanmapper.readthedocs.io/en/latest"
-#: Viewer docs URL.
-DOCS_URL_VIEWER: str = f"{DOCS_URL}/viewers.html"
+
+
+class DocsURLs(Enum):
+    """URLs to online documentation."""
+    #: Docs base URL.
+    DOCS_URL = "https://magellanmapper.readthedocs.io/en/latest"
+    #: Viewer doc suffix.
+    DOCS_URL_VIEWER = "viewers.html"
+    #: Settings doc URL.
+    DOCS_URL_SETTINGS = "settings.html"
+
 
 #: float: Threshold for positive values for float comparison.
 POS_THRESH = 0.001

--- a/magmap/settings/config.py
+++ b/magmap/settings/config.py
@@ -37,6 +37,11 @@ APP_NAME = "MagellanMapper"
 URI_SCHEME = "magmap"
 #: str: Reverse Domain Name System identifier.
 DNS_REVERSE = f"io.github.sanderslab.{APP_NAME}"
+#: Docs URL.
+DOCS_URL: str = "https://magellanmapper.readthedocs.io/en/latest"
+#: Viewer docs URL.
+DOCS_URL_VIEWER: str = f"{DOCS_URL}/viewers.html"
+
 #: float: Threshold for positive values for float comparison.
 POS_THRESH = 0.001
 #: int: Number of CPUs for multiprocessing tasks; defaults to None to


### PR DESCRIPTION
The GUI tools have many functions that are not inherently obvious, such as shortcuts that are not shown in the GUI or tooltips that only appear when hovering over specific GUI elements. As a first step to making documentation more accessible, this PR adds buttons to open the ReadTheDocs documentation in an external browser.

Specifically, this PR adds buttons to the ROI and Profiles panels to open the docs pages specific to these controls. The buttons open the pages through the Qt `QDesktopServices.openUrl` function, which opens the links in the default browser. Qt also provides the functionality to open the links directly in the app itself, but this would require making the `PyQtWebEngine` package a dependency.

TraitsUI also supports displaying basic HTML pages `QTextBrowser`. Future PRs could extract a subset of the docs such as the shortcut tables to display these controls in a built-in docs viewer. These docs are currently in MarkDown format, however, and would need to be converted, ideally dynamically to avoid duplicate docs.

This PR also bundles a few unrelated changes:
- Fix error when turning off a verification flag for a newly added detection circle
- Simplify adding a detection circle for different channels
- Auto-scroll the table of detections to the selected row
- Fix alignment of headers and columns in data frames printed to console with logging