### PR TITLE
Roundup to fix removing filenames after periods, store image metadata in image object, add control for default blob label

### DIFF
--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -13,10 +13,13 @@
 - "Blend" option in the image adjustment panel to visualize alignment in overlaid images
 - Drag and remove loaded profiles in the Profiles tab table
 - "Help" buttons added to open the online documentation (#109)
+- Default confirmation labels can be set before detection (#115)
+- Fixed to reset the ROI selector when redrawing (#115)
 
 #### CLI
 
 - The `--proc export_tif` task exports an NPY file to TIF format
+- Fixed to only remove the final extension from image paths, and paths given by the `--prefix <path>` CLI argument do not undergo any stripping (#115)
 
 #### Atlas refinement
 
@@ -36,6 +39,7 @@
 #### I/O
 
 - The `--proc export_planes` task can export a subset of image planes specified by `--slice`, or an ROI specified by `--offset` and `--size`
+- Image metadata is stored in the `Image5d` image object (#115)
 
 #### Server pipelines
 
@@ -53,6 +57,7 @@
 
 - Python 3.8 is the default version now that Python 3.6 has reached End-of-Life
 - `Tifffile` is now a direct dependency, previously already installed as a sub-dependency of other required packages
+- Updated to use the `axis_channel` parameter in Scikit-image's `transform.rescale` function (#115)
 
 #### R Dependency Changes
 

--- a/magmap/atlas/labels_meta.py
+++ b/magmap/atlas/labels_meta.py
@@ -14,7 +14,7 @@ class LabelsMeta:
     
     Attributes:
         prefix: Path prefix for saving metadata and locating the reference
-            file path.
+            file path. Any extension will be removed. Defaults to None.
         save_path: Path to save this metadata.
         path_ref: Path to labels reference file.
         region_ids_orig: Sequence of original label IDs.

--- a/magmap/atlas/transformer.py
+++ b/magmap/atlas/transformer.py
@@ -180,7 +180,8 @@ def transpose_img(filename, series, plane=None, rescale=None, target_size=None):
     time_start = time()
     # even if loaded already, reread to get image metadata
     # TODO: consider saving metadata in config and retrieving from there
-    img5d, info = importer.read_file(filename, series, return_info=True)
+    img5d = importer.read_file(filename, series)
+    info = img5d.meta
     image5d = img5d.img
     sizes = info["sizes"]
     

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -1869,16 +1869,13 @@ class Visualization(HasTraits):
     
     @on_trait_change("_channel")
     def update_channel(self):
-        """Update the selected channel, resetting the current state to 
-        prevent displaying the old channel.
+        """Update the selected channel and image adjustment controls.
         """
         if not self._channel:
             # resetting channel names triggers channel update as empty array
             return
         config.channel = sorted([int(n) for n in self._channel])
         self._setup_imgadj_channels()
-        self.rois_check_list = _ROI_DEFAULT
-        self._reset_segments()
         print("Changed channel to {}".format(config.channel))
     
     def reset_stale_viewers(self, val=vis_handler.StaleFlags.IMAGE):

--- a/magmap/io/importer.py
+++ b/magmap/io/importer.py
@@ -933,7 +933,8 @@ def import_multiplane_images(chl_paths, prefix, import_md, series=None,
     time_start = time()
     if series is None:
         series = 0
-    filename_image5d, filename_meta = make_filenames(prefix, series)
+    filename_image5d, filename_meta = make_filenames(
+        prefix, series, keep_ext=True)
     libmag.printcb("Initializing multiplane image import planes to \"{}\", "
                    "may take awhile..."
                    .format(filename_image5d), fn_feedback)
@@ -1239,8 +1240,8 @@ def import_planes_to_stack(chl_paths, prefix, import_md, rgb_to_grayscale=True,
     # allow import of arbitrarily large images
     Image.MAX_IMAGE_PIXELS = None
     
-    print("prefix", prefix)
-    filename_image5d_npz, filename_info_npz = make_filenames(prefix + ".")
+    filename_image5d_npz, filename_info_npz = make_filenames(
+        prefix, keep_ext=True)
     libmag.printcb("Importing single-plane images into multiplane Numpy format "
                    "file: {}".format(filename_image5d_npz), fn_feedback)
     image5d = None

--- a/magmap/io/libmag.py
+++ b/magmap/io/libmag.py
@@ -272,7 +272,7 @@ def get_filename_without_ext(path: str) -> str:
 
 def combine_paths(
         base_path: str, suffix: str, sep: str = "_", ext: str = None,
-        check_dir: bool = False):
+        check_dir: bool = False, keep_ext: bool = False):
     """Merge two paths by appending ``suffix``, replacing the extention 
     in ``base_path``.
     
@@ -287,6 +287,7 @@ def combine_paths(
             the extension in ``suffix``.
         check_dir: True to check if ``base_path`` is an existing directory,
             in which case it is simply joined to ``suffix``; defaults to False.
+        keep_ext: True to keep the `base_path` extension; defaults to False.
     
     Returns:
         Merged path.
@@ -301,8 +302,12 @@ def combine_paths(
         # unnecessary to split out ext and adding sep
         path = os.path.join(base_path, suffix)
     else:
-        path = splitext(base_path)[0] + sep + suffix
-    if ext: path = "{}.{}".format(splitext(path)[0], ext)
+        # remove the extension if flagged and combine with separator and suffix
+        path = base_path if keep_ext else splitext(base_path)[0]
+        path = path + sep + suffix
+    if ext:
+        # replace extension from suffix with given ext
+        path = f"{splitext(path)[0]}.{ext}"
     return path
 
 

--- a/magmap/io/np_io.py
+++ b/magmap/io/np_io.py
@@ -107,8 +107,7 @@ def find_scaling(
     res = None
     if scale is not None or load_size is not None:
         # retrieve scaling from a rescaled/resized image
-        _, img_info = importer.read_file(
-            img_path_transposed, config.series, return_info=True)
+        img_info = importer.read_file(img_path_transposed, config.series).meta
         scaling = img_info["scaling"]
         res = np.multiply(config.resolutions[0], scaling)
         print("retrieved scaling from resized image:", scaling)
@@ -326,7 +325,7 @@ def setup_images(path, series=None, offset=None, size=None,
                                 importer.DEFAULT_IMG_STACK_NAME)
                         img5d = importer.import_planes_to_stack(
                             chls, prefix, import_md)
-                    elif import_only or img5d is None:
+                    elif import_only or img5d is None or img5d.img is None:
                         # import multi-plane image
                         chls, import_path = importer.setup_import_multipage(
                             path)

--- a/magmap/io/np_io.py
+++ b/magmap/io/np_io.py
@@ -365,7 +365,8 @@ def setup_images(path, series=None, offset=None, size=None,
             print(e)
     
     # load metadata related to the labels image
-    config.labels_metadata = labels_meta.LabelsMeta(path).load()
+    config.labels_metadata = labels_meta.LabelsMeta(
+        f"{path}." if config.prefix else path).load()
     
     if annotation_suffix is not None:
         try:

--- a/magmap/io/np_io.py
+++ b/magmap/io/np_io.py
@@ -4,7 +4,7 @@
 """
 import os
 import pathlib
-from typing import Any, Optional, Sequence, Tuple, Union
+from typing import Any, Dict, Optional, Sequence, Tuple, Union
 
 import numpy as np
 import tifffile
@@ -22,24 +22,32 @@ class Image5d:
     """Main image storage.
     
     Attributes:
-        img (:obj:`np.ndarray`): 5D Numpy array in the format ``t,z,y,x,c``;
+        img: 5D Numpy array in the format ``t,z,y,x,c``; defaults to None.
+        path_img: Path from which ``img`` was loaded; defaults to None.
+        path_meta: Path from which metadata for ``img`` was loaded;
             defaults to None.
-        path_img (str): Path from which ``img`` was loaded; defaults to None.
-        path_meta (str): Path from which metadata for ``img`` was loaded;
-            defaults to None.
-        img_io (enum): I/O source for image5d array; defaults to None.
-        subimg_offset (Sequence[int]): Sub-image offset in ``z,y,x``.
-        subimg_size (Sequence[int]): Sub-image size in ``z,y,x``.
+        img_io: I/O source for image5d array; defaults to None.
+        subimg_offset: Sub-image offset in ``z,y,x``; defaults to None.
+        subimg_size: Sub-image size in ``z,y,x``; defaults to None.
+        meta: Image metadata dictionary; defaults to None.
     
     """
-    def __init__(self, img=None, path_img=None, path_meta=None, img_io=None):
+    def __init__(
+            self, img: Optional[np.ndarray] = None,
+            path_img: Optional[str] = None,
+            path_meta: Optional[str] = None,
+            img_io: Optional[config.LoadIO] = None):
         """Construct an Image5d object."""
+        # attributes assignable from args
         self.img = img
         self.path_img = path_img
         self.path_meta = path_meta
         self.img_io = img_io
-        self.subimg_offset = None
-        self.subimg_size = None
+        
+        # additional attributes
+        self.subimg_offset: Optional[Sequence[int]] = None
+        self.subimg_size: Optional[Sequence[int]] = None
+        self.meta: Optional[Dict[config.MetaKeys, Any]] = None
 
 
 def img_to_blobs_path(path):


### PR DESCRIPTION
This PR rounds up a number of changes:
- Extension in main image paths are normally stripped when converting the paths to MagellanMapper-specific paths. This removal would also strip multiple path parts after periods, however, such as converting `MyFile.1.czi` to `MyFile`. Now only the final extension will be removed, and paths given by the `--prefix <path>` CLI argument do not undergo any stripping.
- Image metadata has been loaded into the global environment and discarded. Now the metadata is stored in the `Image5d` object to access more of the metadata and encapsulate it with the image. This change is part of the longer term plan to not store the metadata globally. One application of this storage is that metadata from an image can be loaded even if the image itself is not.
- Scikit-image recently changed the API for `transform.rescale` for multichannel images, updated here.
- The ROI selector now resets when redrawing.
- The default detection flag can be set before running detections.