### PR TITLE
Fixes roundup for GUI, image loading

### DIFF
--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -15,9 +15,12 @@
 - Drag and remove loaded profiles in the Profiles tab table
 - "Help" buttons added to open the online documentation (#109)
 - Default confirmation labels can be set before detection (#115)
+- Resets the labels reference file path when reloading an image in the GUI (#139)
 - Fixed to reset the ROI selector when redrawing (#115)
 - Fixed to reorient the camera after clearing the 3D space (#121)
 - Fixed to turn off the minimum intensity slider's auto setting when manually changing the slider (#126) 
+- Fixed error window when moving the atlas level slider before a 3D image has been rendered (#139)
+- Fixed saving blobs in an ROI using the first displayed ROI or after moving the sliders without redrawing (#139)
 
 #### CLI
 
@@ -65,6 +68,7 @@
 - The `--proc export_planes` task can export a subset of image planes specified by `--slice`, or an ROI specified by `--offset` and `--size`
 - Image metadata is stored in the `Image5d` image object (#115)
 - Fixed re-importing an image after loading it (#117)
+- Fixed to store the image path when loading a registered image as the main image, which fixes saving the experiment name used when saving blobs (#139)
 
 #### Server pipelines
 

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -911,9 +911,9 @@ class Visualization(HasTraits):
         if self._margin is None:
             self._margin = (5, 5, 3)  # x,y,z
         
-        # store ROI offset for currently drawn plot in case user previews a
-        # new ROI offset, which shifts the current offset sliders
-        self._drawn_offset = self._curr_offset()
+        #: ROI offset at which viewers were drawn. May differ from the
+        #: current state of the offset sliders.
+        self._drawn_offset: Sequence[int] = self._curr_offset()
 
         # setup interface for image
         self._ignore_filename = False  # ignore file update trigger
@@ -1727,9 +1727,8 @@ class Visualization(HasTraits):
             self.z_high, self.y_high, self.x_high = config.image5d.shape[1:4]
             if config.roi_offset is not None:
                 # apply user-defined offsets
-                self.x_offset = config.roi_offset[0]
-                self.y_offset = config.roi_offset[1]
-                self.z_offset = config.roi_offset[2]
+                self.x_offset, self.y_offset, self.z_offset = config.roi_offset
+                self._drawn_offset = self._curr_offset()
             self.roi_array = ([[100, 100, 12]] if config.roi_size is None
                               else [config.roi_size])
             

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -18,7 +18,7 @@ from enum import auto, Enum
 import os
 import subprocess
 import sys
-from typing import Optional
+from typing import Optional, Sequence
 
 import matplotlib
 matplotlib.use("Qt5Agg")  # explicitly use PyQt5 for custom GUI events

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -1347,7 +1347,7 @@ class Visualization(HasTraits):
         print("segments", self.segments)
         segs_transposed = []
         segs_to_delete = []
-        offset = self._curr_offset()
+        offset = self._drawn_offset
         curr_roi_size = self.roi_array[0].astype(int)
         print("Preparing to insert segments to database with border widths {}"
               .format(self.border))
@@ -1405,7 +1405,7 @@ class Visualization(HasTraits):
         exp_id = config.db.select_or_insert_experiment(exp_name)
         roi_id, out = sqlite.select_or_insert_roi(
             config.db.conn, config.db.cur, exp_id, config.series, 
-            np.add(self._drawn_offset, self.border).tolist(),
+            np.add(offset, self.border).tolist(),
             np.subtract(curr_roi_size, np.multiply(self.border, 2)).tolist())
         sqlite.delete_blobs(
             config.db.conn, config.db.cur, roi_id, segs_to_delete)

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -1789,13 +1789,14 @@ class Visualization(HasTraits):
             self._main_img_name = self._main_img_names.selections[0]
             self._labels_img_name = labels_suffix
             
-            # get labels reference file path, prioritizing CLI arg
+            # get labels reference file path, prioritizing CLI arg, and
+            # populate labels reference path field
             lbls_ref = config.load_labels
             if not lbls_ref and config.labels_metadata:
                 lbls_ref = config.labels_metadata.path_ref
-            if lbls_ref:
-                # populate labels reference path field
-                self._labels_ref_path = lbls_ref
+            if not lbls_ref:
+                lbls_ref = ""
+            self._labels_ref_path = lbls_ref
 
         # set up image adjustment controls
         self._init_imgadj()

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -1480,9 +1480,11 @@ class Visualization(HasTraits):
             self._atlas_label = ontology.get_label(
                 center[::-1], config.labels_img, config.labels_ref_lookup, 
                 config.labels_scaling, level, rounding=True)
-            if self._atlas_label is not None:
+            
+            if self._atlas_label is not None and self.scene_3d_shown:
                 title = ontology.get_label_name(self._atlas_label)
                 if title is not None:
+                    # update title in 3D viewer
                     self._mlab_title = self.scene.mlab.title(title)
     
     def _post_3d_display(self, title="clrbrain3d", show_orientation=True):

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -2282,7 +2282,8 @@ class Visualization(HasTraits):
                 self.segs_cmap = get_atlas_cmap(
                     detector.Blobs.get_blob_abs_coords(
                         segs_all[self.segs_in_mask]))
-                if self.blobs.blob_matches is not None:
+                if (self.blobs.blob_matches is not None and
+                        self.blobs.blob_matches.coords is not None):
                     self.blobs.blob_matches.cmap = get_atlas_cmap(
                         np.add(self.blobs.blob_matches.coords, offset[::-1]))
             

--- a/magmap/io/np_io.py
+++ b/magmap/io/np_io.py
@@ -396,6 +396,7 @@ def setup_images(
                 path, atlas_suffix, make_3d=True)[None]
             config.img5d.img = config.image5d
             config.img5d.img_io = config.LoadIO.SITK
+            config.img5d.path_img = path
         except FileNotFoundError as e:
             print(e)
     


### PR DESCRIPTION
This PR contains a bunch of fixes:
- Error window when moving the atlas level slider before a 3D image has been rendered
- Resets the labels reference file path when reloading an image in the GUI
- Fixed saving blobs in an ROI using the first displayed ROI or after moving the sliders without redrawing
- Fixed to store the image path when loading a registered image as the main image, which fixes saving the experiment name used when saving blobs
- Fixed loading blobs in the GUI when blob matches are present but without coordinates