### PR TITLE
Configure colorbar in profile

### DIFF
--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -66,6 +66,7 @@
 
 #### Python stats and plots
 
+- Color bars can be configured in ROI profiles using [settings in Matplotlib](https://matplotlib.org/3.5.0/api/_as_gen/matplotlib.pyplot.colorbar.html), update dynamically, and no longer repeat in animations (#128)
 - Fixed alignment of headers and columns in data frames printed to console (#109)
 
 #### R stats and plots

--- a/magmap/gui/plot_editor.py
+++ b/magmap/gui/plot_editor.py
@@ -474,13 +474,14 @@ class PlotEditor:
             alpha_blends=alpha_blends)
         
         # add or update colorbar
+        colobar_prof = config.roi_profile["colorbar"]
         if self._colorbar:
             self._colorbar.update_normal(ax_imgs[0][0])
-        elif config.roi_profile["colorbar"]:
+        elif colobar_prof:
             # store colorbar since it's tied to the artist, which will be
             # replaced with the next display and cannot be further accessed
             self._colorbar = self.axes.figure.colorbar(
-                ax_imgs[0][0], ax=self.axes)
+                ax_imgs[0][0], ax=self.axes, **colobar_prof)
         
         # display coordinates and label values for each image
         self.axes.format_coord = pixel_display.PixelDisplay(

--- a/magmap/gui/plot_editor.py
+++ b/magmap/gui/plot_editor.py
@@ -192,6 +192,7 @@ class PlotEditor:
         self._editing = False
         self._show_labels = True  # show atlas labels on mouseover
         self._show_crosslines = False  # show crosslines to orthogonal views
+        self._colorbar = None  # colorbar for first main image
 
         # ROI offset and size in z,y,x
         self._roi_offset = None
@@ -473,14 +474,13 @@ class PlotEditor:
             alpha_blends=alpha_blends)
         
         # add or update colorbar
-        cbar = None
-        if self._plot_ax_imgs and self._plot_ax_imgs[0]:
-            # get colorbar from first image
-            cbar = self._plot_ax_imgs[0][0].colorbar
-        if cbar:
-            cbar.update_normal(ax_imgs[0][0])
+        if self._colorbar:
+            self._colorbar.update_normal(ax_imgs[0][0])
         elif config.roi_profile["colorbar"]:
-            self.axes.figure.colorbar(ax_imgs[0][0], ax=self.axes)
+            # store colorbar since it's tied to the artist, which will be
+            # replaced with the next display and cannot be further accessed
+            self._colorbar = self.axes.figure.colorbar(
+                ax_imgs[0][0], ax=self.axes)
         
         # display coordinates and label values for each image
         self.axes.format_coord = pixel_display.PixelDisplay(

--- a/magmap/gui/plot_editor.py
+++ b/magmap/gui/plot_editor.py
@@ -383,9 +383,6 @@ class PlotEditor:
 
     def show_overview(self):
         """Show the main 2D plane, taken as a z-plane."""
-        # assume colorbar already shown if set and image previously displayed
-        colorbar = (config.roi_profile["colorbar"]
-                    and len(self.axes.images) < 1)
         self.axes.clear()
         self.hline = None
         self.vline = None
@@ -482,7 +479,7 @@ class PlotEditor:
             cbar = self._plot_ax_imgs[0][0].colorbar
         if cbar:
             cbar.update_normal(ax_imgs[0][0])
-        elif colorbar:
+        elif config.roi_profile["colorbar"]:
             self.axes.figure.colorbar(ax_imgs[0][0], ax=self.axes)
         
         # display coordinates and label values for each image

--- a/magmap/gui/plot_editor.py
+++ b/magmap/gui/plot_editor.py
@@ -474,8 +474,18 @@ class PlotEditor:
             self.axes, self.aspect, self.origin, imgs2d, self._channels, cmaps,
             alphas, vmins, vmaxs, check_single=(self._ax_img_labels is None),
             alpha_blends=alpha_blends)
-        if colorbar:
+        
+        # add or update colorbar
+        cbar = None
+        if self._plot_ax_imgs and self._plot_ax_imgs[0]:
+            # get colorbar from first image
+            cbar = self._plot_ax_imgs[0][0].colorbar
+        if cbar:
+            cbar.update_normal(ax_imgs[0][0])
+        elif colorbar:
             self.axes.figure.colorbar(ax_imgs[0][0], ax=self.axes)
+        
+        # display coordinates and label values for each image
         self.axes.format_coord = pixel_display.PixelDisplay(
             imgs2d, ax_imgs, shapes, cmap_labels=self.cmap_labels)
 

--- a/magmap/io/export_stack.py
+++ b/magmap/io/export_stack.py
@@ -189,9 +189,10 @@ class StackPlaneIO(chunking.SharedArrsContainer):
             ax_imgs = plot_support.overlay_images(
                 ax, self.aspect, self.origin, imgs, None, cmaps_all,
                 ignore_invis=True, check_single=True)
-            if colorbar and len(ax_imgs) > 0 and len(ax_imgs[0]) > 0:
+            if (colorbar is not None and len(ax_imgs) > 0
+                    and len(ax_imgs[0]) > 0):
                 # add colorbar with scientific notation if outside limits
-                cbar = ax.figure.colorbar(ax_imgs[0][0], ax=ax, shrink=0.7)
+                cbar = ax.figure.colorbar(ax_imgs[0][0], ax=ax, **colorbar)
                 plot_support.set_scinot(cbar.ax, lbls=None, units=None)
             plotted_imgs[imgi] = np.array(ax_imgs).flatten()
             

--- a/magmap/io/export_stack.py
+++ b/magmap/io/export_stack.py
@@ -190,7 +190,7 @@ class StackPlaneIO(chunking.SharedArrsContainer):
                 ax, self.aspect, self.origin, imgs, None, cmaps_all,
                 ignore_invis=True, check_single=True)
             if (colorbar is not None and len(ax_imgs) > 0
-                    and len(ax_imgs[0]) > 0):
+                    and len(ax_imgs[0]) > 0 and imgi == 0):
                 # add colorbar with scientific notation if outside limits
                 cbar = ax.figure.colorbar(ax_imgs[0][0], ax=ax, **colorbar)
                 plot_support.set_scinot(cbar.ax, lbls=None, units=None)

--- a/magmap/plot/plot_support.py
+++ b/magmap/plot/plot_support.py
@@ -21,6 +21,7 @@ from magmap.io import libmag
 from magmap.plot import plot_3d
 
 try:
+    from matplotlib.axes import Axes
     from matplotlib_scalebar import scalebar
 except ImportError as e:
     scalebar = None
@@ -761,7 +762,10 @@ def set_overview_title(ax, plane, z_overview, zoom="", level=0,
     ax.set_title(title)
 
 
-def set_scinot(ax, lims=(-3, 4), lbls=None, units=None):
+def set_scinot(
+        ax: "Axes", lims: Sequence[int] = (-3, 4),
+        lbls: Optional[Sequence[str]] = None,
+        units: Optional[Sequence[str]] = None):
     """Set scientific notation for tick labels and shift exponents from 
     axes to their labels.
     
@@ -772,16 +776,16 @@ def set_scinot(ax, lims=(-3, 4), lbls=None, units=None):
     unit labels. Units will be formatted with math text.
     
     Args:
-        ax (:class:`matplotlib.image.Axes`): Axis object.
-        lims (Sequence[int]): Scientific notation limits as a sequence of lower
+        ax: Axis object.
+        lims: Scientific notation limits as a sequence of lower
             and upper bounds outside of which scientific notation will
             be used for each applicable axis. Defaults to ``(-2, 4)``.
-        lbls (Sequence[str]): Sequence of axis labels given in the order
+        lbls: Sequence of axis labels given in the order
             ``(y-axis, x-axis)``. Defaults to None, which causes the
             corresponding value from :attr:`config.plot_labels` to be used
             if available. A None element prevents the label main text from
             displaying and will show the unit without parentheses if available.
-        units (Sequence[str]): Sequence of units given in the order
+        units: Sequence of units given in the order
             ``(y-axis, x-axis)``. Defaults to None, which causes the
             corresponding value from :attr:`config.plot_labels` to be used
             if available. A None element prevents unit display other than

--- a/magmap/settings/roi_prof.py
+++ b/magmap/settings/roi_prof.py
@@ -40,6 +40,12 @@ class ROIProfile(profiles.SettingsDict):
     )
 
     def __init__(self, *args, **kwargs):
+        """Initialize an ROI profile dictionary.
+        
+        Args:
+            *args: 
+            **kwargs: 
+        """
         super().__init__(self)
         self[self.NAME_KEY] = self.DEFAULT_NAME
 
@@ -50,7 +56,8 @@ class ROIProfile(profiles.SettingsDict):
         self["channel_colors"] = (
             config.Cmaps.CMAP_GRBK_NAME, config.Cmaps.CMAP_RDBK_NAME)
         self["scale_bar_color"] = "w"
-        self["colorbar"] = False
+        #: Colorbar args passed to :meth:`matplotlib.figure.Figure.colorbar`.
+        self["colorbar"] = None
         # num of times to rotate image by 90deg after loading
         self["load_rot90"] = 0
         self["norm"] = None  # (min, max) normalization of image5d
@@ -228,7 +235,7 @@ class ROIProfile(profiles.SettingsDict):
             "diverging": {
                 "channel_colors": ("RdBu", "BrBG"),
                 "scale_bar_color": "k",
-                "colorbar": True,
+                "colorbar": {"shrink": 0.7},
             },
 
             # lightsheet 5x of cytoplasmic markers


### PR DESCRIPTION
The ROI profile has allowed the user to toggle a colorbar displayed in the Plot Editor and when exporting a stack. This PR adds the following features:

- Changes the profile setting from a simple boolean to a dictionary that takes the arguments used in the Matplotlib [colorbar](https://matplotlib.org/3.5.0/api/_as_gen/matplotlib.pyplot.colorbar.html) function
- The colorbar now updates when adjusting the intensity min/max sliders
- The colorbar is no longer repeated when exporting an animation