### PR TITLE
Fix blob verification and resaving from blob match errors

### DIFF
--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -27,6 +27,7 @@
 - Auto-scrolls to the selected annotation (#109)
 - `ctrl+[n]+click` to add a channel now sets the channel directly to `n` rather than to the `n`th seleted channel (#109)
 - Fixed blob segmentation for newer versions of Scikit-image (#91)
+- Fixed verifying and resaving blobs
 
 #### Volumetric image processing
 

--- a/magmap/cv/colocalizer.py
+++ b/magmap/cv/colocalizer.py
@@ -445,8 +445,7 @@ def _get_roi_id(db, offset, shape, exp_name=None):
     if exp_name is None:
         exp_name = sqlite.get_exp_name(
             config.img5d.path_img if config.img5d else None)
-    exp_id = sqlite.select_or_insert_experiment(
-        db.conn, db.cur, exp_name, None)
+    exp_id = db.select_or_insert_experiment(exp_name, None)
     roi_id = sqlite.select_or_insert_roi(
         db.conn, db.cur, exp_id, config.series, offset, shape)[0]
     return roi_id

--- a/magmap/io/sqlite.py
+++ b/magmap/io/sqlite.py
@@ -846,7 +846,7 @@ class ClrDB:
             return (self.select_blob(roi_id, blob)[1] if blob_id is None
                     else blob_id)
         
-        if matches is None: return None
+        if matches is None or matches.df is None: return None
         ids = []
         for _, match in matches.df.iterrows():
             blob1_id = get_blob_id(


### PR DESCRIPTION
Blob verification and resaving ROIs triggered errors related to the blob matching introduced in v1.5, even when not performing blob matches. This PR fixes those errors.