### PR TITLE
Add swarm plots

### DIFF
--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -68,12 +68,13 @@
 
 #### Python stats and plots
 
+- Generate swarm plots in Seaborn (#137)
 - Color bars can be configured in ROI profiles using [settings in Matplotlib](https://matplotlib.org/3.5.0/api/_as_gen/matplotlib.pyplot.colorbar.html), update dynamically, and no longer repeat in animations (#128)
 - Unit factor conversions adapts to image dimensions (eg 2D vs 3D) (#132)
 - New plot label sub-arguments (#135):
   - `--plot labels err_col_abs=<col>`: plot error bars with a column of absolute rather than relative values, now that Clrstats gives absolute values for effect sizes
   - `--plot_labels background=<color>`: change plot background color with a Matplotlib color string
-  - `--plot_labels vspan_col=<col>`: column denoting vertical span groups
+  - `--plot_labels vspan_col=<col> vspan_format=<str>`: column denoting vertical span groups and string format for them, respectively (#135, 137)
 - Fixed errors when generating labels difference heat maps, and conditions can be set through `--plot_labels condition=cond1,cond2,...` (#132)
 - Fixed alignment of headers and columns in data frames printed to console (#109)
 
@@ -98,6 +99,7 @@
 - Python 3.8 is the default version now that Python 3.6 has reached End-of-Life
 - `Tifffile` is now a direct dependency, previously already installed as a sub-dependency of other required packages
 - Updated to use the `axis_channel` parameter in Scikit-image's `transform.rescale` function (#115)
+- Seaborn as an optional dependency for additional plot support (currently only swarm plots, #137)
 
 #### R Dependency Changes
 

--- a/magmap/plot/plot_2d.py
+++ b/magmap/plot/plot_2d.py
@@ -314,12 +314,13 @@ def _bar_plots(ax, lists, errs, legend_names, x_labels, colors, y_label,
     plot_support.set_scinot(ax, lbls=(y_label,), units=(y_unit,))
     ax.set_xticks(indices + width * len(lists) / 2)
     plot_support.scale_xticks(ax, rotation, x_labels)
-    
-    # further group x-vals into vertical spans
-    plot_support.add_vspans(ax, vspans, vspan_lbls, padding, vspan_alt_y)
 
     if legend_names:
-        ax.legend(bars, legend_names, loc="best", fancybox=True, framealpha=0.5)
+        # set legend names for the bars
+        ax.legend(bars, legend_names, framealpha=0.5)
+
+    # further group x-vals into vertical spans
+    plot_support.add_vspans(ax, vspans, vspan_lbls, padding, vspan_alt_y)
 
 
 def plot_bars(

--- a/magmap/plot/plot_2d.py
+++ b/magmap/plot/plot_2d.py
@@ -1182,6 +1182,7 @@ def main(ax=None):
     legend_names = config.plot_labels[config.PlotLabels.LEGEND_NAMES]
     hline = config.plot_labels[config.PlotLabels.HLINE]
     col_vspan = config.plot_labels[config.PlotLabels.VSPAN_COL]
+    vspan_fmt = config.plot_labels[config.PlotLabels.VSPAN_FORMAT]
     
     # perform 2D plot task, deferring save until the post-processing step
     if plot_2d_type is config.Plot2DTypes.BAR_PLOT:
@@ -1193,7 +1194,7 @@ def main(ax=None):
             legend_names=legend_names, col_groups=group_col, title=title,
             y_label=y_lbl, y_unit=y_unit, hline=hline,
             size=size, show=False, groups=config.groups,
-            col_vspan=col_vspan, vspan_fmt="L{}",
+            col_vspan=col_vspan, vspan_fmt=vspan_fmt,
             prefix=config.prefix, save=False,
             col_wt=col_wt, x_tick_labels=x_tick_lbls, rotation=45, err_cols_abs=err_col_abs)
     

--- a/magmap/plot/plot_support.py
+++ b/magmap/plot/plot_support.py
@@ -916,6 +916,8 @@ def add_vspans(
         vspan_alt_y: bool = False):
     """Add vertical spans to group x-values.
     
+    Shifts legend away from span labels.
+    
     Args:
         ax: Matplotlib axes.
         vspans: Sequence of vertical span x-vals in data units.
@@ -953,6 +955,12 @@ def add_vspans(
             y = y_top - y_span * y_frac
             ax.text(
                 x, y, vspan_lbls[i], color="k", horizontalalignment="center")
+    
+    legend = ax.get_legend()
+    if legend:
+        # shift legend away from span labels
+        legend.loc = "best"
+        legend.set_bbox_to_anchor((0, 0, 1, 0.9))
 
 
 def get_plane_axis(plane, get_index=False):

--- a/magmap/settings/config.py
+++ b/magmap/settings/config.py
@@ -316,6 +316,7 @@ class PlotLabels(Enum):
     CONDITION = auto()  # condition
     #: Column indicating grouping for vertical span.
     VSPAN_COL = auto()
+    VSPAN_FORMAT = auto()
     #: Background color as a Matplotlib or RGBA string.
     BACKGROUND = auto()
 

--- a/magmap/settings/config.py
+++ b/magmap/settings/config.py
@@ -264,14 +264,17 @@ class Cmaps(Enum):
     CMAP_RDBK_NAME = "Red_black"
 
 
-# processing type directly in module
-Plot2DTypes = Enum(
-    "Plot2DTypes", (
-        "BAR_PLOT", "BAR_PLOT_VOLS_STATS_EFFECTS", 
-        "ROC_CURVE", "SCATTER_PLOT",
-        "LINE_PLOT",  # generic line plot
-    )
-)
+class Plot2DTypes(Enum):
+    """2D plot tasks."""
+    BAR_PLOT = auto()
+    BAR_PLOT_VOLS_STATS = auto()
+    BAR_PLOT_VOLS_STATS_EFFECTS = auto()
+    ROC_CURVE = auto()
+    SCATTER_PLOT = auto()
+    LINE_PLOT = auto()
+    SWARM_PLOT = auto()
+    
+
 plot_2d_type = None
 
 

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ config = {
         "all": [
             "matplotlib_scalebar", 
             "pyamg",  # for Random-Walker segmentation "cg_mg" mode
+            "seaborn",  # for Seaborn-based plots
             *_EXTRAS_PANDAS,
             *_EXTRAS_IMPORT,  
             *_EXTRAS_AWS, 


### PR DESCRIPTION
Swarm plots show each data sample as a separate point, with points spaced to avoid overlap. These plots are [implemented here in Seaborn](https://seaborn.pydata.org/generated/seaborn.swarmplot.html), and they incorporate additional functionality from the bar plots task such as x-tick scaling and vertical span groups.

Many of the Seaborn plot functions take data in long rather than wide format, whereas our bar plots have expected wide format. For consistency with Seaborn, our swarm plot wrapper takes long format. We may consider shifting to long format for all plot tasks if it simplifies/clarifies our data handling and call signatures.

Additional changes:
- Added `--plot_labels vspan_format=<str>` to specify the format for vertical span labels.
- Setting scientific notation on incompatible axes can lead to errors, which are now caught