### PR TITLE
Fix to uncheck Auto when manually changing the min intensity slider

### DIFF
--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -16,6 +16,7 @@
 - Default confirmation labels can be set before detection (#115)
 - Fixed to reset the ROI selector when redrawing (#115)
 - Fixed to reorient the camera after clearing the 3D space (#121)
+- Fixed to turn off the minimum intensity slider's auto setting when manually changing the slider (#126) 
 
 #### CLI
 

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -1148,18 +1148,20 @@ class Visualization(HasTraits):
     def _set_inten_min_to_curr(self, plot_ax_img):
         # set min intensity to current image value
         if plot_ax_img is not None:
-            self._imgadj_min_ignore_update = True
             vmin = plot_ax_img.ax_img.norm.vmin
             self._adapt_imgadj_limits(plot_ax_img)
-            self._imgadj_min = vmin
+            if self._imgadj_min != vmin:
+                self._imgadj_min_ignore_update = True
+                self._imgadj_min = vmin
 
     def _set_inten_max_to_curr(self, plot_ax_img):
         # set max intensity to current image value
         if plot_ax_img is not None:
-            self._imgadj_max_ignore_update = True
             vmax = plot_ax_img.ax_img.norm.vmax
             self._adapt_imgadj_limits(plot_ax_img)
-            self._imgadj_max = vmax
+            if self._imgadj_max != vmax:
+                self._imgadj_max_ignore_update = True
+                self._imgadj_max = vmax
 
     @on_trait_change("_imgadj_min")
     def _adjust_img_min(self):


### PR DESCRIPTION
Changing the min slider manually has not unchecked the Auto box initially because the change was ignored. When the min/max sliders are matched to the current image, any changes triggered by these sliders are flagged to be ignored, and the flag is reset. If the new min/max value is the same as the current value, the flag was not reset until the user made multiple manual changes to the slider. Fix by setting this flag only when the min/max values are changed from their current values.