### PR TITLE
Build API docs for ReadTheDocs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -206,3 +206,32 @@ napoleon_use_admonition_for_references = False
 napoleon_use_ivar = True
 napoleon_use_param = True
 napoleon_use_rtype = True
+
+
+# automate building API .rst files, necessary for ReadTheDocs, as inspired by:
+# https://github.com/readthedocs/readthedocs.org/issues/1139#issuecomment-398083449
+def run_apidoc(_):
+    ignore_paths = []
+
+    argv = [
+        "-f",
+        "-T",
+        "-e",
+        "-M",
+        "-o", ".",
+        ".."
+    ] + ignore_paths
+
+    try:
+        # Sphinx >= 1.7
+        from sphinx.ext import apidoc
+        apidoc.main(argv)
+    except ImportError:
+        # Sphinx  < 1.7
+        from sphinx import apidoc
+        argv.insert(0, apidoc.__file__)
+        apidoc.main(argv)
+
+
+def setup(app):
+    app.connect('builder-inited', run_apidoc)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -184,9 +184,9 @@ texinfo_documents = [
 intersphinx_mapping = {
     'https://docs.python.org/3/': None,
     'https://numpy.org/doc/stable/': None,
-    'https://docs.scipy.org/doc/scipy/reference': None,
-    'https://matplotlib.org': None,
-    'https://pandas.pydata.org/pandas-docs/stable/': None,
+    "https://docs.scipy.org/doc/scipy/": None,
+    "https://matplotlib.org/stable/": None,
+    "https://pandas.pydata.org/docs/": None,
     "http://docs.enthought.com/mayavi/mayavi/": None,
     "https://www.riverbankcomputing.com/static/Docs/PyQt5/": None,
     "http://docs.enthought.com/mayavi/tvtk/": None,


### PR DESCRIPTION
The API docs have not been built for the ReadTheDocs documentation because the RST files are not generated by default. As inspired by this [wokaround](https://github.com/readthedocs/readthedocs.org/issues/1139#issuecomment-398083449), this PR adds a configuration step to generate the RST files automatically when ReadTheDocs builds the documentation. Additionally, intersphinx links have been updated for Scipy, Matplotlib, and Pandas.