### PR TITLE
Use image metadata in blobs instead of registered image for density map if available

### DIFF
--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -50,6 +50,7 @@
 #### Volumetric image processing
 
 - Match-based colocalizations use larger processing blocks to avoid gaps (#120)
+- Voxel density maps no longer require a registered image (#125)
 - Fixed 3D surface area measurement with Scikit-image >= v0.19
 
 #### I/O

--- a/magmap/io/importer.py
+++ b/magmap/io/importer.py
@@ -19,7 +19,7 @@ from time import time
 import glob
 import pprint
 import re
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 from xml import etree as et
 
 import numpy as np
@@ -1386,22 +1386,26 @@ def save_np_image(image, filename, series=None):
         lows, highs)
 
 
-def calc_scaling(image5d, scaled, image5d_shape=None, scaled_shape=None):
+def calc_scaling(
+        image5d: Optional[np.ndarray], scaled: Optional[np.ndarray],
+        image5d_shape: Optional[Sequence[int]] = None,
+        scaled_shape: Optional[Sequence[int]] = None) -> np.ndarray:
     """Calculate the exact scaling between two images where one image had 
     been scaled from the other.
     
     Args:
-        image5d (:obj:`np.ndarray`): Original image in 5D (time included,
-            channel optional) format.
-        scaled (:obj:`np.ndarray`): Scaled image, assumed to be in either
-            3D or 5D format (3D with channel not currently supported).
-        image5d_shape (List): ``image5d`` shape, which can be given if
+        image5d: Original image in 5D (time included, channel optional) format.
+            Can be None if ``image5d_shape`` is given.
+        scaled: Scaled image, assumed to be in either 3D or 5D format (3D with
+            channel not currently supported). Can be None if ``scaled_shape``
+            is given.
+        image5d_shape: ``image5d`` shape, which can be given if
             ``image5d`` is None; defaults to None.
-        scaled_shape (List): ``scaled`` shape, which can be given if
+        scaled_shape: ``scaled`` shape, which can be given if
             ``scaled`` is None; defaults to None.
     
     Returns:
-        Array of (z, y, x) scaling factors from the original to the scaled
+        Array of ``z,y,x`` scaling factors from the original to the scaled
         image.
     """
     if image5d_shape is None:
@@ -1415,7 +1419,7 @@ def calc_scaling(image5d, scaled, image5d_shape=None, scaled_shape=None):
     if len(scaled_shape) >= 4:
         scaled_shape = scaled_shape[1:4]
     scaling = np.divide(scaled_shape[:3], image5d_shape[:3])
-    print("image scaling compared to image5d: {}".format(scaling))
+    _logger.debug("Image scaling compared to image5d: %s", scaling)
     return scaling
 
 

--- a/magmap/io/np_io.py
+++ b/magmap/io/np_io.py
@@ -47,7 +47,7 @@ class Image5d:
         # additional attributes
         self.subimg_offset: Optional[Sequence[int]] = None
         self.subimg_size: Optional[Sequence[int]] = None
-        self.meta: Optional[Dict[config.MetaKeys, Any]] = None
+        self.meta: Optional[Dict[Union[str, config.MetaKeys], Any]] = None
 
 
 def img_to_blobs_path(path):


### PR DESCRIPTION
Fixes #47. Creating a density map has loaded in a registered labels image to use as the output shape. The shape parameter has allowed specifying this output shape, the registered image has still been used in finding the scaling between the blobs and output image. Now that the blobs archive contains the size and resolutions from the original image, use this info when available to determine the scaling. When a shape argument is also present, bypass loading the registered image.

Future implementations could consider removing the pathways loading the `scale` and `target_size` values to find the original image now that the blobs stores this info.