### PR TITLE
Fix performance issue when loading large numbers of blob matches from the database

### DIFF
--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -31,6 +31,7 @@
 - `ctrl+[n]+click` to add a channel now sets the channel directly to `n` rather than to the `n`th seleted channel (#109)
 - Match-based colocalization can run without the main image, using just its metadata instead (#117)
 - Fixed match-based colocalizations when no matches are found (#117)
+- Fixed slow loading of match-based colocalizations (#119)
 - Fixed blob segmentation for newer versions of Scikit-image (#91)
 - Fixed verifying and resaving blobs
 

--- a/magmap/io/df_io.py
+++ b/magmap/io/df_io.py
@@ -18,6 +18,8 @@ from magmap.settings import config
 from magmap.io import cli
 from magmap.io import libmag
 
+_logger = config.logger.getChild(__name__)
+
 
 #: dict[:class:`config.DFTasks`, func]: Dictionary of data frame tasks
 # and function to apply.
@@ -647,15 +649,21 @@ def data_frames_to_csv(
         libmag.backup_file(path)
     combined = data_frames
     if not isinstance(data_frames, pd.DataFrame):
+        # combine data frames
         combined = pd.concat(combined)
     if sort_cols is not None:
+        # sort column
         combined = combined.sort_values(sort_cols)
-    combined.to_csv(path, index=index, na_rep="NaN")
+    if path:
+        # save to file
+        combined.to_csv(path, index=index, na_rep="NaN")
     if show is not None:
+        # print to console
         print_data_frame(combined, show)
     if path:
-        print("exported volume data per sample to CSV file: \"{}\""
-              .format(path))
+        # show the exported data path
+        _logger.info(
+            "Exported volume data per sample to CSV file: \"%s\"", path)
     return combined
 
 

--- a/magmap/io/export_regions.py
+++ b/magmap/io/export_regions.py
@@ -209,8 +209,9 @@ def make_density_image(
             defaults to None.
         labels_img_sitk: Labels image; defaults to None to load from a
             registered labels image.
-        channel: Sequence of channels to include in density image;
-            defaults to None to combine blobs from all channels.
+        channel: Sequence of channels to include in density image. For
+            multiple channels, blobs from all these channels are combined
+            into one heatmap.  Defaults to None to use all channels.
         matches: Dictionary of channel combinations to blob matches; defaults
             to None.
         atlas_profile: Atlas profile, used for scaling; defaults to None.
@@ -257,7 +258,9 @@ def make_density_image(
     # annotate blobs based on position
     blobs_chl = blobs.blobs
     if channel is not None:
-        _logger.info("Using blobs from channel: %s", channel)
+        _logger.info(
+            "Using blobs from channel(s), combining if multiple channels: %s",
+            channel)
         blobs_chl = blobs_chl[np.isin(detector.get_blobs_channel(
             blobs_chl), channel)]
     heat_map = make_heat_map()

--- a/magmap/io/sqlite.py
+++ b/magmap/io/sqlite.py
@@ -921,7 +921,7 @@ class ClrDB:
             blobn: int,
             blob_ids: Sequence[int],
             max_params: int = 100000
-    ) -> "magmap.cv.colocalizer.BlobMatch":
+    ) -> "colocalizer.BlobMatch":
         """Select blob matches corresponding to the given blob IDs in the
         given blob column.
 

--- a/magmap/io/sqlite.py
+++ b/magmap/io/sqlite.py
@@ -9,7 +9,7 @@ import os
 import glob
 import datetime
 import sqlite3
-from typing import List, Optional, Tuple
+from typing import List, Optional, Sequence, Tuple
 
 import numpy as np
 
@@ -25,6 +25,8 @@ DB_VERSION = 4
 
 _COLS_BLOBS = "roi_id, z, y, x, radius, confirmed, truth, channel"
 _COLS_BLOB_MATCHES = "roi_id, blob1, blob2, dist"
+
+_logger = config.logger.getChild(__name__)
 
 
 def _create_db(path):
@@ -913,39 +915,67 @@ class ClrDB:
             .format(_COLS_BLOB_MATCHES), (roi_id,))
         return self._parse_blob_matches(self.cur.fetchall())
 
-    def select_blob_matches_by_blob_id(self, row_id, blobn, blob_ids):
+    def select_blob_matches_by_blob_id(
+            self,
+            row_id: int,
+            blobn: int,
+            blob_ids: Sequence[int],
+            max_params: int = 100000
+    ) -> "magmap.cv.colocalizer.BlobMatch":
         """Select blob matches corresponding to the given blob IDs in the
         given blob column.
 
         Args:
-            row_id (int): Row ID.
-            blobn (int): 1 or 2 to indicate the first or second blob column,
+            row_id: Row ID.
+            blobn: 1 or 2 to indicate the first or second blob column,
                 respectively.
-            blob_ids (List[int]): Blob IDs.
+            blob_ids: Blob IDs.
+            max_params: Maximum number of parameters for the `SELECT`
+                statements; defaults to 100000. The max is determined by
+                `SQLITE_MAX_VARIABLE_NUMBER` set at the sqlite3 compile
+                time. If this number is exceeded, this function is called
+                recursively with half the given `max_params`.
 
         Returns:
-            :class:`magmap.cv.colocalizer.BlobMatch`: Blob match object,
-            which is empty if not matches are found.
+            Blob match object, which is empty if not matches are found.
+        
+        Raises:
+            :meth:`sqlit3.OperationalError`: if the maximum number of
+            parameters is < 1.
 
         """
+        if max_params < 1:
+            raise sqlite3.OperationalError(
+                "Could not determine number of parameters for selecting blob "
+                "matches")
+        
         matches = []
         if isinstance(blob_ids, np.ndarray):
             blob_ids = blob_ids.tolist()
-        max_params = 990  # max params of 999 in sqlite < v3.32.0
-        for i in range(len(blob_ids) // max_params + 1):
-            # select blob matches by block to avoid exceeding sqlite parameter
-            # limit
-            ids = blob_ids[i*max_params:(i+1)*max_params]
-            ids.insert(0, row_id)
-            self.cur.execute(
-                "SELECT {}, id FROM blob_matches WHERE roi_id = ?"
-                "AND blob{} IN ({})"
-                .format(_COLS_BLOB_MATCHES, blobn,
-                        ",".join("?" * (len(ids) - 1))),
-                ids)
-            df = self._parse_blob_matches(self.cur.fetchall()).df
-            if df is not None:
-                matches.append(df)
+        try:
+            # select matches by block to avoid exceeding sqlite parameter limit
+            nblocks = len(blob_ids) // max_params + 1
+            for i in range(nblocks):
+                _logger.info(
+                    "Selecting blob matches block %s of %s", i, nblocks - 1)
+                ids = blob_ids[i*max_params:(i+1)*max_params]
+                ids.insert(0, row_id)
+                self.cur.execute(
+                    f"SELECT {_COLS_BLOB_MATCHES}, id FROM blob_matches "
+                    f"WHERE roi_id = ? AND blob{blobn} "
+                    f"IN ({','.join('?' * (len(ids) - 1))})",
+                    ids)
+                df = self._parse_blob_matches(self.cur.fetchall()).df
+                if df is not None:
+                    matches.append(df)
+        except sqlite3.OperationalError:
+            # call recursively with halved number of parameters
+            _logger.debug(
+                "Exceeded max sqlite query parameters; trying with smaller "
+                "number")
+            return self.select_blob_matches_by_blob_id(
+                row_id, blobn, blob_ids, max_params // 2)
+        
         if len(matches) > 0:
             return colocalizer.BlobMatch(df=df_io.data_frames_to_csv(matches))
         return colocalizer.BlobMatch()


### PR DESCRIPTION
Loading match-based blob colocalizations from the database can be very slow since blobs are extracted in batches to avoid exceeding the maximum number of parameters in a `SELECT` query statement. The max number was [limited](https://www.sqlite.org/limits.html) to the default for earlier versions of Sqlite3, but it turns out that the number is set by the compilation and may differ from the default. In testing on Python 3.8.8, for example, the limits is much higher than the 999 default in SQLite < 3.32.0. Using small batch sizes requires more batches and slows down performance considerably.

To maximize the batch size without exceeding it, this PR starts with a large batch size and recursively decreases this size if SQLite raises an error. User feedback is also provided in the console to show the progress of blob match loading. Additionally, blob matches and other Pandas data frames are not converted unnecessarily to strings when combining data frames.