### PR TITLE
Fix displaying colocalizations when none are present in an ROI and increase block overlaps when matching blobs

### DIFF
--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -30,13 +30,14 @@
 - Auto-scrolls to the selected annotation (#109)
 - `ctrl+[n]+click` to add a channel now sets the channel directly to `n` rather than to the `n`th seleted channel (#109)
 - Match-based colocalization can run without the main image, using just its metadata instead (#117)
-- Fixed match-based colocalizations when no matches are found (#117)
+- Fixed match-based colocalizations when no matches are found (#117, #120)
 - Fixed slow loading of match-based colocalizations (#119)
 - Fixed blob segmentation for newer versions of Scikit-image (#91)
 - Fixed verifying and resaving blobs
 
 #### Volumetric image processing
 
+- Match-based colocalizations use larger processing blocks to avoid gaps (#120)
 - Fixed 3D surface area measurement with Scikit-image >= v0.19
 
 #### I/O

--- a/magmap/cv/colocalizer.py
+++ b/magmap/cv/colocalizer.py
@@ -410,7 +410,7 @@ def colocalize_blobs_match(blobs, offset, size, tol, inner_padding=None):
     if blobs is None:
         return None
     thresh, scaling, inner_pad, resize, blobs = verifier.setup_match_blobs_roi(
-        blobs, tol)
+        tol, blobs)
     if inner_padding is None:
         inner_padding = inner_pad
     matches_chls = {}

--- a/magmap/cv/colocalizer.py
+++ b/magmap/cv/colocalizer.py
@@ -200,10 +200,9 @@ class StackColocalizer(object):
             "Colocalizing blobs based on matching blobs in each pair of "
             "channels")
         # set up ROI blocks from which to select blobs in each block
-        sub_roi_slices, sub_rois_offsets, _, _, _, overlap_base, _, _ \
-            = stack_detect.setup_blocks(config.roi_profile, shape)
+        blocks = stack_detect.setup_blocks(config.roi_profile, shape)
         match_tol = np.multiply(
-            overlap_base, config.roi_profile["verify_tol_factor"])
+            blocks.overlap_base, config.roi_profile["verify_tol_factor"])
         
         is_fork = chunking.is_fork()
         if is_fork:

--- a/magmap/cv/stack_detect.py
+++ b/magmap/cv/stack_detect.py
@@ -5,10 +5,10 @@
 Detect blobs within a stack that has been chunked to allow parallel 
 processing.
 """
-
 from enum import Enum
 import os
 from time import time
+from typing import NamedTuple, Sequence, TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
@@ -17,6 +17,9 @@ from magmap.cv import chunking, colocalizer, detector, verifier
 from magmap.io import cli, df_io, importer, libmag, naming
 from magmap.plot import plot_3d
 from magmap.settings import config, roi_prof
+
+if TYPE_CHECKING:
+    from magmap.settings import profiles
 
 _logger = config.logger.getChild(__name__)
 
@@ -242,28 +245,34 @@ class StackDetector(object):
         return seg_rois
 
 
-def setup_blocks(settings, shape):
-    """Set up blocks for block processing, where each block is a chunk of
-    a larger image processed sequentially or in parallel to optimize
-    resource usage.
+def setup_blocks(
+        settings: "profiles.SettingsDict", shape: Sequence[int]) -> NamedTuple:
+    """Set up blocks for block processing
+    
+    Each block is a chunk of a larger image processed sequentially or in
+    parallel to optimize resource usage.
     
     Args:
-        settings (:obj:`magmap.settings.profiles.SettingsDict`): Settings
-            dictionary that defines that the blocks.
-        shape (List[int]): Shape of full image in z,y,x.
+        settings: Settings dictionary that defines that the blocks.
+        shape: Shape of full image in ``z, y, x``.
 
     Returns:
-        :obj:`np.ndarray`, :obj:`np.ndarray`, :obj:`np.ndarray`, List[int],
-        :obj:`np.ndarray`, :obj:`np.ndarray`, :obj:`np.ndarray`,
-        :obj:`np.ndarray`: Numpy object array of tuples containing slices
-        of each block; similar Numpy array but with tuples of offsets;
-        Numpy int array of max shape for each sub-block used for denoising;
-        List of ints for border pixels to exclude in z,y,x;
-        match tolerance as a Numpy float array in z,y,x;
-        Numpy float array of overlapping pixels in z,y,x;
-        similar overlap array but modified by the border exclusion; and
-        similar overlap array but for padding beyond the overlap.
-
+        A named tuple of the block parameters.
+        
+        - ``sub_roi_slices``: Numpy object array of tuples containing slices of
+          each block.
+        - ``sub_rois_offsets``: similar Numpy array but with tuples of offsets.
+          ``denoise_max_shape``: Numpy int array of max shape for each sub-block
+          used for denoising.
+        - ``exclude_border``: List of ints for border pixels to exclude in
+          ``z, y, x``.
+        - ``tol``: match tolerance as a Numpy float array in ``z, y, x``.
+        - ``overlap_base``: Numpy float array of overlapping pixels in
+          ``z, y, x``.
+        - ``overlap``: similar overlap array but modified by the border exclusion.
+        - ``overlap_padding``: similar overlap array but for padding beyond the
+          overlap.
+        
     """
     scaling_factor = detector.calc_scaling_factor()
     print("microsope scaling factor based on resolutions: {}"
@@ -301,8 +310,15 @@ def setup_blocks(settings, shape):
           .format(denoise_max_shape, max_pixels))
     sub_roi_slices, sub_rois_offsets = chunking.stack_splitter(
         shape, max_pixels, overlap)
-    return sub_roi_slices, sub_rois_offsets, denoise_max_shape, \
-        exclude_border, tol, overlap_base, overlap, overlap_padding
+    blocks = NamedTuple("Blocks", [
+        ("sub_roi_slices", np.ndarray), ("sub_rois_offsets", np.ndarray),
+        ("denoise_max_shape", np.ndarray), ("exclude_border", Sequence[int]),
+        ("tol", np.ndarray), ("overlap_base", np.ndarray),
+        ("overlap", np.ndarray), ("overlap_padding", np.ndarray),
+    ])
+    return blocks(
+        sub_roi_slices, sub_rois_offsets, denoise_max_shape,
+        exclude_border, tol, overlap_base, overlap, overlap_padding)
 
 
 def detect_blobs_blocks(filename_base, image5d, offset, size, channels,
@@ -361,23 +377,21 @@ def detect_blobs_blocks(filename_base, image5d, offset, size, channels,
     time_detection_start = time()
     settings = config.get_roi_profile(channels[0])
     print("Profile for block settings:", settings[settings.NAME_KEY])
-    sub_roi_slices, sub_rois_offsets, denoise_max_shape, exclude_border, \
-        tol, overlap_base, overlap, overlap_padding = setup_blocks(
-            settings, roi.shape)
+    blocks = setup_blocks(settings, roi.shape)
     
     # TODO: option to distribute groups of sub-ROIs to different servers 
     # for blob detection
     seg_rois = StackDetector.detect_blobs_sub_rois(
-        roi, sub_roi_slices, sub_rois_offsets, denoise_max_shape,
-        exclude_border, coloc, channels)
+        roi, blocks.sub_roi_slices, blocks.sub_rois_offsets,
+        blocks.denoise_max_shape, blocks.exclude_border, coloc, channels)
     detection_time = time() - time_detection_start
     print("blob detection time (s):", detection_time)
     
     # prune blobs in overlapping portions of sub-ROIs
     time_pruning_start = time()
     segments_all, df_pruning = StackPruner.prune_blobs_mp(
-        roi, seg_rois, overlap, tol, sub_roi_slices, sub_rois_offsets, channels,
-        overlap_padding)
+        roi, seg_rois, blocks.overlap, blocks.tol, blocks.sub_roi_slices,
+        blocks.sub_rois_offsets, channels, blocks.overlap_padding)
     pruning_time = time() - time_pruning_start
     print("blob pruning time (s):", pruning_time)
     #print("maxes:", np.amax(segments_all, axis=0))
@@ -431,7 +445,7 @@ def detect_blobs_blocks(filename_base, image5d, offset, size, channels,
         if verify:
             stats_detection, fdbk = verifier.verify_stack(
                 filename_base, subimg_path_base, settings, segments_all,
-                channels, overlap_base)
+                channels, blocks.overlap_base)
     
     if config.save_subimg:
         subimg_base_path = libmag.combine_paths(

--- a/magmap/cv/stack_detect.py
+++ b/magmap/cv/stack_detect.py
@@ -263,6 +263,8 @@ class Blocks(NamedTuple):
     overlap: np.ndarray
     #: Similar overlap array but for padding beyond the overlap.
     overlap_padding: np.ndarray
+    #: Max pixels for each side in ``z, y, x`` order.
+    max_pixels: np.ndarray
 
 
 def setup_blocks(
@@ -318,7 +320,7 @@ def setup_blocks(
         shape, max_pixels, overlap)
     return Blocks(
         sub_roi_slices, sub_rois_offsets, denoise_max_shape,
-        exclude_border, tol, overlap_base, overlap, overlap_padding)
+        exclude_border, tol, overlap_base, overlap, overlap_padding, max_pixels)
 
 
 def detect_blobs_blocks(filename_base, image5d, offset, size, channels,

--- a/magmap/cv/verifier.py
+++ b/magmap/cv/verifier.py
@@ -125,15 +125,16 @@ def setup_match_blobs_roi(
     scaling = thresh / tol
     # casting to int causes improper offset import into db
     inner_padding = np.floor(tol[::-1])
-    _logger.debug(
-        "verifying blobs with tol %s leading to thresh %s, scaling %s, "
-        "inner_padding %s", tol, thresh, scaling, inner_padding)
+    libmag.log_once(
+        _logger.debug, 
+        f"verifying blobs with tol {tol} leading to thresh {thresh}, "
+        f"scaling {scaling}, inner_padding {inner_padding}")
     
     # resize blobs based only on first profile
     resize = config.get_roi_profile(0)["resize_blobs"]
     if resize and blobs is not None:
         blobs = detector.multiply_blob_rel_coords(blobs, resize)
-        _logger.debug("resized blobs by %s:\n%s", resize, blobs)
+        libmag.log_once(_logger.debug, f"resized blobs by {resize}:\n{blobs}")
     
     return thresh, scaling, inner_padding, resize, blobs
 

--- a/magmap/cv/verifier.py
+++ b/magmap/cv/verifier.py
@@ -83,8 +83,6 @@ def find_closest_blobs_cdist(blobs, blobs_master, thresh=None, scaling=None):
         # filter out matches beyond the given threshold distance
         dists_in = dists_closest < thresh
         if config.verbose:
-            print("only keeping blob matches within threshold distance of",
-                  thresh)
             for blob, blob_sc, blob_base, blob_base_sc, dist, dist_in in zip(
                     blobs[rowis], blobs_scaled[rowis], blobs_master[colis],
                     blobs_master_scaled[colis], dists_closest,
@@ -173,9 +171,6 @@ def match_blobs_roi(blobs, blobs_base, offset, size, thresh, scaling,
     # get all blobs in inner and total ROI
     offset_inner = np.add(offset, inner_padding)
     size_inner = np.subtract(size, inner_padding * 2)
-    libmag.printv(
-        "offset: {}, offset_inner: {}, size: {}, size_inner: {}"
-        .format(offset, offset_inner, size, size_inner))
     blobs_roi, _ = detector.get_blobs_in_roi(blobs, offset, size)
     if resize is not None:
         # TODO: doesn't align with exported ROIs
@@ -223,6 +218,8 @@ def match_blobs_roi(blobs, blobs_base, offset, size, thresh, scaling,
     matches = colocalizer.BlobMatch([*matches_inner, *matches_outer])
     if config.verbose:
         '''
+        print("offset: {}, offset_inner: {}, size: {}, size_inner: {}"
+              .format(offset, offset_inner, size, size_inner))
         print("blobs_roi:\n{}".format(blobs_roi))
         print("blobs_inner:\n{}".format(blobs_inner))
         print("blobs_base_inner:\n{}".format(blobs_base_inner))
@@ -239,18 +236,20 @@ def match_blobs_roi(blobs, blobs_base, offset, size, thresh, scaling,
         print("blobs_inner_plus:\n{}".format(blobs_inner_plus))
         print("blobs_truth_inner_plus:\n{}".format(blobs_truth_inner_plus))
         '''
-
-        print("Closest matches found (truth, detected, distance):")
-        msgs = ("\n- Inner ROI:", "\n- Outer ROI:")
-        for msg, matches_sub in zip(msgs, (matches_inner, matches_outer)):
-            print(msg)
-            for match in matches_sub:
-                print(
-                    "Blob1:", match[0][:3], "chl",
-                    detector.get_blob_channel(match[0]), "Blob2:", match[1][:3],
-                    "chl", detector.get_blob_channel(match[1]),
-                    "dist:", match[2])
-        print()
+        
+        if len(matches_inner) + len(matches_outer) > 0:
+            _logger.debug("Closest matches found (truth, detected, distance):")
+            msgs = ("\n- Inner ROI:", "\n- Outer ROI:")
+            for msg, matches_sub in zip(msgs, (matches_inner, matches_outer)):
+                _logger.debug(msg)
+                for match in matches_sub:
+                    _logger.debug(
+                        f"Blob1: {match[0][:3]}, chl: "
+                        f"{detector.get_blob_channel(match[0])}, "
+                        f"Blob2: {match[1][:3]}, "
+                        f"chl: {detector.get_blob_channel(match[1])}, "
+                        f"dist: {match[2]}")
+            _logger.debug("\n")
     
     return blobs_inner_plus, blobs_truth_inner_plus, offset_inner, size_inner, \
         matches

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -2103,7 +2103,7 @@ class Visualization(HasTraits):
                 matches = colocalizer.colocalize_blobs_match(
                     segs_all, np.zeros(3, dtype=int), roi_size, verify_tol,
                     np.zeros(3, dtype=int))
-                if matches:
+                if matches and len(matches) > 0:
                     # TODO: include all channel combos
                     self.blobs.blob_matches = matches[tuple(matches.keys())[0]]
         else:
@@ -2125,11 +2125,11 @@ class Visualization(HasTraits):
                 matches = colocalizer.select_matches(
                     config.db, config.channel, offset[::-1], roi_size[::-1])
                 # TODO: include all channel combos
-                if matches is not None:
+                if matches is not None and len(matches) > 0:
                     matches = matches[tuple(matches.keys())[0]]
                     shift = [n * -1 for n in offset[::-1]]
                     matches.update_blobs(detector.shift_blob_rel_coords, shift)
-                self.blobs.blob_matches = matches
+                    self.blobs.blob_matches = matches
                 print("loaded blob matches:\n", self.blobs.blob_matches)
             elif (ColocalizeOptions.INTENSITY.value in self._colocalize
                   and config.blobs.colocalizations is not None

--- a/magmap/io/libmag.py
+++ b/magmap/io/libmag.py
@@ -3,11 +3,12 @@
 """Shared functions with the MagellanMapper package.
 """
 
+from functools import lru_cache
 import os
 import pathlib
 import shutil
 import sys
-from typing import Optional, Union
+from typing import Callable, Optional, Sequence, Union
 import warnings
 
 if sys.version_info >= (3, 8):
@@ -454,6 +455,20 @@ def warn(msg, category=UserWarning, stacklevel=2):
 
     """
     warnings.warn(msg, category, stacklevel=stacklevel)
+
+
+@lru_cache(10)
+def log_once(fn_log: Callable[[str], None], msg: str):
+    """Log a message only once.
+    
+    Args:
+        fn_log: Log function.
+        msg: Message
+
+    """
+    # use cache to ignore repeated calls
+    # TODO: check appropriate maxsize
+    fn_log(msg)
 
 
 def series_as_str(series):

--- a/magmap/io/np_io.py
+++ b/magmap/io/np_io.py
@@ -318,20 +318,20 @@ def setup_images(
         print("Loading main image")
         try:
             path_lower = path.lower()
+            import_only = proc_type is config.ProcessTypes.IMPORT_ONLY
             if path_lower.endswith(sitk_io.EXTS_3D):
                 # attempt to format supported by SimpleITK and prepend time axis
                 config.image5d = sitk_io.read_sitk_files(path)[None]
                 config.img5d.img = config.image5d
                 config.img5d.path_img = path
                 config.img5d.img_io = config.LoadIO.SITK
-            elif path_lower.endswith((".tif", ".tiff")):
+            elif not import_only and path_lower.endswith((".tif", ".tiff")):
                 # load TIF file directly
                 _, meta = read_tif(path, config.img5d)
                 config.resolutions = meta[config.MetaKeys.RESOLUTIONS]
                 config.image5d = config.img5d.img
             else:
                 # load or import from MagellanMapper Numpy format
-                import_only = proc_type is config.ProcessTypes.IMPORT_ONLY
                 img5d = None
                 if not import_only:
                     # load previously imported image


### PR DESCRIPTION
This PR address a couple issues:

- Fixes display of colocalizations in the GUI when the given ROI does not have any colocalizations
- Increases the overlap of blocks when finding matching blobs for colocalizations in large images since the matches are primarily detected with a smaller "inner ROI," which caused many colocalizations in the rest of the ROI to be missed

A couple additional changes:

- Fixes to import TIF files during the `import_only` task rather than simply opening the file
- Reduces repetitive logging during colocalization by logging blob verification parameters only when they change