### PR TITLE
Allow match-based colocalization when the full main image is not available

### DIFF
--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -29,6 +29,8 @@
 
 - Auto-scrolls to the selected annotation (#109)
 - `ctrl+[n]+click` to add a channel now sets the channel directly to `n` rather than to the `n`th seleted channel (#109)
+- Match-based colocalization can run without the main image, using just its metadata instead (#117)
+- Fixed match-based colocalizations when no matches are found (#117)
 - Fixed blob segmentation for newer versions of Scikit-image (#91)
 - Fixed verifying and resaving blobs
 
@@ -40,6 +42,7 @@
 
 - The `--proc export_planes` task can export a subset of image planes specified by `--slice`, or an ROI specified by `--offset` and `--size`
 - Image metadata is stored in the `Image5d` image object (#115)
+- Fixed re-importing an image after loading it (#117)
 
 #### Server pipelines
 

--- a/magmap/cv/verifier.py
+++ b/magmap/cv/verifier.py
@@ -232,8 +232,6 @@ def match_blobs_roi(blobs, blobs_base, offset, size, thresh, scaling,
               .format(blobs_base_inner_missed))
         print("truth blobs detected by an outside blob:\n{}"
               .format(blobs_base_inner_missed[found_base_out]))
-        print("all those outside detection blobs:\n{}"
-              .format(blobs_roi_extra))
         print("blobs_inner_plus:\n{}".format(blobs_inner_plus))
         print("blobs_truth_inner_plus:\n{}".format(blobs_truth_inner_plus))
         '''

--- a/magmap/io/cli.py
+++ b/magmap/io/cli.py
@@ -781,7 +781,8 @@ def process_proc_tasks(
             for proc_task, proc_val in proc_tasks.items():
                 # set up image for the given task
                 np_io.setup_images(
-                    filename, series, offset, size, proc_task)
+                    filename, series, offset, size, proc_task,
+                    fallback_main_img=False)
                 process_file(
                     filename, proc_task, proc_val, series, offset, size,
                     config.roi_offsets[0] if config.roi_offsets else None,

--- a/magmap/io/cli.py
+++ b/magmap/io/cli.py
@@ -1177,8 +1177,13 @@ def process_file(
     elif proc_type is config.ProcessTypes.COLOC_MATCH:
         if config.blobs is not None and config.blobs.blobs is not None:
             # colocalize blobs in separate channels by matching blobs
-            shape = (config.image5d.shape[1:] if subimg_size is None
-                     else subimg_size)
+            shape = subimg_size
+            if shape is None:
+                # get shape from loaded image, falling back to its metadata
+                if config.image5d is not None:
+                    shape = config.image5d.shape[1:]
+                else:
+                    shape = config.img5d.meta[config.MetaKeys.SHAPE][1:]
             matches = colocalizer.StackColocalizer.colocalize_stack(
                 shape, config.blobs.blobs)
             # insert matches into database

--- a/magmap/io/export_regions.py
+++ b/magmap/io/export_regions.py
@@ -24,6 +24,9 @@ from magmap.plot import colormaps
 from magmap.settings import config, atlas_prof
 from magmap.stats import vols
 
+_logger = config.logger.getChild(__name__)
+
+
 
 def export_region_ids(labels_ref_lookup, path, level=None,
                       drawn_labels_only=False):
@@ -182,8 +185,8 @@ def make_density_image(
         shape: Optional[Sequence[int]] = None, suffix: Optional[str] = None, 
         labels_img_sitk: Optional[sitk.Image] = None,
         channel: Optional[Sequence[int]] = None,
-        matches: Dict[Tuple[int, int], colocalizer.BlobMatch] = None,
-        atlas_profile: Optional[atlas_prof.AtlasProfile] = None
+        matches: Dict[Tuple[int, int], "colocalizer.BlobMatch"] = None,
+        atlas_profile: Optional["atlas_prof.AtlasProfile"] = None
 ) -> Tuple[np.ndarray, str]:
     """Make a density image based on associated blobs.
     
@@ -222,10 +225,11 @@ def make_density_image(
         # build heat map to store densities per label px and save to file
         coord_scaled = ontology.scale_coords(
             blobs_chl[:, :3], scaling, labels_img.shape)
-        print("coords", coord_scaled)
+        _logger.debug("Scaled coords:\n%s", coord_scaled)
         return cv_nd.build_heat_map(labels_img.shape, coord_scaled)
     
     # set up paths and get labels image
+    _logger.info("\n\nGenerating heat map from blobs")
     mod_path = img_path
     if suffix is not None:
         mod_path = libmag.insert_before_ext(img_path, suffix)
@@ -248,15 +252,15 @@ def make_density_image(
             np.divide(labels_img.shape, shape))
         labels_img = np.zeros(shape, dtype=labels_img.dtype)
         labels_img_sitk.SetSpacing(labels_spacing[::-1])
-    print("using scaling: {}".format(scaling))
+    _logger.debug("Using image scaling: {}".format(scaling))
     
     # annotate blobs based on position
     blobs_chl = blobs.blobs
     if channel is not None:
+        _logger.info("Using blobs from channel: %s", channel)
         blobs_chl = blobs_chl[np.isin(detector.get_blobs_channel(
             blobs_chl), channel)]
     heat_map = make_heat_map()
-    print("heat map", heat_map.shape, heat_map.dtype, labels_img.shape)
     imgs_write = {
         config.RegNames.IMG_HEAT_MAP.value:
             sitk_io.replace_sitk_with_numpy(labels_img_sitk, heat_map)}
@@ -266,8 +270,9 @@ def make_density_image(
         # create heat maps for match-based colocalization combos
         heat_colocs = []
         for chl_combo, chl_matches in matches.items():
-            print("Generating match-based colocalization heat map "
-                  "for channel combo:", chl_combo)
+            _logger.info(
+                "Generating match-based colocalization heat map "
+                "for channel combo: %s", chl_combo)
             # use blobs in first channel of each channel pair for simplicity
             blobs_chl = chl_matches.get_blobs(1)
             heat_colocs.append(make_heat_map())
@@ -288,8 +293,9 @@ def make_density_image(
             
             heat_colocs = []
             for combo in combos:
-                print("Generating intensity-based colocalization heat map "
-                      "for channel combo:", combo)
+                _logger.info(
+                    "Generating intensity-based colocalization heat map "
+                    "for channel combo: %s", combo)
                 blobs_chl = blobs.blobs[np.all(np.equal(
                     blobs.colocalizations[:, combo], 1), axis=1)]
                 heat_colocs.append(make_heat_map())

--- a/magmap/io/np_io.py
+++ b/magmap/io/np_io.py
@@ -330,7 +330,7 @@ def setup_images(
                 if not import_only:
                     # load previously imported image
                     img5d = importer.read_file(path, series)
-                if allow_import and img5d is None or img5d.img is None:
+                if allow_import and (img5d is None or img5d.img is None):
                     # import image; will re-import over any existing image file 
                     if os.path.isdir(path) and all(
                             [r is None for r in config.reg_suffixes.values()]):

--- a/magmap/io/np_io.py
+++ b/magmap/io/np_io.py
@@ -330,8 +330,8 @@ def setup_images(
                 if not import_only:
                     # load previously imported image
                     img5d = importer.read_file(path, series)
-                if allow_import:
-                    # re-import over existing image or import new image
+                if allow_import and img5d is None or img5d.img is None:
+                    # import image; will re-import over any existing image file 
                     if os.path.isdir(path) and all(
                             [r is None for r in config.reg_suffixes.values()]):
                         # import directory of single plane images to single
@@ -345,7 +345,7 @@ def setup_images(
                                 importer.DEFAULT_IMG_STACK_NAME)
                         img5d = importer.import_planes_to_stack(
                             chls, prefix, import_md)
-                    elif import_only or img5d is None or img5d.img is None:
+                    elif import_only:
                         # import multi-plane image
                         chls, import_path = importer.setup_import_multipage(
                             path)

--- a/magmap/settings/config.py
+++ b/magmap/settings/config.py
@@ -30,6 +30,8 @@ from magmap.settings import logs
 if TYPE_CHECKING:
     import SimpleITK as sitk
     from magmap.atlas import labels_meta
+    from magmap.cv import detector
+    from magmap.io import np_io
 
 #: str: Application name.
 APP_NAME = "MagellanMapper"
@@ -124,11 +126,11 @@ subimg_sizes = None
 
 image5d = None  # numpy image array
 image5d_is_roi = False  # flag when image5d was loaded as an ROI
-#: :obj:`magmap.io.np_io.Image5d`: Image5d object.
-img5d = None
+#: Image5d object.
+img5d: Optional["np_io.Image5d"] = None
 
-#: obj:`magmap.cv.detector.Blobs`: Blobs object.
-blobs = None
+#: Blobs object.
+blobs: Optional["detector.Blobs"] = None
 
 #: :obj:`np.ndarray`: 2D array of shapes per time point in
 # ``[n_time_point, n_shape]`` format in case image5d is not available


### PR DESCRIPTION
Match-based object colocalization has assumed that the whole image was available for blob detection, but the colocalization depends only on the detected blobs, not the image. By providing an option to perform the colocalization without the image, this task could be performed afterward, such as in a local computer that does not have the large main image.

This PR allows performing this colocalization without the image so long as its metadata file is present. When a main image is not loaded, a registered image has been loaded instead if present, but this image typically has different resolutions than the main image and is no longer loaded during this task. As a side effect, the image loader was also restructured to not attempt re-importing an image file if the main image was not loaded, which had prevented the metadata from being stored.

Additionally, two fixes added are:
- Fixed circular import when generating heat maps
- Fixed match-based colocalization when no matches are found