### PR TITLE
Improve retrieval times for match-based colocalizations

### DIFF
--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -45,7 +45,7 @@
 - Match-based colocalization can run without the main image, using just its metadata instead (#117)
 - These colocalizations are now displayed in the 3D viewer (#121)
 - Fixed match-based colocalizations when no matches are found (#117, #120)
-- Fixed slow loading of match-based colocalizations (#119)
+- Fixed slow loading of match-based colocalizations (#119, #123)
 
 #### Volumetric image processing
 

--- a/magmap/cv/colocalizer.py
+++ b/magmap/cv/colocalizer.py
@@ -4,7 +4,7 @@
 
 from enum import Enum
 import multiprocessing as mp
-from typing import Optional
+from typing import List, Optional, Sequence
 
 import pandas as pd
 import numpy as np
@@ -99,27 +99,29 @@ class BlobMatch:
             return "Empty blob matches"
         return df_io.print_data_frame(self.df, show=False, max_rows=10)
     
-    def get_blobs(self, n):
+    def get_blobs(self, n: int) -> Optional[np.ndarray]:
         """Get blobs as a numpy array.
 
         Args:
-            n (int): 1 for blob1, otherwise blob 2.
+            n: 1 for blob1, otherwise blob 2.
 
         Returns:
-            :class:`numpy.ndarray`: Numpy array of the given blob type, or
+            Numpy array of the given blob type, or
             None if the :attr:`df` is None or the blob column does not exist.
 
         """
         col = BlobMatch.Cols.BLOB1 if n == 1 else BlobMatch.Cols.BLOB2
         if self.df is None or col.value not in self.df:
             return None
-        return np.vstack(self.df[col.value])
+        df = self.df[col.value]
+        if len(df) == 0:
+            return None
+        return np.vstack(df)
     
-    def get_blobs_all(self):
+    def get_blobs_all(self) -> Optional[List[np.ndarray]]:
         """Get all blobs in the blob matches.
         
         Returns:
-            tuple[:class:`numpy.ndarray`, :class:`numpy.ndarray`]:
             Tuple of ``(blobs1, blobs2)``, or None if either are None.
 
         """

--- a/magmap/io/sqlite.py
+++ b/magmap/io/sqlite.py
@@ -9,6 +9,7 @@ import os
 import glob
 import datetime
 import sqlite3
+from time import time
 from typing import List, Optional, Sequence, Tuple
 
 import numpy as np
@@ -489,9 +490,38 @@ def get_roi_size(roi):
     return (roi["size_x"], roi["size_y"], roi["size_z"])
 
 
-def match_elements(src, delim, repeat):
+def match_elements(src: str, delim: str, repeat: str) -> str:
+    """Repeat a value to match the same number of delimited string elements.
+    
+    Args:
+        src: Delimited string.
+        delim: Delimiter.
+        repeat: String to repeat for each delimited element.
+
+    Returns:
+        String with ``repeat`` repeated a number of times equal to the
+        number of ``delim``-delimited elements in ``src``.
+
+    """
     src_split = src.split(delim)
     return delim.join([repeat] * len(src_split))
+
+
+def _specify_table_cols(src, delim, table):
+    """Add a prefix and alias for columns from a table.
+    
+    Args:
+        src: Delimted string.
+        delim: Delimiter.
+        table: Table name.
+
+    Returns:
+        String with ``table`` added to column names as ``<table>.<col>``
+        and an alias based on the table, ``<table>_<col>``.
+
+    """
+    src_split = src.split(delim)
+    return delim.join([f"{table}.{s} {table}_{s}" for s in src_split])
 
 
 def _merge_dbs(db_paths, db_merged=None):
@@ -881,6 +911,9 @@ class ClrDB:
 
         Returns:
             :class:`magmap.cv.colocalizer.BlobMatch`: Blob match object.
+        
+        Deprecated: 1.6.0
+            Use :meth:`select_blob_matches` instead.
 
         """
         # build list of blob matches, which contain matching blobs and their
@@ -900,20 +933,88 @@ class ClrDB:
             blob_matches = colocalizer.BlobMatch()
         return blob_matches
     
-    def select_blob_matches(self, roi_id):
+    def select_blob_matches(
+            self, roi_id: int, offset: Optional[Sequence[int]] = None,
+            shape: Optional[Sequence[int]] = None) -> "colocalizer.BlobMatch":
         """Select blob matches for the given ROI.
         
         Args:
-            roi_id (int): ROI ID.
+            roi_id: ROI ID.
+            offset: ROI offset in ``z,y,x``; defaults to None.
+            shape: ROI shape in ``z,y,x``; defaults to None.
 
         Returns:
-            List[:obj:`BlobMatch`]: List of blob matches.
+            Blob matches.
 
         """
-        self.cur.execute(
-            "SELECT {}, id FROM blob_matches WHERE roi_id = ?"
-            .format(_COLS_BLOB_MATCHES), (roi_id,))
-        return self._parse_blob_matches(self.cur.fetchall())
+        _logger.debug("Selecting blob matches for ROI ID: %s", roi_id)
+        start = time()
+        
+        # set up columns for each table
+        cols_matches = _specify_table_cols(
+            _COLS_BLOB_MATCHES + ', id', ', ', 'bm')
+        cols_blobs = _COLS_BLOBS + ", id"
+        cols_blobs1 = _specify_table_cols(cols_blobs, ', ', 'b1')
+        cols_blobs2 = _specify_table_cols(cols_blobs, ', ', 'b2')
+        
+        # set up select statement
+        stmnt = (
+            f"SELECT {cols_matches}, "
+            f"{cols_blobs1}, "
+            f"{cols_blobs2} "
+            f"FROM blob_matches bm "
+            f"INNER JOIN blobs b1 ON bm.blob1 = b1.id "
+            f"INNER JOIN blobs b2 ON bm.blob2 = b2.id "
+            f"WHERE bm.roi_id = ?")
+        args = [roi_id, ]
+        
+        if offset is not None and shape is not None:
+            # add ROI parameters
+            bounds = zip(offset, np.add(offset, shape))
+            bounds = [str(b) for bound in bounds for b in bound]
+            stmnt += (
+                " AND b1.z >= ? AND b1.z < ?"
+                "AND b1.y >= ? AND b1.y < ? AND b1.x >= ? AND b1.x < ?"
+                "AND b2.z >= ? AND b2.z < ?"
+                "AND b2.y >= ? AND b2.y < ? AND b2.x >= ? AND b2.x < ?")
+            args.extend(bounds)
+            args.extend(bounds)
+        
+        # execute query
+        self.cur.execute(stmnt, args)
+        rows = self.cur.fetchall()
+        
+        df_matches = None
+        if len(rows) > 0:
+            # convert to data frame to access by named columns
+            df = df_io.dict_to_data_frame(rows, records_cols=rows[0].keys())
+            
+            def get_cols(col_full):
+                # extract column aliases
+                return [c.split(" ")[1] for c in col_full.split(", ")]
+            
+            # extract columns for blob matches
+            df_matches = df[get_cols(cols_matches)]
+            df_matches = df_matches.rename(columns={
+                "bm_blob1": colocalizer.BlobMatch.Cols.BLOB1_ID.value,
+                "bm_blob2": colocalizer.BlobMatch.Cols.BLOB2_ID.value,
+                "bm_id": colocalizer.BlobMatch.Cols.MATCH_ID.value,
+                "bm_roi_id": colocalizer.BlobMatch.Cols.ROI_ID.value,
+                "bm_dist": colocalizer.BlobMatch.Cols.DIST.value,
+            })
+            
+            # merge each set of blob columns into a single column of blob lists
+            cols_dict = {
+                colocalizer.BlobMatch.Cols.BLOB1.value: cols_blobs1,
+                colocalizer.BlobMatch.Cols.BLOB2.value: cols_blobs2,
+            }
+            for col, cols in cols_dict.items():
+                cols = get_cols(cols)[1:]
+                df_matches[col] = df[cols].to_numpy().tolist()
+            
+        blob_matches = colocalizer.BlobMatch(df=df_matches)
+        _logger.debug("Finished selecting blob matches in %s s", time() - start)
+        return blob_matches
 
     def select_blob_matches_by_blob_id(
             self,
@@ -942,6 +1043,9 @@ class ClrDB:
         Raises:
             :meth:`sqlit3.OperationalError`: if the maximum number of
             parameters is < 1.
+        
+        Deprecated: 1.6.0
+            Use :meth:`select_blob_matches` instead.
 
         """
         if max_params < 1:


### PR DESCRIPTION
Blob match selection has been slowed by several factors:
- Initial blob selection
- Blob match selection on blob IDs, which requires batch processing because of the large number of IDs for the select parameters
- Redundant blob selection for each blob ID in the resulting blob matches

This PR improves selection performance by unifying these steps, removing redundant selections, and selecting in bulk:
- Select blobs as an inner join on the blob match selections
- Convert blobs to the blob match data frame format in bulk rather than match-by-match
- Filter by ROI parameters as an option rather than selecting these blobs first

We have seen blob match loading time improvements down from 6 min to 1 min. The prior blob match and ROI-parameter blob selection selection functions have been deprecated now that they are no longer used.