### PR TITLE
Make blobs columns flexible and encapsulated

### DIFF
--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -38,6 +38,7 @@
 - `ctrl+[n]+click` to add a channel now sets the channel directly to `n` rather than to the `n`th seleted channel (#109)
 - Added a slider to choose the fraction of 3D blobs to display (#121)
 - Improved blob size slider range and readability (#121)
+- Blob columns can be customized, including excluding or reordering columns (#133)
 - Fixed to scale blobs' radii when viewing blobs detections on a downsampled image (#121)
 - Fixed getting atlas colors for blobs for ROIs inside the main image (#121)
 - Fixed blob segmentation for newer versions of Scikit-image (#91)
@@ -80,6 +81,8 @@
 - Stats errors are caught rather than stopping the pipeline (#132)
 
 #### Code base and docs
+
+- Blob column accessors are encapsulated in the `Blobs` class, which allows for flexibility in column inclusion and order (#133)
 
 ### Dependency Updates
 

--- a/magmap/cv/colocalizer.py
+++ b/magmap/cv/colocalizer.py
@@ -403,8 +403,10 @@ def colocalize_blobs(roi, blobs, thresh=None):
                 mask_blob = mask == blobi
                 blob_avg = np.mean(roi[mask_blob, chl_other])
                 if config.verbose:
-                    print(blobi, detector.get_blob_channel(blobs_roi[blobi]),
-                          blobs_roi[blobi, :3], blob_avg, threshs[chl_other])
+                    print(
+                        blobi, detector.Blobs.get_blobs_channel(
+                            blobs_roi[blobi]),
+                        blobs_roi[blobi, :3], blob_avg, threshs[chl_other])
                 if blob_avg >= threshs[chl_other]:
                     # intensities in another channel around blob's position
                     # is above that channel's threshold
@@ -415,7 +417,7 @@ def colocalize_blobs(roi, blobs, thresh=None):
     colocs[blobs_roi_mask] = colocs_roi
     if config.verbose:
         for i, (blob, coloc) in enumerate(zip(blobs_roi, colocs)):
-            print(i, detector.get_blob_channel(blob), blob[:3], coloc)
+            print(i, detector.Blobs.get_blobs_channel(blob), blob[:3], coloc)
     return colocs
 
 

--- a/magmap/cv/colocalizer.py
+++ b/magmap/cv/colocalizer.py
@@ -361,7 +361,7 @@ def colocalize_blobs(roi, blobs, thresh=None):
     # surrounds, but ROI is not available for them
     blobs_roi, blobs_roi_mask = detector.get_blobs_in_roi(
         blobs, (0, 0, 0), roi.shape[:3], reverse=False)
-    blobs_chl = detector.get_blobs_channel(blobs_roi)
+    blobs_chl = detector.Blobs.get_blobs_channel(blobs_roi)
     blobs_range_chls = []
     
     # get labeled masks of blobs for each channel and threshold intensities
@@ -390,7 +390,7 @@ def colocalize_blobs(roi, blobs, thresh=None):
             roi_mask = roi if np.sum(mask_blobs) < 1 else roi[mask_blobs, chl]
             threshs.append(np.percentile(roi_mask, thresh))
 
-    channels = np.unique(detector.get_blobs_channel(blobs_roi)).astype(int)
+    channels = np.unique(detector.Blobs.get_blobs_channel(blobs_roi)).astype(int)
     colocs_roi = np.zeros((blobs_roi.shape[0], roi.shape[3]), dtype=np.uint8)
     for chl in channels:
         # get labeled mask of blobs in the given channel
@@ -446,7 +446,7 @@ def colocalize_blobs_match(
     if inner_padding is None:
         inner_padding = inner_pad
     matches_chls = {}
-    channels = np.unique(detector.get_blobs_channel(blobs)).astype(int)
+    channels = np.unique(detector.Blobs.get_blobs_channel(blobs)).astype(int)
     for chl in channels:
         # pair channels
         blobs_chl = detector.blobs_in_channel(blobs, chl)
@@ -554,13 +554,13 @@ def select_matches(db, channels, offset=None, shape=None, exp_name=None):
             blobs1 = blob_matches.get_blobs(1)
             if blobs1 is None: continue
             chl_matches = BlobMatch(df=blob_matches.df.loc[
-                detector.get_blobs_channel(blobs1) == chl])
+                detector.Blobs.get_blobs_channel(blobs1) == chl])
             
             # also extract only blob1's paired to blob2's in the 2nd channel 
             blobs2 = chl_matches.get_blobs(2)
             if blobs2 is None: continue
             chl_matches.df = chl_matches.df.loc[
-                detector.get_blobs_channel(blobs2) == chl_other]
+                detector.Blobs.get_blobs_channel(blobs2) == chl_other]
             
             # store the matches with chl1-chl2 as key
             matches[(chl, chl_other)] = chl_matches

--- a/magmap/cv/colocalizer.py
+++ b/magmap/cv/colocalizer.py
@@ -465,8 +465,8 @@ def colocalize_blobs_match(
             
             # reset truth and confirmation blob flags in matches
             chl_combo = (chl, chl_other)
-            matches.update_blobs(detector.set_blob_truth, -1)
-            matches.update_blobs(detector.set_blob_confirmed, -1)
+            matches.update_blobs(detector.Blobs.set_blob_truth, -1)
+            matches.update_blobs(detector.Blobs.set_blob_confirmed, -1)
             matches_chls[chl_combo] = matches
     return matches_chls
 

--- a/magmap/cv/colocalizer.py
+++ b/magmap/cv/colocalizer.py
@@ -451,13 +451,13 @@ def colocalize_blobs_match(
     channels = np.unique(detector.Blobs.get_blobs_channel(blobs)).astype(int)
     for chl in channels:
         # pair channels
-        blobs_chl = detector.blobs_in_channel(blobs, chl)
+        blobs_chl = detector.Blobs.blobs_in_channel(blobs, chl)
         for chl_other in channels:
             # prevent duplicates by skipping other channels below given channel
             if chl >= chl_other: continue
             # find colocalizations between blobs from one channel to blobs
             # in another channel
-            blobs_chl_other = detector.blobs_in_channel(blobs, chl_other)
+            blobs_chl_other = detector.Blobs.blobs_in_channel(blobs, chl_other)
             blobs_inner_plus, blobs_truth_inner_plus, offset_inner, \
                 size_inner, matches = verifier.match_blobs_roi(
                     blobs_chl_other, blobs_chl, offset, size, thresh, scaling,

--- a/magmap/cv/detector.py
+++ b/magmap/cv/detector.py
@@ -14,7 +14,7 @@ from enum import Enum
 import math
 import pprint
 from time import time
-from typing import Dict, Optional, Sequence
+from typing import Dict, Optional, Sequence, Union
 
 import numpy as np
 from skimage.feature import blob_log
@@ -258,6 +258,76 @@ class Blobs:
         if blobs.ndim > 1:
             return blobs[..., chli]
         return blobs[chli]
+    
+    @classmethod
+    def set_blob_col(
+            cls, blob: np.ndarray, col: int, val: Union[int, np.ndarray]
+    ) -> np.ndarray:
+        """Set the value for the given column of a blob or blobs.
+
+        Args:
+            blob: 1D blob array or 2D array of blobs.
+            col: Column index in ``blob``.
+            val: New value. If ``blob`` is 2D, can be an array the length
+                of ``blob``.
+
+        Returns:
+            ``blob`` after modifications.
+
+        """
+        if blob.ndim > 1:
+            blob[..., col] = val
+        else:
+            blob[col] = val
+        return blob
+    
+    @classmethod
+    def set_blob_confirmed(
+            cls, blob: np.ndarray, val: Union[int, np.ndarray]) -> np.ndarray:
+        """Set the confirmed flag of a blob or blobs.
+
+        Args:
+            blob: 1D blob array or 2D array of blobs.
+            val: Confirmed value. If ``blob`` is 2D, can be an array the length
+                of ``blob``.
+
+        Returns:
+            ``blob`` after modifications.
+
+        """
+        return cls.set_blob_col(blob, cls.col_inds[cls.Cols.CONFIRMED], val)
+    
+    @classmethod
+    def set_blob_truth(
+            cls, blob: np.ndarray, val: Union[int, np.ndarray]) -> np.ndarray:
+        """Set the truth flag of a blob or blobs.
+
+        Args:
+            blob: 1D blob array or 2D array of blobs.
+            val: Truth value. If ``blob`` is 2D, can be an array the length
+                of ``blob``.
+
+        Returns:
+            ``blob`` after modifications.
+
+        """
+        return Blobs.set_blob_col(blob, cls.col_inds[cls.Cols.TRUTH], val)
+    
+    @classmethod
+    def set_blob_channel(
+            cls, blob: np.ndarray, val: Union[int, np.ndarray]) -> np.ndarray:
+        """Set the channel of a blob or blobs.
+
+        Args:
+            blob: 1D blob array or 2D array of blobs.
+            val: Channel value. If ``blob`` is 2D, can be an array the length
+                of ``blob``.
+
+        Returns:
+            ``blob`` after modifications.
+
+        """
+        return Blobs.set_blob_col(blob, cls.col_inds[cls.Cols.CHANNEL], val)
 
 
 def calc_scaling_factor():
@@ -502,39 +572,6 @@ def get_blob_confirmed(blob):
     return blob[4]
 
 
-def set_blob_col(blob, col, val):
-    """Set the value for the given column of a blob or blobs.
-
-    Args:
-        blob (:class:`numpy.ndarray`): 1D blob array or 2D array of blobs.
-        col (int): Column index in ``blob``.
-        val (int): Truth value.
-    
-    Returns:
-        :class:`numpy.ndarray`: ``blob`` after modifications.
-
-    """
-    if blob.ndim > 1:
-        blob[..., col] = val
-    else:
-        blob[col] = val
-    return blob
-
-
-def set_blob_confirmed(blob, val):
-    """Set the confirmed flag of a blob or blobs.
-
-    Args:
-        blob (:class:`numpy.ndarray`): 1D blob array or 2D array of blobs.
-        val (int): Confirmed flag.
-    
-    Returns:
-        :class:`numpy.ndarray`: ``blob`` after modifications.
-
-    """
-    return set_blob_col(blob, 4, val)
-
-
 def get_blob_truth(blob):
     """Get the truth flag of a blob or blobs.
     
@@ -549,34 +586,6 @@ def get_blob_truth(blob):
     if blob.ndim > 1:
         return blob[..., 5]
     return blob[5]
-
-
-def set_blob_truth(blob, val):
-    """Set the truth flag of a blob or blobs.
-
-    Args:
-        blob (:class:`numpy.ndarray`): 1D blob array or 2D array of blobs.
-        val (int): Truth value.
-    
-    Returns:
-        :class:`numpy.ndarray`: ``blob`` after modifications.
-
-    """
-    return set_blob_col(blob, 5, val)
-
-
-def set_blob_channel(blob, val):
-    """Set the channel of a blob or blobs.
-
-    Args:
-        blob (:class:`numpy.ndarray`): 1D blob array or 2D array of blobs.
-        val (int): Channel value.
-    
-    Returns:
-        :class:`numpy.ndarray`: ``blob`` after modifications.
-
-    """
-    return set_blob_col(blob, 6, val)
 
 
 def replace_rel_with_abs_blob_coords(blobs):

--- a/magmap/cv/detector.py
+++ b/magmap/cv/detector.py
@@ -242,22 +242,66 @@ class Blobs:
         return blobs_arc
     
     @classmethod
-    def get_blobs_channel(cls, blobs: np.ndarray) -> np.ndarray:
-        """Get the blobs' channels.
-                
+    def get_blob_col(
+            cls, blob: np.ndarray, col: int) -> Union[int, float, np.ndarray]:
+        """Get the value for the given column of a blob or blobs.
+
         Args:
-            blobs: Blobs array, which can be a 1D array of one blob or a
-                2D array of multiple blobs.
+            blob: 1D blob array or 2D array of blobs.
+            col: Column index in ``blob``.
 
         Returns:
-            Array of channels.
+            Single value if ``blob`` is a single blob or array of values if
+            it is an array of blobs.
+
+        """
+        if blob.ndim > 1:
+            return blob[..., col]
+        return blob[col]
+    
+    @classmethod
+    def get_blob_confirmed(
+            cls, blob: np.ndarray) -> Union[int, float, np.ndarray]:
+        """Get the confirmed value for blob or blobs.
+
+        Args:
+            blob: 1D blob array or 2D array of blobs.
+
+        Returns:
+            Single value if ``blob`` is a single blob or array of values if
+            it is an array of blobs.
+
+        """
+        return cls.get_blob_col(blob, cls.col_inds[cls.Cols.CONFIRMED])
+    
+    @classmethod
+    def get_blob_truth(cls, blob: np.ndarray) -> Union[int, float, np.ndarray]:
+        """Get the truth value for blob or blobs.
+
+        Args:
+            blob: 1D blob array or 2D array of blobs.
+
+        Returns:
+            Single value if ``blob`` is a single blob or array of values if
+            it is an array of blobs.
+
+        """
+        return cls.get_blob_col(blob, cls.col_inds[cls.Cols.TRUTH])
+
+    @classmethod
+    def get_blobs_channel(cls, blob: np.ndarray) -> np.ndarray:
+        """Get the channel value for blob or blobs.
+        
+        Args:
+            blob: 1D blob array or 2D array of blobs.
+
+        Returns:
+            Single value if ``blob`` is a single blob or array of values if
+            it is an array of blobs.
 
         """
         # get the channel index from the class attribute of indices
-        chli = cls.col_inds[cls.Cols.CHANNEL]
-        if blobs.ndim > 1:
-            return blobs[..., chli]
-        return blobs[chli]
+        return cls.get_blob_col(blob, cls.col_inds[cls.Cols.CHANNEL])
     
     @classmethod
     def set_blob_col(
@@ -564,28 +608,6 @@ def multiply_blob_abs_coords(blobs, factor):
         abs_coords = blobs[..., abs_slice] * factor
         blobs[..., abs_slice] = abs_coords.astype(np.int)
     return blobs
-
-
-def get_blob_confirmed(blob):
-    if blob.ndim > 1:
-        return blob[..., 4]
-    return blob[4]
-
-
-def get_blob_truth(blob):
-    """Get the truth flag of a blob or blobs.
-    
-    Args:
-        blob (:obj:`np.ndarray`): 1D blob array or 2D array of blobs.
-
-    Returns:
-        int or :obj:`np.ndarray`: The truth flag of the blob as an int
-        for a single blob or array of truth flags for an array of blobs. 
-
-    """
-    if blob.ndim > 1:
-        return blob[..., 5]
-    return blob[5]
 
 
 def replace_rel_with_abs_blob_coords(blobs):

--- a/magmap/cv/detector.py
+++ b/magmap/cv/detector.py
@@ -196,6 +196,19 @@ class Blobs:
         if config.verbose:
             pprint.pprint(blobs_arc)
         return blobs_arc
+    
+    @staticmethod
+    def get_blobs_channel(blobs: np.ndarray) -> np.ndarray:
+        """Get the blobs' channels.
+                
+        Args:
+            blobs: Blobs array.
+
+        Returns:
+            Array of channels.
+
+        """
+        return blobs[:, 6]
 
 
 def calc_scaling_factor():
@@ -507,9 +520,6 @@ def get_blob_channel(blob):
     return blob[6]
 
 
-def get_blobs_channel(blobs):
-    return blobs[:, 6]
-
 
 def set_blob_channel(blob, val):
     """Set the channel of a blob or blobs.
@@ -547,7 +557,7 @@ def blobs_in_channel(blobs, channel, return_mask=False):
     blobs_chl = blobs
     mask = None
     if channel is not None:
-        mask = np.isin(get_blobs_channel(blobs), channel)
+        mask = np.isin(Blobs.get_blobs_channel(blobs), channel)
         blobs_chl = blobs[mask]
     if return_mask:
         return blobs_chl, mask
@@ -879,7 +889,7 @@ def show_blobs_per_channel(blobs):
     Args:
         blobs: Blobs as 2D array of [n, [z, row, column, radius, ...]].
     """
-    channels = np.unique(get_blobs_channel(blobs))
+    channels = np.unique(Blobs.get_blobs_channel(blobs))
     for channel in channels:
         num_blobs = len(blobs_in_channel(blobs, channel))
         print("- blobs in channel {}: {}".format(int(channel), num_blobs))

--- a/magmap/cv/stack_detect.py
+++ b/magmap/cv/stack_detect.py
@@ -439,7 +439,7 @@ def detect_blobs_blocks(filename_base, image5d, offset, size, channels,
         if coloc:
             colocs = segments_all[:, 10:10+num_chls_roi].astype(np.uint8)
         # remove absolute coordinate and any co-localization columns
-        segments_all = detector.remove_abs_blob_coords(segments_all)
+        segments_all = detector.Blobs.remove_abs_blob_coords(segments_all, True)
         
         # compare detected blobs with truth blobs
         # TODO: assumes ground truth is relative to any ROI offset,

--- a/magmap/cv/stack_detect.py
+++ b/magmap/cv/stack_detect.py
@@ -484,7 +484,7 @@ def detect_blobs_blocks(filename_base, image5d, offset, size, channels,
         print("\nNo blobs detected")
     else:
         print("\nTotal blobs found:", len(segments_all))
-        detector.show_blobs_per_channel(segments_all)
+        detector.Blobs.show_blobs_per_channel(segments_all)
     print("\nTotal detection processing times (s):")
     path_times = "stack_detection_times.csv" if save_dfs else None
     df_io.dict_to_data_frame(times_dict, path_times, show=" ")
@@ -555,7 +555,7 @@ def detect_blobs_stack(filename_base, subimg_offset, subimg_size, coloc=False):
             print("\nNo blobs found across channels")
         else:
             print("\nTotal blobs found across channels:", len(blobs_all.blobs))
-            detector.show_blobs_per_channel(blobs_all.blobs)
+            detector.Blobs.show_blobs_per_channel(blobs_all.blobs)
         blobs_all.colocalizations = libmag.combine_arrs(
             [b.colocalizations for b in detection_out["blobs"]
              if b.colocalizations is not None])
@@ -675,7 +675,7 @@ class StackPruner(object):
         for i in channels:
             # prune blobs from each channel separately to avoid pruning based on 
             # co-localized channel signals
-            blobs = detector.blobs_in_channel(blobs_merged, i)
+            blobs = detector.Blobs.blobs_in_channel(blobs_merged, i)
             for axis in range(3):
                 # prune planes with all the overlapping regions within a given axis,
                 # skipping if this axis has no overlapping sub-regions

--- a/magmap/cv/stack_detect.py
+++ b/magmap/cv/stack_detect.py
@@ -160,8 +160,8 @@ class StackDetector(object):
             # absolute positioning, using the latter set to store shifted 
             # coordinates based on duplicates and the former for initial 
             # positions to check for multiple duplicates
-            detector.shift_blob_rel_coords(segments, offset)
-            detector.shift_blob_abs_coords(segments, offset)
+            detector.Blobs.shift_blob_rel_coords(segments, offset)
+            detector.Blobs.shift_blob_abs_coords(segments, offset)
             #print("segs after:\n{}".format(segments))
         return coord, segments
     
@@ -435,7 +435,7 @@ def detect_blobs_blocks(filename_base, image5d, offset, size, channels,
     colocs = None
     if segments_all is not None:
         # remove the duplicated elements that were used for pruning
-        detector.replace_rel_with_abs_blob_coords(segments_all)
+        detector.Blobs.replace_rel_with_abs_blob_coords(segments_all)
         if coloc:
             colocs = segments_all[:, 10:10+num_chls_roi].astype(np.uint8)
         # remove absolute coordinate and any co-localization columns

--- a/magmap/cv/verifier.py
+++ b/magmap/cv/verifier.py
@@ -245,9 +245,9 @@ def match_blobs_roi(blobs, blobs_base, offset, size, thresh, scaling,
                 for match in matches_sub:
                     _logger.debug(
                         f"Blob1: {match[0][:3]}, chl: "
-                        f"{detector.get_blob_channel(match[0])}, "
+                        f"{detector.Blobs.get_blobs_channel(match[0])}, "
                         f"Blob2: {match[1][:3]}, "
-                        f"chl: {detector.get_blob_channel(match[1])}, "
+                        f"chl: {detector.Blobs.get_blobs_channel(match[1])}, "
                         f"dist: {match[2]}")
             _logger.debug("\n")
     

--- a/magmap/cv/verifier.py
+++ b/magmap/cv/verifier.py
@@ -291,7 +291,7 @@ def verify_rois(rois, blobs, blobs_truth, tol, output_db, exp_id, exp_name,
         metrics in a data frame.
     
     """
-    blobs_truth = detector.blobs_in_channel(blobs_truth, channel)
+    blobs_truth = detector.Blobs.blobs_in_channel(blobs_truth, channel)
     blobs_truth_rois = None
     blobs_rois = None
     rois_falsehood = []

--- a/magmap/cv/verifier.py
+++ b/magmap/cv/verifier.py
@@ -131,7 +131,7 @@ def setup_match_blobs_roi(
     # resize blobs based only on first profile
     resize = config.get_roi_profile(0)["resize_blobs"]
     if resize and blobs is not None:
-        blobs = detector.multiply_blob_rel_coords(blobs, resize)
+        blobs = detector.Blobs.multiply_blob_rel_coords(blobs, resize)
         libmag.log_once(_logger.debug, f"resized blobs by {resize}:\n{blobs}")
     
     return thresh, scaling, inner_padding, resize, blobs
@@ -177,9 +177,9 @@ def match_blobs_roi(blobs, blobs_base, offset, size, thresh, scaling,
         padding = config.plot_labels[config.PlotLabels.PADDING]
         libmag.printv("shifting blobs in ROI by offset {}, border {}"
                       .format(offset, padding))
-        blobs_roi = detector.shift_blob_rel_coords(blobs_roi, offset)
+        blobs_roi = detector.Blobs.shift_blob_rel_coords(blobs_roi, offset)
         if padding:
-            blobs_roi = detector.shift_blob_rel_coords(blobs_roi, padding)
+            blobs_roi = detector.Blobs.shift_blob_rel_coords(blobs_roi, padding)
     blobs_inner, blobs_inner_mask = detector.get_blobs_in_roi(
         blobs_roi, offset_inner, size_inner)
     blobs_base_roi, _ = detector.get_blobs_in_roi(blobs_base, offset, size)

--- a/magmap/gui/roi_editor.py
+++ b/magmap/gui/roi_editor.py
@@ -1294,7 +1294,7 @@ class ROIEditor(plot_support.ImageSyncMixin):
                     segments_z = segs_in[segs_in[:, 0] == z_relative]
                     if segs_out_z is not None:
                         segs_out_z_confirmed = segs_out_z[
-                            detector.get_blob_confirmed(segs_out_z) == 1]
+                            detector.Blobs.get_blob_confirmed(segs_out_z) == 1]
                         if len(segs_out_z_confirmed) > 0:
                             # include confirmed blobs; TODO: show contextual
                             # circles in adjacent planes?
@@ -1388,7 +1388,7 @@ class ROIEditor(plot_support.ImageSyncMixin):
         """
         channel = detector.Blobs.get_blobs_channel(segment)
         facecolor = DraggableCircle.BLOB_COLORS[
-            detector.get_blob_confirmed(segment)]
+            detector.Blobs.get_blob_confirmed(segment)]
         if linestyle is None:
             linestyle = self._BLOB_LINESTYLES[channel]
         circle = patches.Circle(

--- a/magmap/gui/roi_editor.py
+++ b/magmap/gui/roi_editor.py
@@ -771,7 +771,7 @@ class ROIEditor(plot_support.ImageSyncMixin):
                                          event.xdata.astype(int), -5]])
                         blob = detector.format_blobs(blob, blob_channel)
                         detector.shift_blob_abs_coords(blob, offset[::-1])
-                        detector.set_blob_confirmed(blob, 1)
+                        detector.Blobs.set_blob_confirmed(blob, 1)
                         blob = fn_update_seg(blob[0])
                         # adds a circle to denote the new segment
                         patch = self._plot_circle(

--- a/magmap/gui/roi_editor.py
+++ b/magmap/gui/roi_editor.py
@@ -1386,7 +1386,7 @@ class ROIEditor(plot_support.ImageSyncMixin):
         Returns:
             The DraggableCircle object.
         """
-        channel = detector.get_blob_channel(segment)
+        channel = detector.Blobs.get_blobs_channel(segment)
         facecolor = DraggableCircle.BLOB_COLORS[
             detector.get_blob_confirmed(segment)]
         if linestyle is None:
@@ -1453,7 +1453,7 @@ class ROIEditor(plot_support.ImageSyncMixin):
                         blob[2], blob[1],
                         ",".join([str(c) for c in np.where(coloc > 0)[0]]),
                         color="C{}".format(
-                            int(detector.get_blob_channel(blob))),
+                            int(detector.Blobs.get_blobs_channel(blob))),
                         alpha=0.8, horizontalalignment="center",
                         verticalalignment="center"))
         self.fig.canvas.draw_idle()

--- a/magmap/gui/roi_editor.py
+++ b/magmap/gui/roi_editor.py
@@ -769,7 +769,7 @@ class ROIEditor(plot_support.ImageSyncMixin):
                         blob = np.array([[axi - self._z_planes_padding,
                                          event.ydata.astype(int),
                                          event.xdata.astype(int), -5]])
-                        blob = detector.format_blobs(blob, blob_channel)
+                        blob = detector.Blobs.format_blobs(blob, blob_channel)
                         detector.Blobs.shift_blob_abs_coords(blob, offset[::-1])
                         detector.Blobs.set_blob_confirmed(blob, 1)
                         blob = fn_update_seg(blob[0])

--- a/magmap/gui/roi_editor.py
+++ b/magmap/gui/roi_editor.py
@@ -770,7 +770,7 @@ class ROIEditor(plot_support.ImageSyncMixin):
                                          event.ydata.astype(int),
                                          event.xdata.astype(int), -5]])
                         blob = detector.format_blobs(blob, blob_channel)
-                        detector.shift_blob_abs_coords(blob, offset[::-1])
+                        detector.Blobs.shift_blob_abs_coords(blob, offset[::-1])
                         detector.Blobs.set_blob_confirmed(blob, 1)
                         blob = fn_update_seg(blob[0])
                         # adds a circle to denote the new segment
@@ -803,7 +803,7 @@ class ROIEditor(plot_support.ImageSyncMixin):
                     seg_new = fn_update_seg(seg_new, seg_old)
                 else:
                     print("Pasting a copied in segment")
-                    detector.shift_blob_abs_coords(seg_new, (dz, 0, 0))
+                    detector.Blobs.shift_blob_abs_coords(seg_new, (dz, 0, 0))
                     seg_new = fn_update_seg(seg_new)
                 self._plot_circle(
                     inax, seg_new, self._BLOB_LINEWIDTH, None, fn_update_seg)
@@ -1286,7 +1286,7 @@ class ROIEditor(plot_support.ImageSyncMixin):
                             # adjusting rel and abs z coords to the given plane
                             z_diff = z_relative - seg[0]
                             seg[0] = z_relative
-                            detector.shift_blob_abs_coords(
+                            detector.Blobs.shift_blob_abs_coords(
                                 segments_z[i], (z_diff, 0, 0))
                             segments_z[i] = fn_update_seg(seg)
                 else:

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -2208,7 +2208,7 @@ class Visualization(HasTraits):
             # un-annotated blob
             confirmed = detector.get_blob_confirmed(segs_all)
             confirmed[confirmed == -1] = self._segs_labels[0]
-            detector.set_blob_confirmed(segs_all, confirmed)
+            detector.Blobs.set_blob_confirmed(segs_all, confirmed)
             
             # convert segments to visualizer table format and plot
             self.segments = detector.shift_blob_abs_coords(
@@ -2954,7 +2954,7 @@ class Visualization(HasTraits):
     
     def _flag_seg_for_deletion(self, seg):
         seg[3] = -1 * abs(seg[3])
-        detector.set_blob_confirmed(seg, -1)
+        detector.Blobs.set_blob_confirmed(seg, -1)
     
     def update_segment(self, segment_new, segment_old=None, remove=False):
         """Update this class object's segments list with a new or updated 

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -973,7 +973,7 @@ class Visualization(HasTraits):
         if config.blobs is not None and config.blobs.blobs is not None:
             # set detection channels to those in loaded blobs
             self._segs_chls_names.selections = [
-                str(n) for n in np.unique(detector.get_blobs_channel(
+                str(n) for n in np.unique(detector.Blobs.get_blobs_channel(
                     config.blobs.blobs).astype(int))]
         else:
             # add detection channel selectors for all image channels
@@ -2252,7 +2252,7 @@ class Visualization(HasTraits):
             
             else:
                 # default to color by channel
-                chls = detector.get_blobs_channel(
+                chls = detector.Blobs.get_blobs_channel(
                     segs_all[self.segs_in_mask]).astype(np.int)
                 cmap = colormaps.discrete_colormap(
                     max(chls) + 1, alpha, True, config.seed)
@@ -2730,7 +2730,7 @@ class Visualization(HasTraits):
             blobs = config.db.select_blobs_by_roi(roi_id)[0]
             if len(blobs) > 0:
                 # change to single-channel if all blobs are from same channel
-                chls = np.unique(detector.get_blobs_channel(blobs))
+                chls = np.unique(detector.Blobs.get_blobs_channel(blobs))
                 if len(chls) == 1:
                     self._channel = [str(int(chls[0]))]
             

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -1325,7 +1325,7 @@ class Visualization(HasTraits):
             for i in range(len(self.segments)):
                 seg = self.segments[i]
                 # uses absolute coordinates from end of seg
-                seg_db = detector.blob_for_db(seg)
+                seg_db = detector.Blobs.blob_for_db(seg)
                 if seg[4] == -1 and seg[3] < config.POS_THRESH:
                     # attempts to delete user added segments, where radius
                     # assumed to be < 0, that are no longer selected
@@ -1382,7 +1382,8 @@ class Visualization(HasTraits):
         # delete the original entry of blobs that moved since replacement
         # is based on coordinates, so moved blobs wouldn't be replaced
         for i in range(len(self._segs_moved)):
-            self._segs_moved[i] = detector.blob_for_db(self._segs_moved[i])
+            self._segs_moved[i] = detector.Blobs.blob_for_db(
+                self._segs_moved[i])
         sqlite.delete_blobs(
             config.db.conn, config.db.cur, roi_id, self._segs_moved)
         self._segs_moved = []
@@ -1394,7 +1395,7 @@ class Visualization(HasTraits):
         # insert blob matches
         if self.blobs.blob_matches is not None:
             self.blobs.blob_matches.update_blobs(
-                detector.shift_blob_rel_coords, offset[::-1])
+                detector.Blobs.shift_blob_rel_coords, offset[::-1])
             config.db.insert_blob_matches(roi_id, self.blobs.blob_matches)
         
         # add ROI to selection dropdown
@@ -2170,9 +2171,10 @@ class Visualization(HasTraits):
                     # shift blobs to relative coordinates
                     matches = matches[tuple(matches.keys())[0]]
                     shift = [n * -1 for n in roi[0]]
-                    matches.update_blobs(detector.shift_blob_rel_coords, shift)
                     matches.update_blobs(
-                        detector.multiply_blob_rel_coords,
+                        detector.Blobs.shift_blob_rel_coords, shift)
+                    matches.update_blobs(
+                        detector.Blobs.multiply_blob_rel_coords,
                         config.blobs.scaling[:3])
                     matches.get_mean_coords()
                     self.blobs.blob_matches = matches
@@ -2211,7 +2213,7 @@ class Visualization(HasTraits):
             detector.Blobs.set_blob_confirmed(segs_all, confirmed)
             
             # convert segments to visualizer table format and plot
-            self.segments = detector.shift_blob_abs_coords(
+            self.segments = detector.Blobs.shift_blob_abs_coords(
                 segs_all, offset[::-1])
             self.blobs.blobs = self.segments
             if colocs is not None:
@@ -2738,7 +2740,7 @@ class Visualization(HasTraits):
             # get matches between blobs, such as verifications
             blob_matches = config.db.select_blob_matches(roi_id)
             blob_matches.update_blobs(
-                detector.shift_blob_rel_coords,
+                detector.Blobs.shift_blob_rel_coords,
                 [n * -1 for n in config.roi_offset[::-1]])
             
             # display blobs
@@ -2997,7 +2999,7 @@ class Visualization(HasTraits):
             # TODO: consider requiring new seg to already have abs coord updated
             self._segs_moved.append(segment_old)
             diff = np.subtract(seg[:3], segment_old[:3])
-            detector.shift_blob_abs_coords(seg, diff)
+            detector.Blobs.shift_blob_abs_coords(seg, diff)
             segi = self._get_vis_segments_index(segment_old)
             if segi == -1:
                 # try to find old blob from deleted blobs

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -2154,7 +2154,7 @@ class Visualization(HasTraits):
             
             # shift coordinates to be relative to offset
             segs_all[:, :3] = np.subtract(segs_all[:, :3], offset[::-1])
-            segs_all = detector.format_blobs(segs_all)
+            segs_all = detector.Blobs.format_blobs(segs_all)
             segs_all, mask_chl = detector.Blobs.blobs_in_channel(
                 segs_all, chls, return_mask=True)
             
@@ -2201,7 +2201,7 @@ class Visualization(HasTraits):
             segs_outside = segs_all[np.logical_not(segs_in_mask)]
             print("segs_outside:\n{}".format(segs_outside))
             segs[:, :3] = np.subtract(segs[:, :3], offset[::-1])
-            segs = detector.format_blobs(segs)
+            segs = detector.Blobs.format_blobs(segs)
             segs = detector.Blobs.blobs_in_channel(segs, chls)
             segs_all = np.concatenate((segs, segs_outside), axis=0)
             

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -2244,8 +2244,9 @@ class Visualization(HasTraits):
                     return atlas_cmap
                 
                 # set up colormaps for blobs and blob matches
-                self.segs_cmap = get_atlas_cmap(detector.get_blob_abs_coords(
-                    segs_all[self.segs_in_mask]))
+                self.segs_cmap = get_atlas_cmap(
+                    detector.Blobs.get_blob_abs_coords(
+                        segs_all[self.segs_in_mask]))
                 if self.blobs.blob_matches is not None:
                     self.blobs.blob_matches.cmap = get_atlas_cmap(
                         np.add(self.blobs.blob_matches.coords, offset[::-1]))

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -2154,7 +2154,7 @@ class Visualization(HasTraits):
             # shift coordinates to be relative to offset
             segs_all[:, :3] = np.subtract(segs_all[:, :3], offset[::-1])
             segs_all = detector.format_blobs(segs_all)
-            segs_all, mask_chl = detector.blobs_in_channel(
+            segs_all, mask_chl = detector.Blobs.blobs_in_channel(
                 segs_all, chls, return_mask=True)
             
             if ColocalizeOptions.MATCHES.value in self._colocalize:
@@ -2200,7 +2200,7 @@ class Visualization(HasTraits):
             print("segs_outside:\n{}".format(segs_outside))
             segs[:, :3] = np.subtract(segs[:, :3], offset[::-1])
             segs = detector.format_blobs(segs)
-            segs = detector.blobs_in_channel(segs, chls)
+            segs = detector.Blobs.blobs_in_channel(segs, chls)
             segs_all = np.concatenate((segs, segs_outside), axis=0)
             
         if segs_all is not None:

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -1291,7 +1291,7 @@ class Visualization(HasTraits):
         seg_str = seg[0:3].astype(int).astype(str).tolist()
         seg_str.append(str(round(seg[3], 3)))
         seg_str.append(str(int(detector.get_blob_confirmed(seg))))
-        seg_str.append(str(int(detector.get_blob_channel(seg))))
+        seg_str.append(str(int(detector.Blobs.get_blobs_channel(seg))))
         return ", ".join(seg_str)
     
     def _append_roi(self, roi, rois_dict):

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -1290,7 +1290,7 @@ class Visualization(HasTraits):
         """
         seg_str = seg[0:3].astype(int).astype(str).tolist()
         seg_str.append(str(round(seg[3], 3)))
-        seg_str.append(str(int(detector.get_blob_confirmed(seg))))
+        seg_str.append(str(int(detector.Blobs.get_blob_confirmed(seg))))
         seg_str.append(str(int(detector.Blobs.get_blobs_channel(seg))))
         return ", ".join(seg_str)
     
@@ -1354,7 +1354,7 @@ class Visualization(HasTraits):
             # unverified blobs are those with default confirmation setting 
             # and radius > 0, where radii < 0 would indicate a user-added circle
             unverified = np.logical_and(
-                detector.get_blob_confirmed(segs_transposed_np) == -1, 
+                detector.Blobs.get_blob_confirmed(segs_transposed_np) == -1, 
                 np.logical_not(segs_transposed_np[:, 3] < config.POS_THRESH))
         if np.any(unverified):
             # show missing verifications
@@ -2206,7 +2206,7 @@ class Visualization(HasTraits):
         if segs_all is not None:
             # set confirmation flag to user-selected label for any
             # un-annotated blob
-            confirmed = detector.get_blob_confirmed(segs_all)
+            confirmed = detector.Blobs.get_blob_confirmed(segs_all)
             confirmed[confirmed == -1] = self._segs_labels[0]
             detector.Blobs.set_blob_confirmed(segs_all, confirmed)
             

--- a/magmap/io/export_regions.py
+++ b/magmap/io/export_regions.py
@@ -278,7 +278,7 @@ def make_density_image(
         _logger.info(
             "Using blobs from channel(s), combining if multiple channels: %s",
             channel)
-        blobs_chl = blobs_chl[np.isin(detector.get_blobs_channel(
+        blobs_chl = blobs_chl[np.isin(detector.Blobs.get_blobs_channel(
             blobs_chl), channel)]
     heat_map = make_heat_map()
     imgs_write = {

--- a/magmap/io/export_rois.py
+++ b/magmap/io/export_rois.py
@@ -134,7 +134,7 @@ def export_rois(db, image5d, channel, path, padding=None, unit_factor=None,
                 img3d = cv_nd.make_isotropic(img3d, isotropic)
                 isotropic_factor = cv_nd.calc_isotropic_factor(isotropic)
                 blobs_orig = np.copy(blobs)
-                blobs = detector.multiply_blob_rel_coords(
+                blobs = detector.Blobs.multiply_blob_rel_coords(
                     blobs, isotropic_factor)
             
             # export ROI and 2D plots

--- a/magmap/io/export_rois.py
+++ b/magmap/io/export_rois.py
@@ -109,14 +109,14 @@ def export_rois(db, image5d, channel, path, padding=None, unit_factor=None,
                 # verified DBs use a truth value of -1 to indicate "detected",
                 # non-truth blobs, including both correct and incorrect 
                 # detections, while the rest of blobs are "truth" blobs
-                truth_vals = detector.get_blob_truth(blobs)
+                truth_vals = detector.Blobs.get_blob_truth(blobs)
                 blobs_detected = blobs[truth_vals == -1]
                 blobs = blobs[truth_vals != -1]
             else:
                 # default to include only confirmed blobs; truth sets 
                 # ironically do not use the truth flag but instead
                 # assume all confirmed blobs are "truth"
-                blobs = blobs[detector.get_blob_confirmed(blobs) == 1]
+                blobs = blobs[detector.Blobs.get_blob_confirmed(blobs) == 1]
             blobs[:, 4] = -1
             
             # adjust ROI size and offset if border set

--- a/magmap/io/np_io.py
+++ b/magmap/io/np_io.py
@@ -300,7 +300,7 @@ def setup_images(
                         img_to_blobs_path(filename_base))
                     blobs.blobs, _ = detector.get_blobs_in_roi(
                         blobs.blobs, offset, size, reverse=False)
-                    detector.shift_blob_rel_coords(
+                    detector.Blobs.shift_blob_rel_coords(
                         blobs.blobs, np.multiply(offset, -1))
             else:
                 # load full image blobs

--- a/magmap/io/sqlite.py
+++ b/magmap/io/sqlite.py
@@ -374,7 +374,7 @@ def insert_blobs(conn, cur, roi_id, blobs):
         blob_entry.extend(blob)
         #print("blob type:\n{}".format(blob.dtype))
         blobs_list.append(blob_entry)
-        if detector.get_blob_confirmed(blob) == 1:
+        if detector.Blobs.get_blob_confirmed(blob) == 1:
             confirmed += 1
     #print(match_elements(_COLS_BLOBS, ", ", "?"))
     cur.executemany("INSERT OR REPLACE INTO blobs ({}) VALUES ({})"

--- a/magmap/io/sqlite.py
+++ b/magmap/io/sqlite.py
@@ -399,7 +399,7 @@ def delete_blobs(conn, cur, roi_id, blobs):
     """
     deleted = 0
     for blob in blobs:
-        blob_entry = [roi_id, *blob[:3], detector.get_blob_channel(blob)]
+        blob_entry = [roi_id, *blob[:3], detector.Blobs.get_blobs_channel(blob)]
         print("attempting to delete blob {}".format(blob))
         cur.execute("DELETE FROM blobs WHERE roi_id = ? AND z = ? AND y = ? "
                     "AND x = ? AND channel = ?", blob_entry)


### PR DESCRIPTION
Blob detections have been represented in MagellanMapper as a 2D NumPy array. The array's columns grew from `z, y, x, radius` to include `truth_flag, confirmation_flag, channel` and later `abs_z, abs_y, abs_x`. While accessing columns started with indexing these known positions, it was inherently error-prone because the indices were numeric rather than named, and the number of columns in the array could change based on the current task or if older versions of the blobs were loaded. Eventually, blobs column accessor functions were added, which used "standard" column indices so that they would not need to be remembered by index value. They assumed that the blob columns were set up to "standard" format, however, and did not allow flexibility in the number of columns. This lack of flexibility meant that most blob archives include the `truth` and `confirmation` flags even though they are only used for blob verification.

To address these issues with column flexibility and access, we have added a way to track columns included in each archive and their order. This approach builds upon encapsulation in the `Blobs` class by adding attributes to define the columns in the blobs array and moving all the column accessors into the class to access columns by these custom positions. Rather than accessing columns by their "standard" positions, they look up the custom columns to find the appropriate index. Columns continue to default to the same "standard" order set before.

Prior to introducing the `Blobs` class, the array was accessed directly. Many functions continue to operate without accessing the class. To support these functions, the custom columns attributes and functions have been set as a class rather than an instance attribute so they can be accessed without a `Blobs` instance. Column indices can thus be set while loading a blobs archive for all blobs access. The drawback is that all blobs will be accessed the same way, which we plan to address by eventually migrating all functions to operate through `Blobs` instances.