### PR TITLE
Fix preprocessing largely empty ROIs

### DIFF
--- a/magmap/cv/colocalizer.py
+++ b/magmap/cv/colocalizer.py
@@ -4,7 +4,7 @@
 
 from enum import Enum
 import multiprocessing as mp
-from typing import List, Optional, Sequence
+from typing import Dict, List, Optional, Sequence, Tuple
 
 import pandas as pd
 import numpy as np
@@ -419,22 +419,24 @@ def colocalize_blobs(roi, blobs, thresh=None):
     return colocs
 
 
-def colocalize_blobs_match(blobs, offset, size, tol, inner_padding=None):
+def colocalize_blobs_match(
+        blobs: np.ndarray, offset: Sequence[int], size: Sequence[int],
+        tol: Sequence[float], inner_padding: Optional[Sequence[int]] = None
+) -> Optional[Dict[Tuple[int, int], "BlobMatch"]]:
     """Co-localize blobs in separate channels but the same ROI by finding
     optimal blob matches.
 
     Args:
-        blobs (:obj:`np.ndarray`): Blobs from separate channels.
-        offset (List[int]): ROI offset given as x,y,z.
-        size (List[int]): ROI shape given as x,y,z.
-        tol (List[float]): Tolerances for matching given as x,y,z
-        inner_padding (List[int]): ROI padding given as x,y,z; defaults
+        blobs: Blobs from separate channels.
+        offset: ROI offset given as x,y,z.
+        size: ROI shape given as x,y,z.
+        tol: Tolerances for matching given as x,y,z
+        inner_padding: ROI padding given as x,y,z; defaults
             to None to use the padding based on ``tol``.
 
     Returns:
-        dict[tuple[int, int], :class:`BlobMatch`]:
         Dictionary where keys are tuples of the two channels compared and
-        values are blob matches objects.
+        values are blob matches objects, or None if ``blobs`` is None.
 
     """
     if blobs is None:

--- a/magmap/cv/detector.py
+++ b/magmap/cv/detector.py
@@ -262,19 +262,21 @@ def show_blob_surroundings(blobs, roi, padding=1):
     np.set_printoptions()
 
 
-def detect_blobs(roi, channel, exclude_border=None):
+def detect_blobs(
+        roi: np.ndarray, channel: Sequence[int],
+        exclude_border: Optional[Sequence[int]] = None) -> Optional[np.ndarray]:
     """Detects objects using 3D blob detection technique.
     
     Args:
         roi: Region of interest to segment.
-        channel (Sequence[int]): Sequence of channels to select, which can
+        channel: Sequence of channels to select, which can
             be None to indicate all channels.
         exclude_border: Sequence of border pixels in x,y,z to exclude;
             defaults to None.
     
     Returns:
-        Array of detected blobs, each given as 
-            (z, row, column, radius, confirmation).
+        Array of detected blobs, each given as
+        ``z, row, column, radius, confirmation``.
     """
     time_start = time()
     shape = roi.shape

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -2185,11 +2185,14 @@ class Visualization(HasTraits):
                 # get corresponding blob co-localizations unless showing
                 # blobs from database, which do not have colocs
                 colocs = config.blobs.colocalizations[mask][mask_chl]
-        _logger.debug(f"All blobs:\n{segs_all}\nTotal blobs: {len(segs_all)}")
+        _logger.debug(
+            f"All blobs:\n{segs_all}\nTotal blobs: "
+            f"{0 if segs_all is None else len(segs_all)}")
         
         if segs is not None:
             # segs are typically loaded from DB for a sub-ROI within the
             # current ROI, so fill in the padding area from segs_all
+            # TODO: remove since blobs from different sources may be confusing?
             _, segs_in_mask = detector.get_blobs_in_roi(
                 segs_all, np.zeros(3), 
                 roi_size, np.multiply(self.border, -1))


### PR DESCRIPTION
Image regions that are largely empty often have the same upper and lower intensity percentiles, leading to a division by 0 error when saturating the ROI. While this scenario does not occur as frequently in microscopy images because of ambient noise, it occurs more often with heat maps. Blob detection has skipped this saturation step, but the 3D viewer attempts saturation during preprocessing, leading to a `Contour` error because of the NaN "saturated" ROI. This PR fixes this error and other potential NaN saturations by skipping the saturation if the intensity percentiles are the same.

Blob detection in the GUI also led to an error during logging when no blobs were detected, also fixed here.