### PR TITLE
Fix regression in generating animation

### DIFF
--- a/magmap/io/export_stack.py
+++ b/magmap/io/export_stack.py
@@ -556,6 +556,7 @@ def stack_to_img(paths, roi_offset, roi_size, series=None, subimg_offset=None,
                 title = os.path.basename(path_sub)
             
             if not stacker.images: continue
+            ax = None
             for k in range(len(stacker.images[0])):
                 # create or retrieve fig; animation has only 1 fig
                 planei = 0 if animated else (
@@ -567,7 +568,9 @@ def stack_to_img(paths, roi_offset, roi_size, series=None, subimg_offset=None,
                         nrows, ncols, config.plot_labels[config.PlotLabels.SIZE])
                     fig_dict = {"fig": fig, "gs": gs, "imgs": []}
                     figs[planei] = fig_dict
-                ax = fig_dict["fig"].add_subplot(fig_dict["gs"][i, j])
+                if ax is None:
+                    # generate new axes for the gridspec position
+                    ax = fig_dict["fig"].add_subplot(fig_dict["gs"][i, j])
                 if title:
                     ax.title.set_text(title)
                 axs.append(ax)


### PR DESCRIPTION
Fixes #110. Matplotlib < 3.4 provided a deprecation warning that `Figure.add_subplot` would generate a new `Axes` object instead of reusing an existing object when given identical arguments. Animation needs to reuse the same `Axes` object and had relied upon `add_subplot` to deliver it, but later versions of Matplotlib generated these animations with a blank image until the final frame. Fix by simply retaining the `Axes` object and reusing it directly.