### PR TITLE
Detect blobs in any channel in the GUI

### DIFF
--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -15,6 +15,7 @@
 - "Help" buttons added to open the online documentation (#109)
 - Default confirmation labels can be set before detection (#115)
 - Fixed to reset the ROI selector when redrawing (#115)
+- Fixed to reorient the camera after clearing the 3D space (#121)
 
 #### CLI
 
@@ -27,13 +28,24 @@
 
 #### Cell detection
 
-- Auto-scrolls to the selected annotation (#109)
+##### Detection
+
+- Detection channels can be selected, including those not in the currently displayed image or loaded from a saved blobs file (#121)
+- Auto-scrolls the detections table to the selected annotation (#109)
 - `ctrl+[n]+click` to add a channel now sets the channel directly to `n` rather than to the `n`th seleted channel (#109)
-- Match-based colocalization can run without the main image, using just its metadata instead (#117)
-- Fixed match-based colocalizations when no matches are found (#117, #120)
-- Fixed slow loading of match-based colocalizations (#119)
+- Added a slider to choose the fraction of 3D blobs to display (#121)
+- Improved blob size slider range and readability (#121)
+- Fixed to scale blobs' radii when viewing blobs detections on a downsampled image (#121)
+- Fixed getting atlas colors for blobs for ROIs inside the main image (#121)
 - Fixed blob segmentation for newer versions of Scikit-image (#91)
 - Fixed verifying and resaving blobs
+
+##### Colocalization
+
+- Match-based colocalization can run without the main image, using just its metadata instead (#117)
+- These colocalizations are now displayed in the 3D viewer (#121)
+- Fixed match-based colocalizations when no matches are found (#117, #120)
+- Fixed slow loading of match-based colocalizations (#119)
 
 #### Volumetric image processing
 

--- a/magmap/cv/colocalizer.py
+++ b/magmap/cv/colocalizer.py
@@ -25,6 +25,7 @@ class BlobMatch:
             :class:`BlobMatch.Cols`; defaults to None.
         coords: Blob match coordinates, typically the mean coordinates of
             each blob pair; defaults to None.
+        cmap: Colormap for each match; defaults to None.
 
     """
     
@@ -61,6 +62,7 @@ class BlobMatch:
         """
         self.df: Optional[pd.DataFrame] = None
         self.coords: Optional[np.ndarray] = None
+        self.cmap: Optional[np.ndarray] = None
         
         if df is not None:
             # set data frame directly and ignore any other arguments

--- a/magmap/cv/colocalizer.py
+++ b/magmap/cv/colocalizer.py
@@ -91,7 +91,7 @@ class BlobMatch:
         """Format the underlying data frame."""
         if self.df is None:
             return "Empty blob matches"
-        return df_io.print_data_frame(self.df, show=False)
+        return df_io.print_data_frame(self.df, show=False, max_rows=10)
     
     def get_blobs(self, n):
         """Get blobs as a numpy array.

--- a/magmap/cv/detector.py
+++ b/magmap/cv/detector.py
@@ -55,6 +55,8 @@ class Blobs:
             defaults to None.
         basename: Archive name, typically the filename without extension
             of the image file in which blobs were detected; defaults to None.
+        scaling: Scaling factor from the blobs' space to the main image's
+            space, in ``z,y,x``; defaults to ``[1, 1, 1]``.
     
     """
 
@@ -93,6 +95,7 @@ class Blobs:
         self.roi_size: Optional[Sequence[int]] = None
         self.resolutions: Optional[Sequence[float]] = None
         self.basename: Optional[str] = None
+        self.scaling: np.ndarray = np.ones(3)
 
     def load_blobs(self, path=None):
         """Load blobs from an archive.

--- a/magmap/gui/vis_3d.py
+++ b/magmap/gui/vis_3d.py
@@ -479,8 +479,9 @@ class Vis3D:
         if matches is not None:
             self.blobs.append(self.scene.mlab.points3d(
                 matches[:, 2], matches[:, 1], matches[:, 0],
-                color=(0.5, 0.5, 0), scale_mode="none", scale_factor=scale,
-                resolution=50, mode="cylinder"))
+                color=(0.5, 0.5, 0), opacity=0.5, mask_points=mask,
+                scale_mode="none", scale_factor=scale,
+                resolution=50, mode="cube")
 
         def pick_callback(pick):
             # handle picking blobs/glyphs

--- a/magmap/gui/vis_3d.py
+++ b/magmap/gui/vis_3d.py
@@ -397,11 +397,13 @@ class Vis3D:
         # copy blobs with duplicate columns to access original values for
         # the coordinates callback when a blob is selected
         segs = np.concatenate((segments[:, :4], segments[:, :4]), axis=1)
-
+        
         matches = None
+        matches_cmap = None
         if blobs.blob_matches is not None:
             # set up match-based colocalizations
             matches = blobs.blob_matches.coords
+            matches_cmap = blobs.blob_matches.cmap
         
         isotropic = plot_3d.get_isotropic_vis(settings)
         if flipz:
@@ -478,11 +480,17 @@ class Vis3D:
         
         # blob match display
         if matches is not None:
+            # default to yellow
+            color = (0.5, 0.5, 0) if matches_cmap is None else None
             self.matches3d = self.scene.mlab.points3d(
                 matches[:, 2], matches[:, 1], matches[:, 0],
-                color=(0.5, 0.5, 0), opacity=0.5, mask_points=mask,
+                np.arange(len(matches)),
+                color=color, opacity=0.5, mask_points=mask,
                 scale_mode="none", scale_factor=scale,
                 resolution=50, mode="cube")
+            if matches_cmap is not None:
+                self.matches3d.module_manager.scalar_lut_manager.lut.table = \
+                    matches_cmap
             self.blobs3d.append(self.matches3d)
 
         def pick_callback(pick):

--- a/magmap/gui/vis_3d.py
+++ b/magmap/gui/vis_3d.py
@@ -400,11 +400,8 @@ class Vis3D:
 
         matches = None
         if blobs.blob_matches is not None:
-            # display colocalizations at the average of matched blob pairs
-            matches = blobs.blob_matches
-            matches = np.mean(
-                (matches.get_blobs(1)[:, :3], matches.get_blobs(2)[:, :3]),
-                axis=0)
+            # set up match-based colocalizations
+            matches = blobs.blob_matches.coords
         
         isotropic = plot_3d.get_isotropic_vis(settings)
         if flipz:

--- a/magmap/gui/vis_3d.py
+++ b/magmap/gui/vis_3d.py
@@ -357,7 +357,7 @@ class Vis3D:
             cmap: np.ndarray,
             roi_offset: Sequence[int], roi_size: Sequence[int],
             show_shadows: bool = False, flipz: bool = None
-    ) -> float:
+    ) -> Tuple[float, float]:
         """Show 3D blobs as points.
 
         Args:
@@ -377,12 +377,15 @@ class Vis3D:
                 defaults to False.
 
         Returns:
-            The current size of the points.
+            Tuple of:
+            - ``scale``: the current size of glyphs
+            - ``mask``: the mask size for glyphs, the denominator for the
+              fraction of glyphs displayed
         
         """
         segments = blobs.blobs
         if segments.shape[0] <= 0:
-            return 0
+            return 0, 0
         if roi_offset is None:
             roi_offset = np.zeros(3, dtype=np.int)
         if self.blobs3d:
@@ -529,7 +532,7 @@ class Vis3D:
         max_dist = max(roi_size) * 0.2
         self.scene.mlab.gcf().on_mouse_pick(pick_callback)
         
-        return scale
+        return scale, mask
 
     def _shadow_img2d(self, img2d, shape, axis):
         """Shows a plane along the given axis as a shadow parallel to

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -2214,7 +2214,8 @@ class Visualization(HasTraits):
                     and config.labels_img is not None):
                 # same colors as corresponding atlas labels
                 blob_ids = ontology.get_label_ids_from_position(
-                    segs_all[self.segs_in_mask, :3].astype(np.int),
+                    detector.get_blob_abs_coords(
+                        segs_all[self.segs_in_mask]).astype(np.int),
                     config.labels_img)
                 self.segs_cmap = config.cmap_labels(
                     config.cmap_labels.convert_img_labels(blob_ids))

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -1574,6 +1574,10 @@ class Visualization(HasTraits):
         if feedback:
             self._update_roi_feedback(" ".join(feedback), print_out=True)
         self.stale_viewers[vis_handler.ViewerTabs.MAYAVI] = None
+        
+        if Vis3dOptions.CLEAR.value in self._check_list_3d:
+            # after clearing the scene, re-orient camera to the new surface
+            self.orient_camera()
     
     def show_label_3d(self, label_id):
         """Show 3D region of main image corresponding to label ID.

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -327,7 +327,6 @@ class Visualization(HasTraits):
     scale_detections = Float(
         tooltip="Change the size of blobs in the 3D viewer"
     )
-    segs_pts = None
     segs_selected = List  # indices
     _segs_row_scroll = Int()  # row index to scroll the table
     # multi-select to allow updating with a list, but segment updater keeps
@@ -1413,7 +1412,6 @@ class Visualization(HasTraits):
         """
         self.segments = None
         self.blobs = detector.Blobs()
-        self.segs_pts = None
         self.segs_in_mask = None
         self.labels = None
         # window with circles may still be open but would lose segments 
@@ -2280,7 +2278,7 @@ class Visualization(HasTraits):
         # get blobs in ROI and display as spheres in Mayavi viewer
         roi_size = self.roi_array[0].astype(int)
         show_shadows = Vis3dOptions.SHADOWS.value in self._check_list_3d
-        self.segs_pts, scale = self._vis3d.show_blobs(
+        scale = self._vis3d.show_blobs(
             self.blobs, self.segs_in_mask, self.segs_cmap,
             self._curr_offset()[::-1], roi_size[::-1], show_shadows, self.flipz)
         
@@ -2316,8 +2314,9 @@ class Visualization(HasTraits):
     def update_scale_detections(self):
         """Updates the glyph scale factor.
         """
-        if self.segs_pts is not None:
-            self.segs_pts.glyph.glyph.scale_factor = self.scale_detections
+        for glyph in (self._vis3d.blobs3d_in, self._vis3d.matches3d):
+            if glyph is not None:
+                glyph.glyph.glyph.scale_factor = self.scale_detections
     
     def _roi_ed_close_listener(self, evt):
         """Handle ROI Editor close events.

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -2157,6 +2157,7 @@ class Visualization(HasTraits):
                     matches.update_blobs(
                         detector.multiply_blob_rel_coords,
                         config.blobs.scaling[:3])
+                    matches.get_mean_coords()
                     self.blobs.blob_matches = matches
                 _logger.debug(
                     f"Loaded blob matches:\n{self.blobs.blob_matches}")

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -311,6 +311,7 @@ class Visualization(HasTraits):
     
     btn_detect = Button("Detect")
     btn_save_segments = Button("Save Blobs")
+    _segs_chls = List  # selected channels for blob detection, 0-based
     _segs_labels = List(  # blob label selector
         ["-1"],
         tooltip="All blob labels will be set to this value when running Detect",
@@ -612,9 +613,12 @@ class Visualization(HasTraits):
     panel_detect = VGroup(
         HGroup(
             Item("btn_detect", show_label=False),
-            Item("btn_save_segments", show_label=False),
+            Item("_segs_chls", label="Chl", style="custom",
+                 editor=CheckListEditor(
+                     name="object._channel_names.selections", cols=8)),
         ),
         HGroup(
+            Item("btn_save_segments", show_label=False),
             Item("_segs_labels", label="Change labels to",
                  editor=CheckListEditor(
                      values=[str(c) for c in
@@ -962,6 +966,7 @@ class Visualization(HasTraits):
         else:
             # select all channels
             self._channel = self._channel_names.selections
+        self._segs_chls = list(self._channel)
         self._profiles_chls = self._channel
 
     def _init_imgadj(self):
@@ -2070,6 +2075,9 @@ class Visualization(HasTraits):
         self.blobs.blob_matches = blob_matches
         cli.update_profiles()
         
+        # get selected channels for blob detection
+        chls = sorted([int(n) for n in self._segs_chls])
+        
         # process ROI in prep for showing filtered 2D view and segmenting
         self._segs_visible = [BlobsVisibilityOptions.VISIBLE.value]
         offset = self._curr_offset()
@@ -2077,8 +2085,8 @@ class Visualization(HasTraits):
         self.roi = plot_3d.prepare_roi(config.image5d, offset, roi_size)
         if not libmag.is_binary(self.roi):
             self.roi = plot_3d.saturate_roi(
-                self.roi, channel=config.channel)
-            self.roi = plot_3d.denoise_roi(self.roi, config.channel)
+                self.roi, channel=chls)
+            self.roi = plot_3d.denoise_roi(self.roi, chls)
         else:
             libmag.printv(
                 "binary image detected, will not preprocess")
@@ -2093,7 +2101,7 @@ class Visualization(HasTraits):
             if config.roi_profile["thresholding"]:
                 # thresholds prior to blob detection
                 roi = plot_3d.threshold(roi)
-            segs_all = detector.detect_blobs(roi, config.channel)
+            segs_all = detector.detect_blobs(roi, chls)
             
             if ColocalizeOptions.MATCHES.value in self._colocalize:
                 # match blobs between two channels
@@ -2118,12 +2126,12 @@ class Visualization(HasTraits):
             segs_all[:, :3] = np.subtract(segs_all[:, :3], offset[::-1])
             segs_all = detector.format_blobs(segs_all)
             segs_all, mask_chl = detector.blobs_in_channel(
-                segs_all, config.channel, return_mask=True)
+                segs_all, chls, return_mask=True)
             if ColocalizeOptions.MATCHES.value in self._colocalize:
                 # get blob matches from whole-image match colocalization,
                 # shifting blobs to relative coordinates
                 matches = colocalizer.select_matches(
-                    config.db, config.channel, offset[::-1], roi_size[::-1])
+                    config.db, chls, offset[::-1], roi_size[::-1])
                 # TODO: include all channel combos
                 if matches is not None:
                     matches = matches[tuple(matches.keys())[0]]
@@ -2149,7 +2157,7 @@ class Visualization(HasTraits):
             print("segs_outside:\n{}".format(segs_outside))
             segs[:, :3] = np.subtract(segs[:, :3], offset[::-1])
             segs = detector.format_blobs(segs)
-            segs = detector.blobs_in_channel(segs, config.channel)
+            segs = detector.blobs_in_channel(segs, chls)
             segs_all = np.concatenate((segs, segs_outside), axis=0)
             
         if segs_all is not None:
@@ -2202,10 +2210,10 @@ class Visualization(HasTraits):
             '''
             # could get initial segmentation from r-w
             walker = segmenter.segment_rw(
-                self.roi, config.channel, erosion=1)
+                self.roi, chls, erosion=1)
             '''
             self.labels = segmenter.segment_ws(
-                self.roi, config.channel, None, blobs)
+                self.roi, chls, None, blobs)
             '''
             # 3D-seeded random-walker with high beta to limit walking 
             # into background, also removing objects smaller than the 
@@ -2216,7 +2224,7 @@ class Visualization(HasTraits):
                 / np.mean(plot_3d.calc_isotropic_factor(1)))
             print("min size threshold for r-w: {}".format(min_size))
             self.labels = segmenter.segment_rw(
-                self.roi, config.channel, beta=100000, 
+                self.roi, chls, beta=100000, 
                 blobs=blobs, remove_small=min_size)
             '''
         #detector.show_blob_surroundings(self.segments, self.roi)

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -2223,11 +2223,11 @@ class Visualization(HasTraits):
                 self.segs_cmap[:, 3] *= alpha
             else:
                 # default to color by channel
+                chls = detector.get_blobs_channel(
+                    segs_all[self.segs_in_mask]).astype(np.int)
                 cmap = colormaps.discrete_colormap(
-                    np_io.get_num_channels(config.image5d), alpha, True,
-                    config.seed)
-                self.segs_cmap = cmap[detector.get_blobs_channel(
-                    segs_all[self.segs_in_mask]).astype(np.int)]
+                    max(chls) + 1, alpha, True, config.seed)
+                self.segs_cmap = cmap[chls]
         
         if self._DEFAULTS_2D[2] in self._check_list_2d:
             blobs = self.segments[self.segs_in_mask]

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -645,7 +645,7 @@ class Visualization(HasTraits):
              editor=RangeEditor(
                  low_name="_scale_detections_low",
                  high_name="_scale_detections_high",
-                 mode="slider")),
+                 mode="slider", format="%.3g")),
         VGroup(
             Item("_segments", editor=segs_table, show_label=False),
             Item("segs_feedback", style="custom", show_label=False),
@@ -2284,9 +2284,8 @@ class Visualization(HasTraits):
             self.blobs, self.segs_in_mask, self.segs_cmap,
             self._curr_offset()[::-1], roi_size[::-1], show_shadows, self.flipz)
         
-        # reduce number of digits to make the slider more compact
-        scale = float(libmag.format_num(scale, 4))
-        self._scale_detections_high = scale * 2
+        # set the max scaling based on the starting value
+        self._scale_detections_high = scale * 5
         self.scale_detections = scale
 
     @on_trait_change("_colocalize")

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -2281,7 +2281,7 @@ class Visualization(HasTraits):
         roi_size = self.roi_array[0].astype(int)
         show_shadows = Vis3dOptions.SHADOWS.value in self._check_list_3d
         self.segs_pts, scale = self._vis3d.show_blobs(
-            self.segments, self.segs_in_mask, self.segs_cmap,
+            self.blobs, self.segs_in_mask, self.segs_cmap,
             self._curr_offset()[::-1], roi_size[::-1], show_shadows, self.flipz)
         
         # reduce number of digits to make the slider more compact

--- a/magmap/io/df_io.py
+++ b/magmap/io/df_io.py
@@ -539,26 +539,32 @@ def pivot_with_conditions(df, index, columns, values, aggfunc="first"):
     return df_lines, cols
 
 
-def print_data_frame(df, sep=" ", index=False, header=True, show=True):
+def print_data_frame(
+        df: pd.DataFrame, sep: str = " ", index: bool = False,
+        header: bool = True, show: bool = True, **kwargs) -> str:
     """Print formatted data frame.
     
     Args:
-        df (:obj:`pd.DataFrame`): Data frame to print.
-        sep (str): Separator for columns. True or " " to print the data 
+        df: Data frame to print.
+        sep: Separator for columns. True or " " to print the data 
             frame with a space-separated table, or can provide an 
             alternate separator. Defaults to " ".
-        index (bool): True to show index; defaults to False.
-        header (bool): True to show header; defaulst to True.
-        show (bool): True to print the formatted data frame; defaults to True.
+        index: True to show index; defaults to False.
+        header: True to show header; defaulst to True.
+        show: True to print the formatted data frame; defaults to True.
+        **kwargs: Additional arguments to :meth:`pandas.DataFrame.to_string`
+            or :meth:`pandas.DataFrame.to_csv`.
     
     Returns:
-        str: The formatted data frame.
+        The formatted data frame.
     
     """
     if sep is True or sep == " ":
-        df_str = df.to_string(index=index, header=header, na_rep="NaN")
+        df_str = df.to_string(
+            index=index, header=header, na_rep="NaN", **kwargs)
     else:
-        df_str = df.to_csv(sep=sep, index=index, header=header, na_rep="NaN")
+        df_str = df.to_csv(
+            sep=sep, index=index, header=header, na_rep="NaN", **kwargs)
     if show:
         # show on a new line to align headers with columns in logger
         print(f"\n{df_str}")

--- a/magmap/io/np_io.py
+++ b/magmap/io/np_io.py
@@ -505,6 +505,7 @@ def setup_images(
             _logger.debug("Scaling blobs to main image by factor: %s", scaling)
             blobs.blobs[:, :4] = ontology.scale_coords(
                 blobs.blobs[:, :4], scaling)
+        blobs.scaling = scaling
 
 
 def get_num_channels(image5d):

--- a/magmap/io/np_io.py
+++ b/magmap/io/np_io.py
@@ -499,10 +499,12 @@ def setup_images(
             and config.img5d.img is not None and blobs.roi_size is not None):
         # scale blob coordinates to main image if shapes differ
         scaling = np.divide(config.img5d.img.shape[1:4], blobs.roi_size)
+        # scale radius by mean of other dimensions' scaling
+        scaling = np.append(scaling, np.mean(scaling))
         if not np.all(scaling == 1):
-            print("Scaling blobs to main image by factor:", scaling)
-            blobs.blobs[:, :3] = ontology.scale_coords(
-                blobs.blobs[:, :3], scaling)
+            _logger.debug("Scaling blobs to main image by factor: %s", scaling)
+            blobs.blobs[:, :4] = ontology.scale_coords(
+                blobs.blobs[:, :4], scaling)
 
 
 def get_num_channels(image5d):


### PR DESCRIPTION
The GUI has assumed that the user wants to detect cells in all currently displayed channels. Sometimes the user may wish to detect cells in one channel while viewing other channels for reference, however. Cells may also have been detected in a prior, large image processing run while displaying these detections on the smaller, downsampled image used for image registration. This image typically only has one channel, and the GUI currently does not allow picking cells from the other channels.

This PR fixes this issues by adding a channel selector in the detection panel to specify the channels for cell detection. The user can unselect channels that are displayed or select channels that are not currently shown. When loading detections, the GUI adds channel choices based on all the loaded cells to allow selecting channels that may not even be present in the current image.