### PR TITLE
Save and restore preferences

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__
 *.sif
 *.zip
 docs/_build
+docs/magmap*.rst
 stats/.*
 .Rproj.user
 build

--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -10,6 +10,7 @@
 
 #### GUI
 
+- More preferences are saved, such as the figure save location and ROI Editor layout (#138)
 - "Blend" option in the image adjustment panel to visualize alignment in overlaid images
 - Drag and remove loaded profiles in the Profiles tab table
 - "Help" buttons added to open the online documentation (#109)
@@ -55,6 +56,7 @@
 
 - Match-based colocalizations use larger processing blocks to avoid gaps (#120)
 - Voxel density maps no longer require a registered image (#125)
+- Grid search profiles are now layered on top of one another rather than applied in sequential runs for consistency with ROI and atlas profiles (#138)
 - Fixed 3D surface area measurement with Scikit-image >= v0.19
 
 #### I/O
@@ -90,12 +92,14 @@
 #### Code base and docs
 
 - Blob column accessors are encapsulated in the `Blobs` class, which allows for flexibility in column inclusion and order (#133)
+- Settings profiles are being migrated from dictionaries to data classes to document and configure settings more easily (#138)
 
 ### Dependency Updates
 
 #### Python Dependency Changes
 
 - Python 3.8 is the default version now that Python 3.6 has reached End-of-Life
+- The `dataclasses` backport is installed for Python < 3.7
 - `Tifffile` is now a direct dependency, previously already installed as a sub-dependency of other required packages
 - Updated to use the `axis_channel` parameter in Scikit-image's `transform.rescale` function (#115)
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -2,11 +2,11 @@
 
 MagellanMapper supports settings configuration at different levels of "permanence." Starting from the most transient to more enduring settings, these settings are:
 
-1. Graphical user interface (GUI) controls, configurable during runtime
+1. Graphical user interface (GUI) controls, configurable during runtime and saved as preferences
 1. Command-line arguments, set at launch time
 1. Profiles, groups of settings saved in a file and set at launch time or loaded through the GUI
 
-Additional data and settings such as blob detections are stored in the user application folder.
+Additional data such as blob detections are stored in a database.
 
 ## User Application Folder
 
@@ -19,7 +19,13 @@ Previously, the database (`magmap.db`) was stored in the application root folder
 
 ## GUI Parameters
 
-The ROI selector provides many options for displaying 2D and 3D regions of interest. Users can select these parameters through checkboxes, sliders, text input, or other controls. Currently these settings are reset with each program launch.
+The ROI selector provides many options for displaying 2D and 3D regions of interest. Users can select these parameters through checkboxes, sliders, text input, or other controls. GUI state is stored in two places:
+- TraitUI database: the GUI library maintains a database that stores a few settings such as window size and position
+- Preferences profile: some GUI settings are saved to `<user-app-dir>/prefs.yaml`
+
+In v1.6, we introduced preference saving by enabling the TraitsUI mechanism and adding a profile type for preferences, similar to ROI and atlas profiles. Currently, only a small subset of GUI controls are saved, and more will neeed to be added.
+
+To reset preferences, go to the "Profiles" tab and press the "Reset Preferences" button. It clears the TraitsUI database and resets the currently loaded preferences profile without otherwise altering the current state of the application. When the application is closed, preferences are resaved based on the current app state.
 
 ## Command-Line Arguments
 

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -858,21 +858,29 @@ class Visualization(HasTraits):
         # set ID to trigger saving TraitsUI preferences for window size/position
         id=f"{__name__}.{__qualname__}",
     )
-
+    
     def __init__(self):
         """Initialize GUI."""
         HasTraits.__init__(self)
         
+        # get saved preferences
+        prefs = config.prefs
+        
         # set up callback flags
         self._ignore_roi_offset_change = False
         
-        # default options setup
+        # set up ROI Editor option
         self._set_border(True)
-        self._circles_2d = [
-            roi_editor.ROIEditor.CircleStyles.CIRCLES.value]
-        self._planes_2d = [self._DEFAULTS_PLANES_2D[0]]
-        self._styles_2d = [Styles2D.SQUARE.value]
+        self._circles_2d = [self.validate_pref(
+            prefs.roi_circles, roi_editor.ROIEditor.CircleStyles.CIRCLES.value,
+            roi_editor.ROIEditor.CircleStyles)]
+        self._planes_2d = [self.validate_pref(
+            prefs.roi_plane, self._DEFAULTS_PLANES_2D[0],
+            self._DEFAULTS_PLANES_2D)]
+        self._styles_2d = [self.validate_pref(
+            prefs.roi_styles, Styles2D.SQUARE.value, Styles2D)]
         # self._check_list_2d = [self._DEFAULTS_2D[1]]
+        
         self._check_list_3d = [
             Vis3dOptions.RAW.value, Vis3dOptions.SURFACE.value]
         if (config.roi_profile["vis_3d"].lower()
@@ -2549,6 +2557,11 @@ class Visualization(HasTraits):
         self.roi_ed = roi_ed
         self._add_mpl_fig_handlers(roi_ed.fig)
         self.stale_viewers[vis_handler.ViewerTabs.ROI_ED] = None
+        
+        # store selected 2D options
+        config.prefs.roi_circles = self._circles_2d[0]
+        config.prefs.roi_plane = self._planes_2d[0]
+        config.prefs.roi_styles = self._styles_2d[0]
 
     def launch_atlas_editor(self):
         if config.image5d is None:

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -843,6 +843,7 @@ class Visualization(HasTraits):
         HSplit(
             panel_options,
             panel_figs,
+            id=f"{__name__}.panel_split",
         ),
         # initial window width, which can be resized down to the minimum
         # widths of each panel in the HSplit

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -2671,7 +2671,7 @@ class Visualization(HasTraits):
         if save_dialog.open() == OK:
             # get user selected path and update preferences
             path = save_dialog.path
-            config.prefs["fig_save_dir"] = os.path.dirname(path)
+            config.prefs.fig_save_dir = os.path.dirname(path)
             return path
         else:
             # user canceled file selection
@@ -2683,7 +2683,7 @@ class Visualization(HasTraits):
         path = None
         try:
             # get the figure save directory from preferences
-            save_dir = config.prefs["fig_save_dir"]
+            save_dir = config.prefs.fig_save_dir
             
             if self.selected_viewer_tab is vis_handler.ViewerTabs.ROI_ED:
                 if self.roi_ed is not None:

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -62,7 +62,7 @@ from magmap.gui import atlas_editor, import_threads, roi_editor, vis_3d, \
     vis_handler
 from magmap.io import cli, importer, libmag, naming, np_io, sitk_io, sqlite
 from magmap.plot import colormaps, plot_2d, plot_3d
-from magmap.settings import config, profiles
+from magmap.settings import config, prefs_prof, profiles
 
 
 # logging instance
@@ -3225,8 +3225,11 @@ class Visualization(HasTraits):
     @on_trait_change("_profiles_reset_prefs_btn")
     def _reset_prefs(self):
         """Handle button to reset preferences."""
-        # trigger reset in handler
+        # trigger resetting TraitsUI prefs in handler
         self._profiles_reset_prefs = True
+        
+        # reset preferences profile
+        config.prefs = prefs_prof.PrefsProfile()
     
     @on_trait_change("_import_browser")
     def _add_import_file(self):

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -958,6 +958,28 @@ class Visualization(HasTraits):
         # set up image
         self._setup_for_image()
 
+    @staticmethod
+    def validate_pref(val, default, choices):
+        """Validate a preference setting.
+        
+        Args:
+            val: Preference value to assign.
+            default: Default value if ``val`` is invalid.
+            choices: Valid preference values.
+
+        Returns:
+            ``val`` if a valid value, otherwise ``default``.
+
+        """
+        try:
+            if issubclass(choices, Enum):
+                choices = [e.value for e in choices]
+        except TypeError:
+            pass
+        if val not in choices:
+            val = default
+        return val
+
     def _init_channels(self):
         """Initialize channel check boxes for the currently loaded main image.
 

--- a/magmap/io/cli.py
+++ b/magmap/io/cli.py
@@ -1089,10 +1089,10 @@ def _grid_search(series_list: List[int]):
             config.grid_search_profile.hyperparams, _detect_subimgs,
             config.filename, series, config.subimg_offsets,
             config.subimg_sizes)
-        parsed_dict, stats_dfs = mlearn.parse_grid_stats(stats_dict)
-        for stats_df in stats_dfs:
-            # plot ROC curve
-            plot_2d.plot_roc(stats_df, config.show)
+        parsed_dict, stats_df = mlearn.parse_grid_stats(stats_dict)
+        
+        # plot ROC curve
+        plot_2d.plot_roc(stats_df, config.show)
 
 
 def process_file(

--- a/magmap/io/cli.py
+++ b/magmap/io/cli.py
@@ -28,16 +28,19 @@ from enum import Enum
 import logging
 import os
 import sys
-from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Type, Union
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Type, \
+    Union
 
 import numpy as np
 
 from magmap.atlas import register, transformer
 from magmap.cloud import notify
 from magmap.cv import chunking, colocalizer, stack_detect
-from magmap.io import df_io, export_stack, importer, libmag, naming, np_io, sqlite
+from magmap.io import df_io, export_stack, importer, libmag, naming, np_io, \
+    sqlite
 from magmap.plot import colormaps, plot_2d
-from magmap.settings import atlas_prof, config, grid_search_prof, logs, roi_prof
+from magmap.settings import atlas_prof, config, grid_search_prof, logs, \
+    prefs_prof, roi_prof
 from magmap.stats import mlearn
 
 _logger = config.logger.getChild(__name__)
@@ -427,6 +430,10 @@ def process_cli_args():
     # redirect standard out/error to logging
     sys.stdout = logs.LogWriter(config.logger.info)
     sys.stderr = logs.LogWriter(config.logger.error)
+    
+    # load preferences file
+    config.prefs = prefs_prof.PrefsProfile()
+    config.prefs.add_profiles(str(config.PREFS_PATH))
     
     if args.version:
         # print version info and exit
@@ -1228,6 +1235,8 @@ def shutdown():
     importer.stop_jvm()
     if config.db is not None:
         config.db.conn.close()
+    if config.prefs is not None:
+        config.prefs.save_settings(config.PREFS_PATH)
     sys.exit()
 
     

--- a/magmap/io/cli.py
+++ b/magmap/io/cli.py
@@ -391,6 +391,15 @@ def process_cli_args():
     # only parse recognized arguments to avoid error for unrecognized ones
     args, args_unknown = parser.parse_known_args()
 
+    # set up application directories
+    user_dir = config.user_app_dirs.user_data_dir
+    if not os.path.isdir(user_dir):
+        # make application data directory
+        if os.path.exists(user_dir):
+            # backup any non-directory file
+            libmag.backup_file(user_dir)
+        os.makedirs(user_dir)
+
     if args.verbose is not None:
         # verbose mode and logging setup
         config.verbose = True
@@ -702,15 +711,6 @@ def process_cli_args():
         print("Set to use themes to {}".format(theme_names))
     # set up Matplotlib styles/themes
     plot_2d.setup_style()
-    
-    # set up application directories
-    user_dir = config.user_app_dirs.user_data_dir
-    if not os.path.isdir(user_dir):
-        # make application data directory
-        if os.path.exists(user_dir):
-            # backup any non-directory file
-            libmag.backup_file(user_dir)
-        os.makedirs(user_dir)
     
     if args.db:
         # set main database path to user arg

--- a/magmap/io/cli.py
+++ b/magmap/io/cli.py
@@ -1086,7 +1086,7 @@ def _grid_search(series_list: List[int]):
         # process each series, typically a tile within an microscopy image
         # set or a single whole image
         stats_dict = mlearn.grid_search(
-            config.grid_search_profile, _detect_subimgs,
+            config.grid_search_profile.hyperparams, _detect_subimgs,
             config.filename, series, config.subimg_offsets,
             config.subimg_sizes)
         parsed_dict, stats_dfs = mlearn.parse_grid_stats(stats_dict)

--- a/magmap/io/yaml_io.py
+++ b/magmap/io/yaml_io.py
@@ -3,23 +3,26 @@
 """YAML file format input/output."""
 
 from enum import Enum
-from typing import Dict
+from typing import Any, Callable, Dict, List, Optional, TYPE_CHECKING, Union
 
 import yaml
 
 from magmap.io import libmag
 
+if TYPE_CHECKING:
+    import pathlib
 
-def _filter_dict(d, fn_parse_val):
+
+def _filter_dict(d: Dict, fn_parse_val: Callable[[Any], Any]) -> Dict:
     """Recursively filter keys and values within nested dictionaries
     
     Args:
-        d (dict): Dictionary to filter.
-        fn_parse_val (func): Function to apply to each value. Should call
+        d: Dictionary to filter.
+        fn_parse_val: Function to apply to each value. Should call
             this parent function if deep recursion is desired.
 
     Returns:
-        dict: Filtered dictionary.
+        Filtered dictionary.
 
     """
     out = {}
@@ -39,17 +42,19 @@ def _filter_dict(d, fn_parse_val):
     return out
 
 
-def load_yaml(path, enums=None):
+def load_yaml(
+        path: Union[str, "pathlib.Path"],
+        enums: Optional[Dict[str, Enum]] = None) -> List[Dict]:
     """Load a YAML file with support for multiple documents and Enums.
 
     Args:
-        path (str): Path to YAML file.
-        enums (dict): Dictionary mapping Enum names to Enum classes; defaults
+        path: Path to YAML file.
+        enums: Dictionary mapping Enum names to Enum classes; defaults
             to None. If a key or value in the YAML file matches an Enum name
             followed by a period, the corresponding Enum will be used.
 
     Returns:
-        List[dict]: Sequence of parsed dictionaries for each document within
+        Sequence of parsed dictionaries for each document within
         a YAML file.
     
     Raises:
@@ -87,8 +92,8 @@ def load_yaml(path, enums=None):
 
 
 def save_yaml(
-        path: str, data: Dict, use_primitives: bool = False,
-        convert_enums: bool = False) -> Dict:
+        path: Union[str, "pathlib.Path"], data: Dict,
+        use_primitives: bool = False, convert_enums: bool = False) -> Dict:
     """Save a dictionary to YAML file format.
     
     Args:

--- a/magmap/plot/plot_2d.py
+++ b/magmap/plot/plot_2d.py
@@ -741,7 +741,8 @@ def plot_scatter(
         col_y: Optional[Union[str, Sequence[str]]] = None,
         col_annot: Optional[str] = None,
         cols_group: Optional[Sequence[str]] = None,
-        names_group: Optional[Sequence[str]] = None,
+        names_group: Optional[Union[
+            Sequence[str], Callable[[str], str]]] = None,
         fig_size: Optional[Sequence[float]] = None, show: bool = True,
         suffix: Optional[str] = None, df: Optional[pd.DataFrame] = None,
         xy_line: bool = False, col_size: Optional[str] = None,
@@ -762,10 +763,10 @@ def plot_scatter(
             If not found, y-values are set to 0 if ``col_x`` is only one column.
         col_annot: Name of column with annotations for each point; defaults to
             None. Can be the name of the index column.
-        cols_group (Sequence[str]): Sequence of column names; defaults to None.
+        cols_group: Sequence of column names; defaults to None.
             Each unique combination in these columns specifies a group
             to plot separately.
-        names_group (Sequence[str]): Sequence of names to display;
+        names_group: Sequence of names to display;
             defaults to None, in which case a name based on ``cols_groups``
             will be used instead. Length should equal that of groups based
             on ``cols_group``.
@@ -785,22 +786,22 @@ def plot_scatter(
         annot_arri: Int as index or slice of indices of annotation value
             if the annotation is a string that can be converted into a
             Numpy array; defaults to None.
-        alpha (float): Point transparency value, from 0-1; defaults to None,
+        alpha: Point transparency value, from 0-1; defaults to None,
             in which case 1.0 will be used.
-        legend_loc (str): Legend location, which should be one of
+        legend_loc: Legend location, which should be one of
             :attr:``plt.legend.loc`` values; defaults to "best".
-        ax (:class:`matplotlib.image.Axes`): Matplotlib axes; defaults to None.
-        save (bool): True to save the plot; defaults to True.
-        annot_thresh_fn (func): Function accepting ``x, y`` and returning
+        ax: Matplotlib axes; defaults to None.
+        save: True to save the plot; defaults to True.
+        annot_thresh_fn: Function accepting ``x, y`` and returning
             a boolean indicated whether to annotate the given point;
             defaults to False.
         colors: Color or sequence of colors for each point; defaults to None.
             If None, distinct colors are auto-generated for each pair of x-y
             column or for each group.
-        kwargs (Any): Extra arguments to :meth:`plot_support.decorate_plot`.
+        kwargs: Extra arguments to :meth:`plot_support.decorate_plot`.
     
     Returns:
-        :class:`matplotlib.image.Axes`: Matplotlib plot.
+        Matplotlib plot axes.
     
     """
     def get_ys(df_y, column):
@@ -903,6 +904,8 @@ def plot_scatter(
             colors = colormaps.discrete_colormap(
                 num_groups, prioritize_default="cn", seed=config.seed,
                 alpha=alpha) / 255
+        
+        names_group_is_fn = callable(names_group)
         for i, group in enumerate(groups):
             # plot all points in each group with same color
             df_group = df
@@ -912,14 +915,22 @@ def plot_scatter(
                 mask = df_groups == group
                 df_group = df.loc[mask]
                 if col_size is not None: sizes_plot = sizes_plot[mask]
-                if names_group is None:
-                    # make label from group names and values
-                    label = ", ".join(
-                        ["{} {}".format(name, libmag.format_num(val, 3))
-                         for name, val in zip(cols_group, group.split(","))])
+                
+                if names_group is None or names_group_is_fn:
+                    # make legend label from group names and values
+                    labels = []
+                    for name, val in zip(cols_group, group.split(",")):
+                        if names_group_is_fn:
+                            # format name by function
+                            name = names_group(name)
+                        labels.append(f"{name} {libmag.format_num(val, 3)}")
+                    label = ", ".join(labels)
+                
                 else:
                     # use given group name directly
                     label = names_group[i]
+            
+            # get x- and y-values and plot
             xs = df_group[col_x]
             ys = get_ys(df_group, col_y)
             plot()
@@ -975,29 +986,34 @@ def plot_probability(path, conds, metric_cols, col_size, **kwargs):
         xy_line=True, col_size=col_size, **kwargs)
 
 
-def plot_roc(df, show=True, annot_arri=None, **kwargs):
+def plot_roc(
+        df: pd.DataFrame, show: bool = True, annot_arri: Optional[int] = None,
+        **kwargs) -> "axes.Axes":
     """Plot ROC curve generated from :meth:``mlearn.grid_search``.
     
     Args:
-        df (:class:`pandas.DataFrame`): Data frame generated from
+        df: Data frame generated from
             :meth:``mlearn.parse_grid_stats``.
-        show (bool): True to display the plot in :meth:``plot_scatter``;
+        show: True to display the plot in :meth:``plot_scatter``;
             defaults to True.
-        annot_arri (int): Int as index or slice of indices of annotation value
+        annot_arri: Int as index or slice of indices of annotation value
             if the annotation is a string that can be converted into a
             Numpy array; defaults to None.
-        kwargs (Any): Extra arguments to :meth:`plot_support.plot_scatter`.
+        kwargs: Extra arguments to :meth:`plot_support.plot_scatter`.
     
     Returns:
-        :class:`matplotlib.image.Axes`: Matplotlib plot.
+        Matplotlib plot axes.
     
     """
+    def format_col(col):
+        # format column name for plot
+        return col[start+1:].replace("_", " ")
+    
     # names of hyperparameters for each group name, with hyperparameters 
     # identified by param prefix
     cols_group = [col for col in df
                   if col.startswith(mlearn.GridSearchStats.PARAM.value)]
     start = len(mlearn.GridSearchStats.PARAM.value)
-    names_group = [col[start+1:] for col in cols_group]
     
     # add extra arguments unless already set in kwargs
     libmag.add_missing_keys({
@@ -1005,7 +1021,7 @@ def plot_roc(df, show=True, annot_arri=None, **kwargs):
         "ylabel": "Sensitivity",
         "xlim": (0, 1),
         "ylim": (0, 1),
-        "title": "Nuclei Detection ROC Over {}".format(names_group[-1]),
+        "title": f"ROC Over {format_col(cols_group[-1])}",
     }, kwargs)
     if "path" in kwargs:
         path = kwargs["path"]
@@ -1018,7 +1034,7 @@ def plot_roc(df, show=True, annot_arri=None, **kwargs):
     return plot_scatter(
         path, mlearn.GridSearchStats.FDR.value,
         mlearn.GridSearchStats.SENS.value, cols_group[-1], cols_group[:-1],
-        names_group, df=df, show=show, annot_arri=annot_arri,
+        format_col, df=df, show=show, annot_arri=annot_arri,
         legend_loc="lower right", **kwargs)
 
 

--- a/magmap/settings/config.py
+++ b/magmap/settings/config.py
@@ -32,6 +32,7 @@ if TYPE_CHECKING:
     from magmap.atlas import labels_meta
     from magmap.cv import detector
     from magmap.io import np_io
+    from magmap.settings import prefs_prof
 
 #: str: Application name.
 APP_NAME = "MagellanMapper"
@@ -62,6 +63,15 @@ app_dir = pathlib.Path(__file__).resolve().parent.parent.parent
 user_app_dirs = AppDirs(APP_NAME, False)
 #: PurePath: Absolution path to main application icon.
 ICON_PATH = app_dir / "images" / "magmap.png"
+
+
+# PREFERENCES
+
+#: Preferences file path.
+PREFS_PATH: pathlib.Path = pathlib.Path(
+    user_app_dirs.user_data_dir) / "prefs.yaml"
+#: Preferences dictionary.
+prefs: Optional["prefs_prof.PrefsProfile"] = None
 
 
 # LOGGING

--- a/magmap/settings/grid_search_prof.py
+++ b/magmap/settings/grid_search_prof.py
@@ -2,7 +2,11 @@
 # Author: David Young, 2019, 2020
 """Profile settings for grid search hyperparameter tuning."""
 
+# import annotations to allow sub-type hints
+from __future__ import annotations
 from collections import OrderedDict
+import dataclasses
+from typing import Dict, List, Sequence
 
 import numpy as np
 
@@ -39,6 +43,7 @@ def make_hyperparm_arr(start, stop, num_steps, num_col, coli, base=1):
     return arr
 
 
+@dataclasses.dataclass
 class GridSearchProfile(profiles.SettingsDict):
     """Grid search profile dictionary.
 
@@ -60,6 +65,10 @@ class GridSearchProfile(profiles.SettingsDict):
     """
 
     PATH_PREFIX = "grid"
+    
+    #: Ordered dictionary of hyperparameters.
+    hyperparams: OrderedDict[str, Sequence[float]] = dataclasses.field(
+        default_factory=OrderedDict)
 
     def __init__(self, *args, **kwargs):
         """Initialize a grid search dict of hyperparameter ranges.
@@ -69,17 +78,19 @@ class GridSearchProfile(profiles.SettingsDict):
             **kwargs:
         """
         super().__init__(self)
-        self._add_mod_directly = True
         self[self.NAME_KEY] = ""
+        
+        # initialize mutable fields
+        self.hyperparams = OrderedDict()
         
         # update with args
         self.update(*args, **kwargs)
 
-        #: OrderedDict[List[int]]: Nested dictionary where each sub-dictionary
+        #: Nested dictionary where each sub-dictionary
         # contains a sequence of values over which to perform a grid search to
         # generate a receiver operating characteristic curve
-        self.profiles = OrderedDict([
-            ("gridtest", OrderedDict([
+        self.profiles: OrderedDict[str, Dict[str, OrderedDict[str, Sequence[float]]]] = OrderedDict([
+            ("gridtest", {"hyperparams": OrderedDict([
                 # test single value by iterating on value that should not affect
                 # detection ability
                 ("points_3d_thresh", [0.7]),
@@ -106,20 +117,20 @@ class GridSearchProfile(profiles.SettingsDict):
                 #("num_sigma", np.arange(5, 16, 1)),
                 #("detection_threshold", np.arange(0.001, 0.01, 0.001)),
                 #("segment_size", np.arange(130, 160, 20)),
-            ])),
-            ("size5x", OrderedDict([
+            ])}),
+            ("size5x", {"hyperparams": OrderedDict([
                 ("min_sigma_factor", np.arange(2, 2.71, 0.1)),
                 ("max_sigma_factor", np.arange(2.7, 3.21, 0.1)),
-            ])),
-            ("size4x", OrderedDict([
+            ])}),
+            ("size4x", {"hyperparams": OrderedDict([
                 ("min_sigma_factor", np.arange(2.5, 3.51, 0.3)),
                 ("max_sigma_factor", np.arange(3.5, 4.51, 0.3)),
-            ])),
-            ("sizeiso", OrderedDict([
+            ])}),
+            ("sizeiso", {"hyperparams": OrderedDict([
                 ("min_sigma_factor", np.arange(2, 3.1, 1)),
                 ("max_sigma_factor", np.arange(3, 4.1, 1)),
                 ("isotropic", make_hyperparm_arr(0.2, 1, 9, 3, 0)),
-            ])),
+            ])}),
         ])
 
     @staticmethod

--- a/magmap/settings/grid_search_prof.py
+++ b/magmap/settings/grid_search_prof.py
@@ -47,26 +47,24 @@ def make_hyperparm_arr(start, stop, num_steps, num_col, coli, base=1):
 class GridSearchProfile(profiles.SettingsDict):
     """Grid search profile dictionary.
 
-    This dictionary is used to set up combinations of parameter values for
-    hyperparameter tuning. The dictionary is in the format:
-    ``self[profile_name]: {
-        hyperparam1: [param1_val1, param1_val2, ...],
-        hyperparm2: [param2_val1, param2_val2, ...], ...
-    }, ...``.
-
-    Hyperparameter combinations can thus be accessed via profile names.
-    Unlike other :class:`profiles.SettingsDict` sub-classes, adding new
-    profile dicts does not update corresponding keys, but rather adds
-    the entire dict as the item value.
-
-    Attributes:
-        PATH_PREFIX (str): Prefix for grid search profile files.
+    This profile is used to set up combinations of parameter values for
+    hyperparameter tuning in a grid search. Hyperparameter dictionaries are
+    in the format::
+    
+        {
+            hyperparam1: [param1_val1, param1_val2, ...],
+            hyperparm2: [param2_val1, param2_val2, ...],
+            ...
+        }
+    
 
     """
-
-    PATH_PREFIX = "grid"
     
-    #: Ordered dictionary of hyperparameters.
+    #: Prefix for grid search profile files.
+    PATH_PREFIX: str = "grid"
+    
+    #: Ordered dictionary of hyperparameters, which should consist of key-pairs
+    #: in the format: ``<ROIProfile-key>: <seq-of-param-vals>``.
     hyperparams: OrderedDict[str, Sequence[float]] = dataclasses.field(
         default_factory=OrderedDict)
 
@@ -86,52 +84,54 @@ class GridSearchProfile(profiles.SettingsDict):
         # update with args
         self.update(*args, **kwargs)
 
-        #: Nested dictionary where each sub-dictionary
-        # contains a sequence of values over which to perform a grid search to
-        # generate a receiver operating characteristic curve
-        self.profiles: OrderedDict[str, Dict[str, OrderedDict[str, Sequence[float]]]] = OrderedDict([
-            ("gridtest", {"hyperparams": OrderedDict([
-                # test single value by iterating on value that should not affect
-                # detection ability
-                ("points_3d_thresh", [0.7]),
-
-                # unfused baseline
-                #("clip_vmax", 98.5),
-                #("clip_max", 0.5),
-                #("clip_vmax", np.arange(98.5, 99, 0.5)),
-                #("clip_max", np.arange(0.5, 0.6, 0.1)),
-
-                # test parameters
-                #("isotropic", make_hyperparm_arr(0.2, 1, 9, 3, 0),
-                #("isotropic", np.array([(0.96, 1, 1)])),
-                #("overlap", np.arange(0.1, 1.0, 0.1)),
-                #("prune_tol_factor", np.array([(4, 1.3, 1.3)])),
-                #("prune_tol_factor", make_hyperparm_arr(0.5, 1, 2, 0.9, 0)),
-                #("clip_min", np.arange(0.0, 0.2, 0.1)),
-                #("clip_vmax", np.arange(97, 100.5, 0.5)),
-                #("clip_max", np.arange(0.3, 0.7, 0.1)),
-                #("erosion_threshold", np.arange(0.16, 0.35, 0.02)),
-                #"denoise_size", np.arange(5, 25, 2)
-                #("unsharp_strength", np.arange(0.0, 1.1, 0.1)),
-                #("tot_var_denoise", (False, True)),
-                #("num_sigma", np.arange(5, 16, 1)),
-                #("detection_threshold", np.arange(0.001, 0.01, 0.001)),
-                #("segment_size", np.arange(130, 160, 20)),
-            ])}),
-            ("size5x", {"hyperparams": OrderedDict([
-                ("min_sigma_factor", np.arange(2, 2.71, 0.1)),
-                ("max_sigma_factor", np.arange(2.7, 3.21, 0.1)),
-            ])}),
-            ("size4x", {"hyperparams": OrderedDict([
-                ("min_sigma_factor", np.arange(2.5, 3.51, 0.3)),
-                ("max_sigma_factor", np.arange(3.5, 4.51, 0.3)),
-            ])}),
-            ("sizeiso", {"hyperparams": OrderedDict([
-                ("min_sigma_factor", np.arange(2, 3.1, 1)),
-                ("max_sigma_factor", np.arange(3, 4.1, 1)),
-                ("isotropic", make_hyperparm_arr(0.2, 1, 9, 3, 0)),
-            ])}),
-        ])
+        #: Profiles as collections of pre-defined hyperparameters in an
+        #: ordered dict. Keys are the names of each group. Each group contains
+        #: a dict with a "hyperparams" key to another ordered dict with
+        #: hyperparameters as defined by :attr:`hyperparams`.
+        self.profiles: OrderedDict[str, Dict[str, OrderedDict[
+            str, Sequence[float]]]] = OrderedDict([
+                ("gridtest", {"hyperparams": OrderedDict([
+                    # test single value by iterating on value that should not
+                    # affect detection ability
+                    ("points_3d_thresh", [0.7]),
+    
+                    # unfused baseline
+                    #("clip_vmax", 98.5),
+                    #("clip_max", 0.5),
+                    #("clip_vmax", np.arange(98.5, 99, 0.5)),
+                    #("clip_max", np.arange(0.5, 0.6, 0.1)),
+    
+                    # test parameters
+                    #("isotropic", make_hyperparm_arr(0.2, 1, 9, 3, 0),
+                    #("isotropic", np.array([(0.96, 1, 1)])),
+                    #("overlap", np.arange(0.1, 1.0, 0.1)),
+                    #("prune_tol_factor", np.array([(4, 1.3, 1.3)])),
+                    #("prune_tol_factor", make_hyperparm_arr(0.5, 1, 2, 0.9, 0)),
+                    #("clip_min", np.arange(0.0, 0.2, 0.1)),
+                    #("clip_vmax", np.arange(97, 100.5, 0.5)),
+                    #("clip_max", np.arange(0.3, 0.7, 0.1)),
+                    #("erosion_threshold", np.arange(0.16, 0.35, 0.02)),
+                    #"denoise_size", np.arange(5, 25, 2)
+                    #("unsharp_strength", np.arange(0.0, 1.1, 0.1)),
+                    #("tot_var_denoise", (False, True)),
+                    #("num_sigma", np.arange(5, 16, 1)),
+                    #("detection_threshold", np.arange(0.001, 0.01, 0.001)),
+                    #("segment_size", np.arange(130, 160, 20)),
+                ])}),
+                ("size5x", {"hyperparams": OrderedDict([
+                    ("min_sigma_factor", np.arange(2, 2.71, 0.1)),
+                    ("max_sigma_factor", np.arange(2.7, 3.21, 0.1)),
+                ])}),
+                ("size4x", {"hyperparams": OrderedDict([
+                    ("min_sigma_factor", np.arange(2.5, 3.51, 0.3)),
+                    ("max_sigma_factor", np.arange(3.5, 4.51, 0.3)),
+                ])}),
+                ("sizeiso", {"hyperparams": OrderedDict([
+                    ("min_sigma_factor", np.arange(2, 3.1, 1)),
+                    ("max_sigma_factor", np.arange(3, 4.1, 1)),
+                    ("isotropic", make_hyperparm_arr(0.2, 1, 9, 3, 0)),
+                ])}),
+            ])
 
     @staticmethod
     def get_files(profiles_dir=None, filename_prefix=None):

--- a/magmap/settings/prefs_prof.py
+++ b/magmap/settings/prefs_prof.py
@@ -9,6 +9,15 @@ from magmap.settings import profiles
 class PrefsProfile(profiles.SettingsDict):
     """Application preferences profile."""
     
+    #: ROI Editor circles style.
+    roi_circles: str = ""
+    
+    #: ROI Editor planes selection.
+    roi_plane: str = ""
+    
+    #: ROI Editor styles selection.
+    roi_styles: str = ""
+    
     #: Figure save directory path.
     fig_save_dir: str = ""
     

--- a/magmap/settings/prefs_prof.py
+++ b/magmap/settings/prefs_prof.py
@@ -1,9 +1,17 @@
 """Preferences profile"""
 
+import dataclasses
+
 from magmap.settings import profiles
 
 
+@dataclasses.dataclass
 class PrefsProfile(profiles.SettingsDict):
+    """Application preferences profile."""
+    
+    #: Figure save directory path.
+    fig_save_dir: str = ""
+    
     def __init__(self, *args, **kwargs):
         """Initialize a preferences profile dictionary.
         
@@ -11,10 +19,4 @@ class PrefsProfile(profiles.SettingsDict):
             *args: 
             **kwargs: 
         """
-        super().__init__(self)
-        self[self.NAME_KEY] = self.DEFAULT_NAME
-        
-        self["fig_save_dir"] = ""
-        
-        # update with args
-        self.update(*args, **kwargs)
+        super().__init__(self, *args, **kwargs)

--- a/magmap/settings/prefs_prof.py
+++ b/magmap/settings/prefs_prof.py
@@ -1,0 +1,20 @@
+"""Preferences profile"""
+
+from magmap.settings import profiles
+
+
+class PrefsProfile(profiles.SettingsDict):
+    def __init__(self, *args, **kwargs):
+        """Initialize a preferences profile dictionary.
+        
+        Args:
+            *args: 
+            **kwargs: 
+        """
+        super().__init__(self)
+        self[self.NAME_KEY] = self.DEFAULT_NAME
+        
+        self["fig_save_dir"] = ""
+        
+        # update with args
+        self.update(*args, **kwargs)

--- a/magmap/settings/profiles.py
+++ b/magmap/settings/profiles.py
@@ -92,10 +92,6 @@ class SettingsDict(dict):
         
         # update with args
         self.update(*args, **kwargs)
-
-        #: bool: add a modifier directly as a value rather than updating
-        # this dict's settings with the corresponding keys
-        self._add_mod_directly = False
     
     def __repr__(self):
         """Represent with dict items and data class attributes."""
@@ -219,30 +215,6 @@ class SettingsDict(dict):
                 mods = self.profiles[profile_name]
         return mods
     
-    def add_profile(
-            self, profile_name: str,
-            mods: Optional[Dict[Union[str, Enum], Union[Dict, str]]]):
-        """Add a profile dictionary into this dictionary.
-        
-        The profile can consist of a subset of keys in this dictionary that
-        will override the current values of the corresponding keys.
-        If both the original and new value are dictionaries for any given key,
-        the original dictionary will be updated with rather than overwritten
-        by the new value.
-
-        Args:
-            profile_name: Name of the modifier, which will be appended to
-                the name of the current settings.
-            mods: Dictionary with which to update this instance.
-        
-        """
-        self[self.NAME_KEY] += self.delimiter + profile_name
-        if self._add_mod_directly:
-            # add/replace the value at mod_name with the found value
-            self[profile_name] = mods
-        else:
-            self.modify_settings(mods)
-
     def add_profiles(self, names_str):
         """Add profiles by names and files.
         
@@ -264,7 +236,8 @@ class SettingsDict(dict):
             # profiles determines the precedence of settings
             mods = self.get_profile(profile)
             if mods:
-                self.add_profile(profile, mods)
+                self[self.NAME_KEY] += self.delimiter + profile
+                self.modify_settings(mods)
 
         if config.verbose:
             _logger.debug("settings for '%s':", self[self.NAME_KEY])

--- a/magmap/settings/profiles.py
+++ b/magmap/settings/profiles.py
@@ -10,10 +10,13 @@ from enum import Enum, auto
 import glob
 import os
 import pprint
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Optional, TYPE_CHECKING, Union
 
 from magmap.io import yaml_io
 from magmap.settings import config
+
+if TYPE_CHECKING:
+    import pathlib
 
 _logger = config.logger.getChild(__name__)
 
@@ -290,3 +293,15 @@ class SettingsDict(dict):
                         return False
         print("Block settings are identical")
         return True
+    
+    def save_settings(self, path: Union[str, "pathlib.Path"]) -> Dict:
+        """Save current settings to YAML file.
+        
+        Args:
+            path: Output path.
+
+        Returns:
+            Saved dictionary, including any modifications
+
+        """
+        return yaml_io.save_yaml(path, self, convert_enums=True)

--- a/magmap/stats/mlearn.py
+++ b/magmap/stats/mlearn.py
@@ -62,11 +62,10 @@ def grid_search(
             print("adding iterable setting {}".format(key2))
             iterable_keys.append(key2)
             
-    def grid_iterate(i, iterable_keys, grid_dict, name, parent_params):
+    def grid_iterate(i, grid_dict, name, parent_params):
         key = iterable_keys[i]
         name = key if name is None else name + "-" + key
         print("name: {}".format(name))
-        stats = []
         if i < len(iterable_keys) - 1:
             name += "("
             for j in grid_dict[key]:
@@ -82,7 +81,7 @@ def grid_search(
                 else:
                     name += " {}".format(j)
                 grid_iterate(
-                    i + 1, iterable_keys, grid_dict, name, parent_params)
+                    i + 1, grid_dict, name, parent_params)
         else:
             # process each value in parameter array
             stats = []
@@ -98,7 +97,7 @@ def grid_search(
             iterable_dict[name] = (
                 stats, last_param_vals, key, parent_params)
     
-    grid_iterate(0, iterable_keys, hyperparams, None, OrderedDict())
+    grid_iterate(0, hyperparams, None, OrderedDict())
     stats_dict["grid"] = iterable_dict
     
     # summary of each file collected together

--- a/magmap/tests/test_libmag.py
+++ b/magmap/tests/test_libmag.py
@@ -7,8 +7,8 @@ import unittest
 
 from magmap.io import libmag
 
+
 class TestLibmag(unittest.TestCase):
-    
     
     def test_insert_before_ext(self):
         self.assertEqual(libmag.insert_before_ext(
@@ -19,18 +19,21 @@ class TestLibmag(unittest.TestCase):
             "foo/bar/item", "totest", "_"), "foo/bar/item_totest")
             
     def test_splitext(self):
-        self.assertEqual(libmag.splitext("foo/bar/item.py"), ("foo/bar/item", ".py"))
+        self.assertEqual(
+            libmag.splitext("foo/bar/item.py"), ("foo/bar/item", ".py"))
         self.assertEqual(libmag.splitext("item.py"), ("item", ".py"))
         self.assertEqual(libmag.splitext("foo/bar/item"), ("foo/bar/item", ""))
-        self.assertEqual(libmag.splitext("foo/bar/item.file.ext"), (
-            "foo/bar/item.file", ".ext"))
+        self.assertEqual(
+            libmag.splitext("foo/bar/item.file.ext"),
+            ("foo/bar/item.file", ".ext"))
         self.assertEqual(libmag.splitext("foo/bar/item.file.py"), (
-        "foo/bar/item.file", ".py"))
+            "foo/bar/item.file", ".py"))
         
     def test_match_ext(self):
-        self.assertEqual(libmag.match_ext(
-            "foo1/bar1/item1.ext1", "foo2/bar2/item2.ext2"), "foo2/bar2/item2.ext1")
-        # if there is no extension in the path to match, it will retain its own extension
+        self.assertEqual(
+            libmag.match_ext("foo1/bar1/item1.ext1", "foo2/bar2/item2.ext2"),
+            "foo2/bar2/item2.ext1")
+        # if there is no extension in the path to match, it will retain its own
         self.assertEqual(libmag.match_ext(
             "foo1/bar1/item1", "foo2/bar2/item2.ext2"), "foo2/bar2/item2.ext2")
         self.assertEqual(libmag.match_ext(
@@ -45,8 +48,10 @@ class TestLibmag(unittest.TestCase):
             "foo2/bar2/item2.file2.ext1"))
             
     def test_get_filename_without_ext(self):
-        self.assertEqual(libmag.get_filename_without_ext("foo/bar/item.py"), "item")
-        self.assertEqual(libmag.get_filename_without_ext("foo/bar/item"), "item")
+        self.assertEqual(
+            libmag.get_filename_without_ext("foo/bar/item.py"), "item")
+        self.assertEqual(
+            libmag.get_filename_without_ext("foo/bar/item"), "item")
         self.assertEqual(libmag.get_filename_without_ext(
             "foo/bar/item.file.py"), "item.file")
         self.assertEqual(libmag.get_filename_without_ext("item.py"), "item")
@@ -70,19 +75,21 @@ class TestLibmag(unittest.TestCase):
         self.assertEqual(libmag.series_as_str("123456789"), "123456789")
         
     def test_splice_before(self):
-        self.assertEqual(libmag.splice_before("base", "file", "edit"), ("base"))
+        self.assertEqual(
+            libmag.splice_before("base", "file", "edit"), ("base",))
         self.assertEqual(libmag.splice_before(
-        "foo/bar/item.py", "item", "file"), "foo/bar/file_item.py")
+            "foo/bar/item.py", "item", "file"), "foo/bar/file_item.py")
         self.assertEqual(libmag.splice_before(
-        "foo/bar/item.py", "edit", "file"), "foo/bar/item_file.py")
+            "foo/bar/item.py", "edit", "file"), "foo/bar/item_file.py")
         self.assertEqual(libmag.splice_before(
-        "foo/bar/item.py", "item", "file", "/"), "foo/bar/file/item.py")
+            "foo/bar/item.py", "item", "file", "/"), "foo/bar/file/item.py")
         
     def test_str_to_disp(self):
         self.assertEqual(libmag.str_to_disp("this_is_a_test"), "this is a test")
         self.assertEqual(libmag.str_to_disp(
-        "       this is a test         "), "this is a test")
-        self.assertEqual(libmag.str_to_disp("    this_is a_test    "), "this is a test")
+            "       this is a test         "), "this is a test")
+        self.assertEqual(
+            libmag.str_to_disp("    this_is a_test    "), "this is a test")
         
     def test_get_int(self):
         self.assertEqual(libmag.get_int("5"), 5)

--- a/magmap/tests/test_libmag.py
+++ b/magmap/tests/test_libmag.py
@@ -76,7 +76,7 @@ class TestLibmag(unittest.TestCase):
         
     def test_splice_before(self):
         self.assertEqual(
-            libmag.splice_before("base", "file", "edit"), ("base",))
+            libmag.splice_before("base", "file", "edit"), "base")
         self.assertEqual(libmag.splice_before(
             "foo/bar/item.py", "item", "file"), "foo/bar/file_item.py")
         self.assertEqual(libmag.splice_before(

--- a/magmap/tests/test_visualizer.py
+++ b/magmap/tests/test_visualizer.py
@@ -1,0 +1,38 @@
+# MagellanMapper unit testing for visualizer
+"""Unit testing for the MagellanMapper visualizer module."""
+
+import unittest
+
+from magmap.gui import roi_editor, visualizer
+
+
+class TestVisualizer(unittest.TestCase):
+    
+    def test_validate_pref(self):
+        # select from enum
+        default = roi_editor.ROIEditor.CircleStyles.CIRCLES.value
+        circles = roi_editor.ROIEditor.CircleStyles.REPEAT_CIRCLES.value
+        pref = visualizer.Visualization.validate_pref(
+            circles, default, roi_editor.ROIEditor.CircleStyles)
+        self.assertEqual(pref, circles)
+
+        circles += "!"
+        pref = visualizer.Visualization.validate_pref(
+            circles, default, roi_editor.ROIEditor.CircleStyles)
+        self.assertEqual(pref, default)
+        
+        # select from list
+        default = visualizer.Visualization._DEFAULTS_PLANES_2D[0]
+        plane = visualizer.Visualization._DEFAULTS_PLANES_2D[1]
+        pref = visualizer.Visualization.validate_pref(
+            plane, default, visualizer.Visualization._DEFAULTS_PLANES_2D)
+        self.assertEqual(pref, plane)
+
+        plane = None
+        pref = visualizer.Visualization.validate_pref(
+            plane, default, visualizer.Visualization._DEFAULTS_PLANES_2D)
+        self.assertEqual(pref, default)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,8 @@ config = {
         # part of stdlib in Python >= 3.8
         "importlib-metadata >= 1.0 ; python_version < '3.8'",
         "tifffile",
+        # part of stdlib in Python >= 3.7
+        "dataclasses ; python_version < '3.7'",
     ], 
     "extras_require": {
         "import": _EXTRAS_IMPORT, 


### PR DESCRIPTION
MagellanMapper [stores settings](https://magellanmapper.readthedocs.io/en/latest/settings.html) in a variety of ways, but most GUI settings are not saved automatically. This PR uses the existing `SettingsDict` profiles class to store user preferences, starting with GUI state.

Profiles have been built on dictionaries, with additional methods to support updating from sub-profiles and saving to YAML files. A drawback of using dicts, however, is that keys had to be managed manually, either through strings or by using Enums. To simply this handling and to make data access safer, we are starting to convert these profiles from dicts to data classes. By using data classes, settings can be defined as attributes, with fields predefined and typing specified.

To ease migration, we will first add `dataclass` as an additional inheritance, alongside dict. Keys that are not found in the dict will be updated as data class attributes instead. Currently, no data class attributes are defined in the base class, but subclasses can add the `dataclass` decorator and define these attributes, which the base class will handle when updating settings or saving to YAML files.

Grid search profiles have inherited from `SettingsDict` but added settings differently from the other profiles, simply adding each profile as a new item with the profile name as the key. Instead of adding them to the dict with user-defined keys, add a data class parameter that takes the ordered dictionary of grid search hyperparameters. These hyperparameters can now be accessed without knowing the profile keys.

The prior setup allowed adding multiple grid search profiles to the same dict. This setup is rarely required, however, since each grid search could be run sequentially in separate sessions rather than all in the same session, which also had the problem of leaving stale settings from each run. As a simplification, this change allows only one set of hyperparameters in the dict/data class at a time. It also has the benefit of layering profile modifications on top of one another when adding multiple profiles, which is consistent with the behavior of the ROI and atlas profiles.

Since `dataclasses` are in Python >= 3.7, we have updated the dependencies to install the backported packaged for Python 3.6 to continue supporting this version in MagellanMapper.

Comparison with existing settings in MagellanMapper:
- The TraitsUI GUI library stores some preferences, such as window size and position, but not many other settings as far as we know
- ROI and atlas profiles allow users to collect settings for various pipelines, but they require editing text files. This new preferences mechanism leverages the profiles' setup to store user state automatically.
- The CLI allows changing settings per session. For preferences that have not been set or for inherently transient settings such as ROI position, we can consider using these CLI settings to update the preferences.