### PR TITLE
Fix computing independent t-test in Clrstats

### DIFF
--- a/clrstats/DESCRIPTION
+++ b/clrstats/DESCRIPTION
@@ -16,8 +16,5 @@ Imports:
   optparse,
   tryCatchLog
 Suggests:
-  dplyr,
-  tidyr,
-  purrr,
-  rstatix
+  effectsize
 RoxygenNote: 6.1.1

--- a/clrstats/DESCRIPTION
+++ b/clrstats/DESCRIPTION
@@ -15,4 +15,9 @@ Imports:
   corrplot,
   optparse,
   tryCatchLog
+Suggests:
+  dplyr,
+  tidyr,
+  purrr,
+  rstatix
 RoxygenNote: 6.1.1

--- a/clrstats/R/clrstats.R
+++ b/clrstats/R/clrstats.R
@@ -892,10 +892,6 @@ setupConfig <- function(name=NULL) {
     config.env$GroupCol <- "Geno"
     config.env$JitterLabels <- TRUE
     
-  } else if (name == "mann.whitney") {
-    # Mann-Whitney or Wilcoxon rank-sum test 
-    config.env$Model <- kModel[6]
-    
   } else if (name == "lessstringent") {
     # compare 2 genotypes with slightly less stringent tests
     setupConfig("benjamini.hochman")

--- a/clrstats/R/clrstats.R
+++ b/clrstats/R/clrstats.R
@@ -212,13 +212,12 @@ meansModel <- function(vals, conditions, model, paired=FALSE, reverse=FALSE) {
       result <- wilcox.test(
         val.conds[[2]], val.conds[[1]], paired=paired, conf.int=TRUE)
   
-      # calculate the standardized effect size, given as z / sqrt(N),
-      # where N = number of pairs
-      eff <- result[[col.effect]]
-      effect.raw <- eff
+      # replace the main effect with a standardized effect size, given as
+      # z / sqrt(N), where N = number of pairs
+      effect.raw <- result[[col.effect]]
       result[col.effect] <- rcompanion::wilcoxonZ(
         val.conds[[2]], val.conds[[1]], paired=paired) / sqrt(num.per.cond)
-      cat("Wilcoxon estimate: ", eff, ", standardized effect: ",
+      cat("Wilcoxon estimate: ", effect.raw, ", standardized effect: ",
           result[[col.effect]], "\n", sep="")
   
     } else if (model == kModel[9]) {
@@ -247,11 +246,12 @@ meansModel <- function(vals, conditions, model, paired=FALSE, reverse=FALSE) {
     # store raw effect if it was standardized; otherwise, leave same as effect
     coef.tab$Value.raw <- effect.raw
   }
-  # get relative confidence intervals as pos vals
   if (is.element("conf.int", names(result))) {
+    # convert confidence intervals from absolute vals to relative, positive
+    # vals for Matplotlib
     ci <- result$conf.int
-    coef.tab$CI.low <- effect - ci[1]
-    coef.tab$CI.hi <- ci[2] - effect
+    coef.tab$CI.low <- coef.tab$Value.raw - ci[1]
+    coef.tab$CI.hi <- ci[2] - coef.tab$Value.raw
   }
   coef.tab$P <- result$p.value
   coef.tab$N <- num.per.cond

--- a/clrstats/R/clrstats.R
+++ b/clrstats/R/clrstats.R
@@ -674,7 +674,7 @@ calcVolStats <- function(
   
   if (is.null(region.ids)) {
     # get regions columns from main df
-    cols <- c("Region", "RegionName", "Level")
+    cols <- c("Region", "RegionName", "RegionAbbr", "Level")
     cols <- cols[cols %in% colnames(df)]
     region.ids <- unique(df[cols])
   } else {
@@ -1083,7 +1083,7 @@ runStats <- function(path=NULL, profiles=NULL, measurements=NULL, prefix=NULL,
       
       if (!is.null(stats) & config.env$PlotVolcano) {
         # plot effects and p's
-        volcanoPlot(stats, meas, stat, c(NA, 1.3, 0.2), config.env$VolcanoLogX, 
+        volcanoPlot(stats, meas, stat, c(NA, 1.3, NA), config.env$VolcanoLogX, 
                     config.env$VolcanoLabels, config.env$PlotSize, 
                     meas.names=kMeasNames)
         volcanoPlot(stats, meas, "sidesR", c(25, 2.5, 0.2), 

--- a/clrstats/R/clrstats.R
+++ b/clrstats/R/clrstats.R
@@ -20,7 +20,8 @@ kStatTypes <- c(
 # statistical models
 kModel <- c(
   "logit", "linregr", "gee", "logit.ord", "ttest",
-  "wilcoxon", "ttest.paired", "wilcoxon.paired", "fligner", "basic")
+  "wilcoxon", "ttest.paired", "wilcoxon.paired", "fligner", "basic",
+  "diff.mean")
 
 # measurements, which correspond to columns in main data frame
 kMeas <- c(
@@ -236,6 +237,12 @@ meansModel <- function(vals, conditions, model, paired=FALSE, reverse=FALSE) {
       result <- fligner.test(vals, conditions)
       effect <- result[["statistic"]]
   
+    } else if (model == kModel[11]) {
+      # difference of means
+      effect <- mean(
+        val.conds[[2]], na.rm=TRUE) - mean(val.conds[[1]], na.rm=TRUE)
+      result <- list(estimate=effect, p.value=NA)
+  
     } else {
       cat("Sorry, model", model, "not found\n")
     }
@@ -372,9 +379,10 @@ statsByRegion <- function(df, col, model, split.by.side=TRUE,
   #   group.col: Name of group column; defaults to NULL, which uses "Condition"
   #     for means models and "Geno" otherwise.
   
+  mean_model_inds <- c(5:9, 11)
   if (is.null(group.col)) {
     # set up default group column name
-    if (is.element(model, kModel[5:9])) {
+    if (is.element(model, kModel[mean_model_inds])) {
       # means models default to splitting by condition
       group.col <- "Condition"
     } else {
@@ -420,7 +428,7 @@ statsByRegion <- function(df, col, model, split.by.side=TRUE,
         df.region.nonnan <- df.region.nonnan[nonnan, ]
         if (is.null(df.region.nonnan)) next
       }
-      if (is.element(model, kModel[5:9])) {
+      if (is.element(model, kModel[mean_model_inds])) {
         # filter for means tests, which compare groups specified in group.col
         # TODO: reconsider aggregating sides but need way to properly
         # average variations in a weighted manner
@@ -443,7 +451,7 @@ statsByRegion <- function(df, col, model, split.by.side=TRUE,
       # apply stats and store in stats data frame, using list to allow 
       # arbitrary size and storing mean volume as well
       coef.tab <- NULL
-      if (is.element(model, kModel[5:9])) {
+      if (is.element(model, kModel[mean_model_inds])) {
         # means tests
         coef.tab <- meansModel(
           vals, df.region.nonnan[[group.col]], model, paired, 

--- a/clrstats/R/clrstats.R
+++ b/clrstats/R/clrstats.R
@@ -209,11 +209,23 @@ meansModel <- function(vals, conditions, model, paired=FALSE, reverse=FALSE) {
       result <- t.test(val.conds[[2]], val.conds[[1]], paired=paired)
       
       # calculate Cohen's d for standardized effect
-      mat <- purrr::map_dfr(val.conds, ~dplyr::as_data_frame(t(.)))
-      df <- tidyr::gather(data.frame(t(mat)))
-      eff <- rstatix::cohens_d(df, value ~ key, paired=paired)
+      
+      # # convert lists of potentially different sizes to df in long format
+      # df <- stack(val.conds)
+      # print(df)
+      
+      # # effect size using rstatix; CI does not appear to be working
+      # eff <- rstatix::cohens_d(df, values ~ ind, paired=paired)
+      # print(eff)
+      
+      # effect size using effectsize
+      # eff <- effectsize::cohens_d(values ~ ind, data=df, paired=paired)
+      eff <- effectsize::cohens_d(val.conds[[2]], val.conds[[1]], paired=paired)
       print(eff)
-      effect <- -eff$effsize
+      # print(effectsize::interpret_cohens_d(eff))
+      effect <- eff$Cohens_d
+      
+      # get raw effect; get diff if multiple vals
       effect.raw <- result[["estimate"]]
       if (length(effect.raw) > 1) {
         effect.raw <- -diff(effect.raw)

--- a/clrstats/R/clrstats.R
+++ b/clrstats/R/clrstats.R
@@ -956,7 +956,7 @@ setupConfig <- function(name=NULL) {
 }
 
 runStats <- function(path=NULL, profiles=NULL, measurements=NULL, prefix=NULL,
-                     verbose=NULL, stat.type=NULL) {
+                     verbose=NULL, stat.type=NULL, model=NULL) {
   # Load data and run full stats.
   #
   # Args:
@@ -969,6 +969,8 @@ runStats <- function(path=NULL, profiles=NULL, measurements=NULL, prefix=NULL,
   #   verbose: True to show verbose debugging information; defaults to NULL.
   #   stat.type: One of kStatTypes specifying stat processing typest. 
   #     Defaults to NULL to use kStatTypes[1].
+  #   model: Statistical model to use, which should be one of `kModel`.
+  #     Defaults to NULL to use the model in [config.env].
 
   if (is.null(stat.type)) {
     message("Running general stats")
@@ -1005,6 +1007,11 @@ runStats <- function(path=NULL, profiles=NULL, measurements=NULL, prefix=NULL,
     measurements.split <- strsplit(measurements, ",")[[1]]
   }
   cat("Measurements:", paste(measurements.split), "\n")
+
+  if (!is.null(model)) {
+    config.env$Model <- model
+    message("Set stats model to: ", config.env$Model)
+  }
 
   if (!is.null(prefix)) {
     # set path prefix

--- a/clrstats/R/clrstats.R
+++ b/clrstats/R/clrstats.R
@@ -200,11 +200,10 @@ meansModel <- function(vals, conditions, model, paired=FALSE, reverse=FALSE) {
     }
   }
   
-  result <- NULL
   effect <- NULL
   effect.raw <- NULL
-  tryCatchLog::tryCatchLog({
   ci <- NULL
+  result <- tryCatchLog::tryCatchLog({
     if (model == kModel[5] | model == kModel[7]) {
       # Student's t-test
       result <- t.test(val.conds[[2]], val.conds[[1]], paired=paired)
@@ -260,11 +259,15 @@ meansModel <- function(vals, conditions, model, paired=FALSE, reverse=FALSE) {
     } else {
       cat("Sorry, model", model, "not found\n")
     }
+    
+    # return result from try block
     print(result)
+    result
   }, error=function(e) {
     message("Unable to generate stat, skipping")
+    return(NULL)
   }, finally={
-  }, include.full.call.stack=FALSE, include.compact.call.stack = FALSE)
+  }, include.full.call.stack=FALSE, include.compact.call.stack=FALSE)
   
   # return if no stats
   if (is.null(result)) return(NULL)
@@ -416,7 +419,7 @@ statsByRegion <- function(df, col, model, split.by.side=TRUE,
   
   # find all regions
   regions <- unique(df$Region)
-  #regions <- c(15565) # TESTING: insert single region
+  # regions <- c(15565, 15566) # TESTING: select region(s)
   cols <- c("Region", "Stats", "Volume", "Nuclei")
   stats <- data.frame(matrix(nrow=length(regions), ncol=length(cols)))
   names(stats) <- cols

--- a/clrstats/run.R
+++ b/clrstats/run.R
@@ -42,6 +42,9 @@ tryCatchLog::tryCatchLog({
       parser, c("-m", "--meas"), type="character",
       help="Names of measurent columns on which to perform stats")
     parser <- optparse::add_option(
+      parser, "--model", type="character",
+      help="Name of stats model")
+    parser <- optparse::add_option(
       parser, "--prefix", type="character",
       help="Path prefix")
     args.parsed <- optparse::parse_args(parser)
@@ -51,7 +54,7 @@ tryCatchLog::tryCatchLog({
   # run main statistics
   print(args.parsed$meas)
   runStats(args.parsed$file, args.parsed$profiles, args.parsed$meas,
-           args.parsed$prefix, args.parsed$verbose)
+           args.parsed$prefix, args.parsed$verbose, model=args.parsed$model)
 }, finally={
   # return to original directory
   setwd(dir.start)

--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -70,15 +70,22 @@
 
 - Color bars can be configured in ROI profiles using [settings in Matplotlib](https://matplotlib.org/3.5.0/api/_as_gen/matplotlib.pyplot.colorbar.html), update dynamically, and no longer repeat in animations (#128)
 - Unit factor conversions adapts to image dimensions (eg 2D vs 3D) (#132)
+- New plot label sub-arguments (#135):
+  - `--plot labels err_col_abs=<col>`: plot error bars with a column of absolute rather than relative values, now that Clrstats gives absolute values for effect sizes
+  - `--plot_labels background=<color>`: change plot background color with a Matplotlib color string
+  - `--plot_labels vspan_col=<col>`: column denoting vertical span groups
 - Fixed errors when generating labels difference heat maps, and conditions can be set through `--plot_labels condition=cond1,cond2,...` (#132)
 - Fixed alignment of headers and columns in data frames printed to console (#109)
 
 #### R stats and plots
 
+- Specify models with the `--model <stats.model>` CLI argument (#135)
+- Effect size confidence intervals are now absolute rather than relative values for clarity (#135)
 - Region IDs file is no longer required since volume stats output from the Python pipeline already includes this region metadata (#132)
+- Added the `diff.means` stats model to simply give the difference of means between conditions (#135) 
 - The `revpairedstats` profile is now `revconds` since it applies to reversing conditions in general, not just for paired stats (#132)
-- Added a `mann.whitney` profile for Mann-Whitney tests (#132)
 - Stats errors are caught rather than stopping the pipeline (#132)
+- Fixed t-test, which also provides Cohen's d as a standardized effect size through the `effectsize` package (#135)
 
 #### Code base and docs
 
@@ -93,5 +100,7 @@
 - Updated to use the `axis_channel` parameter in Scikit-image's `transform.rescale` function (#115)
 
 #### R Dependency Changes
+
+- `effectsize` is a suggested dependency for Cohen's d, used in t-tests (#135)
 
 #### Server dependency Changes

--- a/magmap/plot/plot_2d.py
+++ b/magmap/plot/plot_2d.py
@@ -1221,15 +1221,6 @@ def main(ax=None):
             prefix=config.prefix, save=False,
             col_wt=col_wt, x_tick_labels=x_tick_lbls, rotation=45)
     
-    elif plot_2d_type is config.Plot2DTypes.BAR_PLOT_VOLS_STATS:
-        # barplot for data frame from R stats from means/CIs
-        ax = plot_bars(
-            config.filename, data_cols=("original.mean", "smoothed.mean"), 
-            err_cols=("original.ci", "smoothed.ci"), 
-            legend_names=("Original", "Smoothed"), col_groups="RegionName", 
-            size=size, show=False, groups=config.groups, save=False,
-            prefix=config.prefix)
-    
     elif plot_2d_type is config.Plot2DTypes.BAR_PLOT_VOLS_STATS_EFFECTS:
         # barplot for data frame from R stats test effect sizes and CIs
         

--- a/magmap/plot/plot_2d.py
+++ b/magmap/plot/plot_2d.py
@@ -1205,6 +1205,7 @@ def main(ax=None):
     y_unit = config.plot_labels[config.PlotLabels.Y_UNIT]
     legend_names = config.plot_labels[config.PlotLabels.LEGEND_NAMES]
     hline = config.plot_labels[config.PlotLabels.HLINE]
+    col_vspan = config.plot_labels[config.PlotLabels.VSPAN_COL]
     
     # perform 2D plot task, deferring save until the post-processing step
     if plot_2d_type is config.Plot2DTypes.BAR_PLOT:
@@ -1216,6 +1217,7 @@ def main(ax=None):
             legend_names=legend_names, col_groups=group_col, title=title,
             y_label=y_lbl, y_unit=y_unit, hline=hline,
             size=size, show=False, groups=config.groups,
+            col_vspan=col_vspan, vspan_fmt="L{}",
             prefix=config.prefix, save=False,
             col_wt=col_wt, x_tick_labels=x_tick_lbls, rotation=45)
     
@@ -1247,7 +1249,7 @@ def main(ax=None):
             legend_names="", col_groups="RegionName", title=title, 
             y_label=y_lbl, y_unit=y_unit, save=False,
             size=size, show=False, groups=config.groups, 
-            prefix=config.prefix, col_vspan="Level", vspan_fmt="L{}", 
+            prefix=config.prefix, col_vspan=col_vspan, vspan_fmt="L{}", 
             col_wt=col_wt, x_tick_labels=x_tick_lbls, rotation=45)
 
     elif plot_2d_type is config.Plot2DTypes.LINE_PLOT:

--- a/magmap/plot/plot_support.py
+++ b/magmap/plot/plot_support.py
@@ -264,6 +264,11 @@ def imshow_multichannel(
             # to avoid repeated inversions with repeated calls
             ax.invert_yaxis()
     
+    bgd = config.plot_labels[config.PlotLabels.BACKGROUND]
+    if bgd:
+        # change the background color
+        ax.set_facecolor(bgd)
+    
     return img
 
 

--- a/magmap/settings/config.py
+++ b/magmap/settings/config.py
@@ -267,7 +267,7 @@ class Cmaps(Enum):
 # processing type directly in module
 Plot2DTypes = Enum(
     "Plot2DTypes", (
-        "BAR_PLOT", "BAR_PLOT_VOLS_STATS", "BAR_PLOT_VOLS_STATS_EFFECTS", 
+        "BAR_PLOT", "BAR_PLOT_VOLS_STATS_EFFECTS", 
         "ROC_CURVE", "SCATTER_PLOT",
         "LINE_PLOT",  # generic line plot
     )

--- a/magmap/settings/config.py
+++ b/magmap/settings/config.py
@@ -310,6 +310,8 @@ class PlotLabels(Enum):
     NAN_COLOR = auto()  # color for NaN values (Matplotlib or RGBA string)
     TEXT_POS = auto()  # text (annotation) position in x,y
     CONDITION = auto()  # condition
+    #: Column indicating grouping for vertical span.
+    VSPAN_COL = auto()
 
 
 #: dict[Any]: Plot labels set from command-line.

--- a/magmap/settings/config.py
+++ b/magmap/settings/config.py
@@ -296,7 +296,10 @@ class PlotLabels(Enum):
     GROUP_COL = auto()  # data frame group column
     WT_COL = auto()  # weight column
     ID_COL = auto()  # ID column
-    ERR_COL = auto()  # error column(s)
+    #: Error column(s) with values relative to the data points.
+    ERR_COL = auto()
+    #: Error column(s) with absolute.
+    ERR_COL_ABS = auto()
     ANNOT_COL = auto()  # annotation column for each point
     ZOOM_SHIFT = auto()  # shift plot offset when zooming into ROI
     HLINE = auto()  # horizontal line, usually fn for each group

--- a/magmap/settings/config.py
+++ b/magmap/settings/config.py
@@ -275,8 +275,8 @@ Plot2DTypes = Enum(
 plot_2d_type = None
 
 
-# plot label keys for command-line parsing
 class PlotLabels(Enum):
+    """Plot label keys for command-line sub-arguments."""
     TITLE = auto()  # figure title
     X_LABEL = auto()  # axis labels
     Y_LABEL = auto()
@@ -307,11 +307,14 @@ class PlotLabels(Enum):
     MARKER = auto()  # Matplotlib marker style
     DROP_DUPS = auto()  # drop duplicates
     DPI = auto()  # dots per inch
-    NAN_COLOR = auto()  # color for NaN values (Matplotlib or RGBA string)
+    #: # Color for NaN values as a Matplotlib or RGBA string.
+    NAN_COLOR = auto()
     TEXT_POS = auto()  # text (annotation) position in x,y
     CONDITION = auto()  # condition
     #: Column indicating grouping for vertical span.
     VSPAN_COL = auto()
+    #: Background color as a Matplotlib or RGBA string.
+    BACKGROUND = auto()
 
 
 #: dict[Any]: Plot labels set from command-line.


### PR DESCRIPTION
Clrstats has expected means test to output a single estimate, but independent t-tests output estimates for both groups. This PR fixes this issue by simply setting the raw effect as the difference of means and also computes a standardized effect using Cohen's d as implemented in the ~~`rstatix`~~ `effectsize` package.

Additional changes:
- ~~Fixed confidence intervals to use the raw effect in case a standardized effect is also computed~~ Confidence intervals for effect sizes are now reported as absolute rather than relative values as these values are more likely expected and correspond to the direct stats output. MagellanMapper adds a `--plot_labels err_col_abs=<col>` sub-argument to plot these values since Matplotlib requires absolute values to be converted to relative values. The single-value confidence intervals given for each group remain relative to the data points.
- The Clrstats CLI option `--model <stats.model>` can now be used to specify one of the statistical models specified in `kModels` in `clrstats.R`. Additional models can be added, separated by commas (eg `ttest,ttest.paired`). Since this option is easier to specify models, we removed the recently added `mann.whitney` profile as it only changed the model.
- The `diff.mean` is a simple stats model that will simply calculate the difference of means between groups, which allows this calculation even when conditions for other tests cannot be met
- Fixed volcano plots by including the "Level" column from region metadata, which is used in volcano plots to color points
- Python plot backgrounds can be set using `--plot_labels background=<color>`, where `color` is a Matplotlib color string
- The column used to specify vertical spans in bar plots can be specified by `--plot_labels vspan_col=<col>`
- The `bar_plot_vol_stats` 2D plot task was removed since it was only used for a very specific analysis