### PR TITLE
Add a registered image type for density images and use for volume stats

### DIFF
--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -22,6 +22,7 @@
 
 - The `--proc export_tif` task exports an NPY file to TIF format
 - the `--transform interpolation=<n>` configures the type of interpolation when resizing images during stack export (#127)
+- Density/heat maps can be specified through `--reg_suffixes density=<suffix>` (#129)
 - Fixed to only remove the final extension from image paths, and paths given by the `--prefix <path>` CLI argument do not undergo any stripping (#115)
 
 #### Atlas refinement

--- a/magmap/atlas/register.py
+++ b/magmap/atlas/register.py
@@ -1504,10 +1504,13 @@ def volumes_by_id(
                 print(e)
                 libmag.warn("will ignore label markers")
             
-            # load heat map of nuclei per voxel if available
+            # load heat map of nuclei per voxel if available; use density
+            # suffix if provided
+            density_suffix = config.reg_suffixes[config.RegSuffixes.DENSITY]
+            if not density_suffix:
+                density_suffix = config.RegNames.IMG_HEAT_MAP.value
             try:
-                heat_map = sitk_io.load_registered_img(
-                    mod_path, config.RegNames.IMG_HEAT_MAP.value)
+                heat_map = sitk_io.load_registered_img(mod_path, density_suffix)
             except FileNotFoundError as e:
                 print(e)
                 libmag.warn("will ignore nuclei stats")

--- a/magmap/settings/config.py
+++ b/magmap/settings/config.py
@@ -550,16 +550,21 @@ GENOTYPE_KEY = "Geno"
 SUB_SEG_MULT = 100  # labels multiplier for sub-segmentations
 REGION_ALL = "all"
 
-# registered image suffix keys for command-line parsing
-RegSuffixes = Enum(
-    "RegSuffixes", [
-        "ATLAS",  # intensity image
-        "ANNOTATION",  # labels image
-        "BORDERS",  # label borders image
-        "FIXED_MASK",  # registration fixed image mask
-        "MOVING_MASK",  # registration moving image mask
-    ]
-)
+
+class RegSuffixes(Enum):
+    """Registered image suffix keys for command-line parsing."""
+    #: Intensity image.
+    ATLAS = auto()
+    #: Labels image.
+    ANNOTATION = auto()
+    #: Borders image.
+    BORDERS = auto()
+    #: Fixed mask for image registration.
+    FIXED_MASK = auto()
+    #: Moving mask for image registration
+    MOVING_MASK = auto()
+
+
 reg_suffixes = dict.fromkeys(RegSuffixes, None)
 
 

--- a/magmap/settings/config.py
+++ b/magmap/settings/config.py
@@ -552,7 +552,7 @@ REGION_ALL = "all"
 
 
 class RegSuffixes(Enum):
-    """Registered image suffix keys for command-line parsing."""
+    """Registered image suffix type keys for command-line parsing."""
     #: Intensity image.
     ATLAS = auto()
     #: Labels image.
@@ -563,9 +563,12 @@ class RegSuffixes(Enum):
     FIXED_MASK = auto()
     #: Moving mask for image registration
     MOVING_MASK = auto()
+    #: Density image.
+    DENSITY = auto()
 
 
-reg_suffixes = dict.fromkeys(RegSuffixes, None)
+#: Dictionary of registered suffix names for each suffix type.
+reg_suffixes: Dict[RegSuffixes, str] = dict.fromkeys(RegSuffixes, None)
 
 
 class ABAKeys(Enum):


### PR DESCRIPTION
We are starting to add more registered image types to allow the user to configure which registered images are used for various tasks, such as the masks used for registration itself. This PR adds a `density` type to specify the density or heat map used when measuring the number of nuclei/cells in each atlas region.