### PR TITLE
Populate the region selector with atlas label names, remap atlas levels, and prompt before redrawing edited viewers

### DIFF
--- a/magmap/atlas/ontology.py
+++ b/magmap/atlas/ontology.py
@@ -260,7 +260,7 @@ class LabelsRef:
                            f"file: {e}")
         return id_dict
 
-    def get_ref_lookup_as_df(self):
+    def get_ref_lookup_as_df(self) -> Optional[pd.DataFrame]:
         """Get the reference lookup dict as a data frame.
         
         Returns:
@@ -268,6 +268,10 @@ class LabelsRef:
             as-is if it is already a data frame.
 
         """
+        if self.ref_lookup is None:
+            # return immediately if no reference dict to convert
+            return None
+        
         if isinstance(self.ref_lookup, pd.DataFrame):
             # return existing data frame
             return self.ref_lookup

--- a/magmap/atlas/ontology.py
+++ b/magmap/atlas/ontology.py
@@ -515,6 +515,41 @@ def labels_to_parent(labels_ref_lookup, level=None,
     return label_parents
 
 
+def make_labels_level(
+        labels_np: np.ndarray, ref: "LabelsRef", level: int) -> np.ndarray:
+    """
+    
+    Args:
+        labels_np: Labels image.
+        ref: Atlas labels reference.
+        level: Level at which ``labels_np`` will be remapped.
+
+    Returns:
+        The remapped ``labels_np``, which will be altered in-place.
+
+    """
+    ids = list(ref.ref_lookup.keys())
+    for key in ids:
+        # get keys from both sides of atlas
+        keys = [key, -1 * key]
+        for region in keys:
+            if region == 0: continue
+            # get ontological label
+            label = ref.ref_lookup[abs(region)]
+            label_level = label[NODE][config.ABAKeys.LEVEL.value]
+            
+            if label_level == level:
+                # get children (including parent first) at given level 
+                # and replace them with parent
+                label_ids = get_children_from_id(
+                    ref.ref_lookup, region)
+                labels_region = np.isin(labels_np, label_ids)
+                print("replacing labels within", region)
+                labels_np[labels_region] = region
+    
+    return labels_np
+
+
 def get_label_item(label, item_key, key=NODE):
     """Convenience function to get the item from the sub-label.
 

--- a/magmap/atlas/register.py
+++ b/magmap/atlas/register.py
@@ -2356,7 +2356,8 @@ def main():
         if len(config.filenames) < 2:
             print("Please provide paths to 2 labels images")
             return
-        labels_imgs = [sitk_io.read_sitk_files(p) for p in config.filenames[:2]]
+        labels_imgs = [
+            sitk_io.read_sitk_files(p).img[0] for p in config.filenames[:2]]
         spacing = scaling
         if spacing is None and len(config.resolutions) > 0:
             # default to using loaded metadata

--- a/magmap/gui/atlas_editor.py
+++ b/magmap/gui/atlas_editor.py
@@ -302,6 +302,7 @@ class AtlasEditor(plot_support.ImageSyncMixin):
             if ed.edited:
                 # display save button as enabled if any editor has been edited
                 enable_btn(self.save_btn)
+                self.edited = True
         if update_atlas_eds and self.fn_refresh_atlas_eds is not None:
             # callback to synchronize other Atlas Editors
             self.fn_refresh_atlas_eds(self)
@@ -378,6 +379,7 @@ class AtlasEditor(plot_support.ImageSyncMixin):
         
         # reset edited flag in all editors and show save button as disabled
         for ed in self.plot_eds.values(): ed.edited = False
+        self.edited = False
         enable_btn(self.save_btn, False)
         print("Saved labels image at {}".format(datetime.datetime.now()))
     

--- a/magmap/gui/atlas_editor.py
+++ b/magmap/gui/atlas_editor.py
@@ -356,12 +356,12 @@ class AtlasEditor(plot_support.ImageSyncMixin):
         except ValueError as e:
             print(e)
     
-    def save_atlas(self, event):
+    def save_atlas(self, event=None):
         """Save atlas labels using the registered image suffix given by
         :attr:`config.reg_suffixes[config.RegSuffixes.ANNOTATION]`.
         
         Args:
-            event: Button event, currently not used.
+            event: Button event, currently not used; defaults to None.
         
         """
         # only save if at least one editor has been edited

--- a/magmap/gui/atlas_threads.py
+++ b/magmap/gui/atlas_threads.py
@@ -1,0 +1,45 @@
+# Atlas-related PyQt5 threads
+from typing import Any, Callable, Optional
+
+from PyQt5 import QtCore
+
+from magmap.atlas import ontology
+from magmap.settings import config
+
+_logger = config.logger.getChild(__name__)
+
+
+class RemapLevelThread(QtCore.QThread):
+    """Thread for remapping a labels image to a different atlas level."""
+    
+    signal = QtCore.pyqtSignal(object)
+    signal_prog = QtCore.pyqtSignal(object, object)
+    
+    def __init__(
+            self, level: Optional[int], fn_success: Callable[[Any], None],
+            fn_prog: Callable[[int, str], None]):
+        """Initialize the import thread."""
+        super().__init__()
+        self.level: Optional[int] = level
+        self.signal.connect(fn_success)
+        self.signal_prog.connect(fn_prog)
+    
+    def update_prog(self, pct, msg):
+        """Update progress bar."""
+        self.signal_prog.emit(pct, msg)
+    
+    def run(self):
+        """Set up image import metadata."""
+        self.update_prog(0, "Initializing atlas level remapping")
+        if (config.labels_img is None or config.labels_ref is None or
+                config.labels_ref.ref_lookup is None or self.level is None):
+            # skip if labels, reference, or level are not available
+            self.update_prog(0, "Labels image or reference not available")
+            return
+        
+        # remap atlas labels image to the given level
+        labels_np = ontology.make_labels_level(
+            config.labels_img, config.labels_ref, self.level, self.update_prog)
+        self.signal.emit(labels_np)
+        self.update_prog(100, "Completed atlas level remapping")
+

--- a/magmap/gui/plot_editor.py
+++ b/magmap/gui/plot_editor.py
@@ -184,6 +184,8 @@ class PlotEditor:
         self.scale_bar = False
         self.max_intens_proj = 0
         self.enable_painting = True
+        #: Ontology level at which to show region names.
+        self.labels_level: Optional[int] = None
 
         self._plot_ax_imgs = None
         self._ax_img_labels = None  # displayed labels image
@@ -1046,7 +1048,8 @@ class PlotEditor:
                         # labels image value under mouse pointer
                         atlas_label = ontology.get_label(
                             coord, self.img3d_labels,
-                            config.labels_ref.ref_lookup, self.scaling)
+                            config.labels_ref.ref_lookup, self.scaling,
+                            self.labels_level)
                         if atlas_label is not None:
                             # extract name and ID from label dict
                             name = "{} ({})".format(

--- a/magmap/gui/plot_editor.py
+++ b/magmap/gui/plot_editor.py
@@ -1036,15 +1036,17 @@ class PlotEditor:
                         self.coord = coord
                         self.fn_update_coords(self.coord, self.plane)
                 
-                if self.img3d_labels is not None and config.labels_ref_lookup:
+                if (self.img3d_labels is not None and
+                        config.labels_ref is not None and
+                        config.labels_ref.ref_lookup):
                     # show atlas label description
                     name = ""
                     if self._show_labels:
                         # get name from labels reference corresponding to
                         # labels image value under mouse pointer
                         atlas_label = ontology.get_label(
-                            coord, self.img3d_labels, config.labels_ref_lookup,
-                            self.scaling)
+                            coord, self.img3d_labels,
+                            config.labels_ref.ref_lookup, self.scaling)
                         if atlas_label is not None:
                             # extract name and ID from label dict
                             name = "{} ({})".format(

--- a/magmap/gui/vis_handler.py
+++ b/magmap/gui/vis_handler.py
@@ -70,6 +70,12 @@ class VisHandler(Handler):
             info.object.open_image)
         app.installEventFilter(self._file_open_handler)
         
+        # move progress bar to status bar
+        status_widgets = info.ui.control.findChildren(QtWidgets.QStatusBar)
+        prog_widgets = info.ui.control.findChildren(QtWidgets.QProgressBar)
+        if status_widgets and prog_widgets:
+            status_widgets[0].addPermanentWidget(prog_widgets[0])
+        
         # create TraitsUI preferences database if it does not exist
         pathlib.Path(traits_home()).mkdir(parents=True, exist_ok=True)
         db = info.ui.get_ui_db("c")

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -2109,6 +2109,9 @@ class Visualization(HasTraits):
             if self.atlas_eds:
                 for ed in self.atlas_eds:
                     ed.labels_img = labels_np
+            
+            # redraw editor
+            self.redraw_selected_viewer()
         
         # remap labels image in separate thread
         self._remap_level_thread = atlas_threads.RemapLevelThread(
@@ -2162,7 +2165,7 @@ class Visualization(HasTraits):
             # prompt to save before redrawing if edited
             if ed.edited:
                 response = confirmation_dialog.confirm(
-                    None, "Edits have not been saved. Save and redraw?",
+                    None, "Edits have not been saved. Save before redrawing?",
                     "Save before redraw?", True, YES)
                 if response == YES:
                     fn()

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -1803,13 +1803,8 @@ class Visualization(HasTraits):
             self._main_img_name = self._main_img_names.selections[0]
             self._labels_img_name = labels_suffix
             
-            # get labels reference file path, prioritizing CLI arg, and
             # populate labels reference path field
-            lbls_ref = config.load_labels
-            if not lbls_ref and config.labels_metadata:
-                lbls_ref = config.labels_metadata.path_ref
-            if not lbls_ref:
-                lbls_ref = ""
+            lbls_ref = config.labels_ref.path_ref if config.labels_ref else ""
             self._labels_ref_path = lbls_ref
 
             # populate region names combo box

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -478,9 +478,9 @@ class Visualization(HasTraits):
     
     # atlas labels
     _atlas_label = None
-    _structure_scale = Int  # ontology structure levels
     _structure_scale_low = -1
     _structure_scale_high = 20
+    _structure_scale = Int(_structure_scale_high)  # ontology structure levels
     _region_name = Str
     _region_names = Instance(TraitsList)
     _region_id = Str
@@ -1483,15 +1483,26 @@ class Visualization(HasTraits):
         if self._mlab_title is not None:
             self._mlab_title.remove()
             self._mlab_title = None
+        
+        level = self._structure_scale
+        if level == self._structure_scale_high:
+            # use drawn label rather than a specific level
+            level = None
+        
+        # set level in ROI and Atlas Editors
+        if self.roi_ed:
+            self.roi_ed.set_labels_level(level)
+        if self.atlas_eds:
+            for ed in self.atlas_eds:
+                ed.set_labels_level(level)
+        
         if (config.labels_ref is not None and
                 config.labels_ref.ref_lookup is not None and
                 curr_offset is not None and curr_roi_size is not None):
+            # get atlas label at ROI center
             center = np.add(
                 curr_offset, 
                 np.around(np.divide(curr_roi_size, 2)).astype(np.int))
-            level = self._structure_scale
-            if level == self._structure_scale_high:
-                level = None
             self._atlas_label = ontology.get_label(
                 center[::-1], config.labels_img, config.labels_ref.ref_lookup, 
                 config.labels_scaling, level, rounding=True)

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -1472,6 +1472,10 @@ class Visualization(HasTraits):
         feedback_str = "\n".join(feedback)
         print(feedback_str)
         self.segs_feedback = feedback_str
+        
+        if self.roi_ed:
+            # reset the ROI Editor's edit flag
+            self.roi_ed.edited = False
 
     def _btn_save_segments_fired(self):
         """Handler to save blobs to database when triggered by Trait."""
@@ -3158,9 +3162,11 @@ class Visualization(HasTraits):
         seg[3] = -1 * abs(seg[3])
         detector.Blobs.set_blob_confirmed(seg, -1)
     
-    def update_segment(self, segment_new, segment_old=None, remove=False):
-        """Update this class object's segments list with a new or updated 
-        segment.
+    def update_segment(
+            self, segment_new: np.ndarray,
+            segment_old: Optional[np.ndarray] = None, remove: bool = False
+    ) -> np.ndarray:
+        """Update segments/blobs list with a new or updated segment.
         
         Args:
             segment_new: Segment to either add or update, including 
@@ -3178,6 +3184,7 @@ class Visualization(HasTraits):
         
         Returns:
             The updated segment.
+        
         """
         seg = segment_new
         # remove all row selections to ensure that no more than one 
@@ -3224,6 +3231,11 @@ class Visualization(HasTraits):
         
         # scroll to first selected row
         self._segs_row_scroll = min(self.segs_selected)
+        
+        if self.roi_ed:
+            # flag ROI Editor as edited
+            self.roi_ed.edited = True
+        
         return seg
     
     @property

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -3585,17 +3585,16 @@ class Visualization(HasTraits):
         """
         self._import_feedback += "{}\n".format(val)
 
-    def _update_roi_feedback(self, val, print_out=False):
+    def _update_roi_feedback(self, val: str, print_out: bool = False):
         """Update the ROI panel feedback text box.
 
         Args:
-            val (str): String to append as a new line.
-            print_out (bool): True to print to console as well; defaults
-                to False.
+            val: String to append as a new line.
+            print_out: True to print to log as well; defaults to False.
 
         """
         if print_out:
-            print(val)
+            _logger.info(val)
         self._roi_feedback += "{}\n".format(val)
 
 

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -1496,7 +1496,7 @@ class Visualization(HasTraits):
             for ed in self.atlas_eds:
                 ed.set_labels_level(level)
         
-        if (config.labels_ref is not None and
+        if (config.labels_img is not None and config.labels_ref is not None and
                 config.labels_ref.ref_lookup is not None and
                 curr_offset is not None and curr_roi_size is not None):
             # get atlas label at ROI center

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -1469,8 +1469,9 @@ class Visualization(HasTraits):
         if self._mlab_title is not None:
             self._mlab_title.remove()
             self._mlab_title = None
-        if (config.labels_ref_lookup is not None and curr_offset is not None 
-            and curr_roi_size is not None):
+        if (config.labels_ref is not None and
+                config.labels_ref.ref_lookup is not None and
+                curr_offset is not None and curr_roi_size is not None):
             center = np.add(
                 curr_offset, 
                 np.around(np.divide(curr_roi_size, 2)).astype(np.int))
@@ -1478,7 +1479,7 @@ class Visualization(HasTraits):
             if level == self._structure_scale_high:
                 level = None
             self._atlas_label = ontology.get_label(
-                center[::-1], config.labels_img, config.labels_ref_lookup, 
+                center[::-1], config.labels_img, config.labels_ref.ref_lookup, 
                 config.labels_scaling, level, rounding=True)
             
             if self._atlas_label is not None and self.scene_3d_shown:
@@ -2837,6 +2838,10 @@ class Visualization(HasTraits):
             self._roi_feedback = "No labels image loaded to find region"
             return
 
+        if config.labels_ref is None or config.labels_ref.ref_lookup is None:
+            self._roi_feedback = "No labels reference loaded to find region"
+            return
+
         # user-given region can be a comma-delimited list of region IDs
         # in the labels reference dict
         region_id_split = self._region_id.split(",")
@@ -2863,7 +2868,7 @@ class Visualization(HasTraits):
             region_ids.append(region_id)
         incl_chil = RegionOptions.INCL_CHILDREN.value in self._region_options
         centroid, self._img_region, region_ids = ontology.get_region_middle(
-            config.labels_ref_lookup, region_ids, config.labels_img,
+            config.labels_ref.ref_lookup, region_ids, config.labels_img,
             config.labels_scaling, both_sides=both_sides,
             incl_children=incl_chil)
         if centroid is None:

--- a/magmap/io/export_regions.py
+++ b/magmap/io/export_regions.py
@@ -458,22 +458,8 @@ def make_labels_level_img(img_path, level, prefix=None, show=False):
     labels_np = sitk.GetArrayFromImage(labels_sitk)
     ref = ontology.LabelsRef(config.load_labels).load()
     
-    ids = list(ref.ref_lookup.keys())
-    for key in ids:
-        keys = [key, -1 * key]
-        for region in keys:
-            if region == 0: continue
-            # get ontological label
-            label = ref.ref_lookup[abs(region)]
-            label_level = label[ontology.NODE][config.ABAKeys.LEVEL.value]
-            if label_level == level:
-                # get children (including parent first) at given level 
-                # and replace them with parent
-                label_ids = ontology.get_children_from_id(
-                    ref.ref_lookup, region)
-                labels_region = np.isin(labels_np, label_ids)
-                print("replacing labels within", region)
-                labels_np[labels_region] = region
+    # remap labels to given level
+    labels_np = ontology.make_labels_level(labels_np, ref, level)
     labels_level_sitk = sitk_io.replace_sitk_with_numpy(labels_sitk, labels_np)
     
     # generate an edge image at this level

--- a/magmap/io/np_io.py
+++ b/magmap/io/np_io.py
@@ -235,6 +235,7 @@ def setup_images(
     config.labels_img_orig = None
     config.borders_img = None
     config.labels_meta = None
+    config.labels_ref = None
     
     # reset blobs
     config.blobs = None
@@ -430,18 +431,20 @@ def setup_images(
         labels_path_ref = config.labels_metadata.path_ref
         if labels_path_ref:
             path_labels_refs.append(labels_path_ref)
+        labels_ref = None
         for ref in path_labels_refs:
             if not ref: continue
             try:
                 # load labels reference file
-                ref_lookup = ontology.LabelsRef(ref).load().ref_lookup
-                if ref_lookup is not None:
-                    config.labels_ref_lookup = ref_lookup
+                labels_ref = ontology.LabelsRef(ref).load()
+                if labels_ref.ref_lookup is not None:
+                    config.labels_ref = labels_ref
                     _logger.debug("Loaded labels reference file from %s", ref)
                     break
             except (FileNotFoundError, KeyError):
                 pass
-        if path_labels_refs and config.labels_ref_lookup is None:
+        if path_labels_refs and (
+                labels_ref is None or labels_ref.ref_lookup is None):
             # warn if labels path given but none found
             _logger.warn(
                 "Unable to load labels reference file from '%s', skipping",

--- a/magmap/plot/plot_support.py
+++ b/magmap/plot/plot_support.py
@@ -138,6 +138,16 @@ class ImageSyncMixin:
         for plot_ed in self.plot_eds.values():
             plot_ed._show_crosslines = val
 
+    def set_labels_level(self, val: int):
+        """Set the labels level all Plot Editors.
+
+        Args:
+            val: Labels level.
+
+        """
+        for plot_ed in self.plot_eds.values():
+            plot_ed.labels_level = val
+
     def update_max_intens_proj(self, shape, display=False):
         """Update max intensity projection planes.
         

--- a/magmap/plot/plot_support.py
+++ b/magmap/plot/plot_support.py
@@ -7,7 +7,7 @@ from collections import OrderedDict
 import math
 import os
 import warnings
-from typing import Any, List, Optional, Sequence, TYPE_CHECKING, Tuple, Union
+from typing import Any, Dict, List, Optional, Sequence, TYPE_CHECKING, Tuple, Union
 
 import numpy as np
 from matplotlib import backend_bases, gridspec, pyplot as plt
@@ -35,21 +35,18 @@ _logger = config.logger.getChild(__name__)
 
 
 class ImageSyncMixin:
-    """Mixin class for synchronizing editors with Matplotlib figures.
-    
-    Attributes:
-        fig (:class:`matplotlib.figure.Figure`): Matplotlib figure.
-        plot_eds (dict[Any, :class:`magmap.gui.plot_editor.PlotEditor`]):
-            Dictionary of plot editors.
-    
-    """
+    """Mixin class for synchronizing editors with Matplotlib figures."""
     
     def __init__(self):
-        self.fig = None
-        self.plot_eds = OrderedDict()
+        #: Matplotlib figure.
+        self.fig: Optional["figure.Figure"] = None
+        #: Dictionary of plot editors.
+        self.plot_eds: Dict[Any, "plot_editor.PlotEditor"] = OrderedDict()
+        #: Edited flag.
+        self.edited: bool = False
 
-        #: Union[int, Sequence[int]]: Plane(s) for max intensity projections.
-        self._max_intens_proj = None
+        #: Plane(s) for max intensity projections.
+        self._max_intens_proj: Optional[Union[int, Sequence[int]]] = None
 
     def get_img_display_settings(self, imgi, chl=None):
         """Get display settings for the given image.

--- a/magmap/settings/config.py
+++ b/magmap/settings/config.py
@@ -29,7 +29,7 @@ from magmap.settings import logs
 
 if TYPE_CHECKING:
     import SimpleITK as sitk
-    from magmap.atlas import labels_meta
+    from magmap.atlas import labels_meta, ontology
     from magmap.cv import detector
     from magmap.io import np_io
     from magmap.settings import prefs_prof
@@ -559,8 +559,8 @@ labels_img_sitk: Optional["sitk.Image"] = None
 labels_img_orig: Optional[np.ndarray] = None
 #: Scaling factors from ``labels_img`` to ``img5d``. 
 labels_scaling: Optional[Sequence[float]] = None
-#: Reference dictionary with keys corresponding to the IDs in the labels image.
-labels_ref_lookup: Optional[Dict[str, Any]] = None
+#: Labels reference IDs corresponding to the labels image values.
+labels_ref: Optional["ontology.LabelsRef"] = None
 labels_level = None
 labels_mirror = True
 borders_img = None

--- a/magmap/tests/test_img_equality.py
+++ b/magmap/tests/test_img_equality.py
@@ -20,7 +20,7 @@ class TestImgEquality:
             img1 = sitk_io.read_sitk_files(config.filenames[0], suffix)
             img2 = sitk_io.read_sitk_files(config.filenames[1], suffix)
             try:
-                testing.assert_array_equal(img1, img2)
+                testing.assert_array_equal(img1.img, img2.img)
                 _logger.info("%s are equal for %s", config.filenames[:2], key)
             except AssertionError as e:
                 _logger.error(e)

--- a/magmap/tests/test_visualizer.py
+++ b/magmap/tests/test_visualizer.py
@@ -32,6 +32,25 @@ class TestVisualizer(unittest.TestCase):
         pref = visualizer.Visualization.validate_pref(
             plane, default, visualizer.Visualization._DEFAULTS_PLANES_2D)
         self.assertEqual(pref, default)
+    
+    def test_get_changed_options(self):
+        curr_options = [visualizer.RegionOptions.BOTH_SIDES.value]
+        prev_options = {e: False for e in visualizer.RegionOptions}
+        options, changed = visualizer.Visualization.get_changed_options(
+            curr_options, prev_options, visualizer.RegionOptions)
+        self.assertTrue(options[visualizer.RegionOptions.BOTH_SIDES])
+        self.assertFalse(options[visualizer.RegionOptions.APPEND])
+        self.assertFalse(changed[visualizer.RegionOptions.APPEND])
+        self.assertTrue(changed[visualizer.RegionOptions.BOTH_SIDES])
+        
+        curr_options = [visualizer.RegionOptions.APPEND.value]
+        options, changed = visualizer.Visualization.get_changed_options(
+            curr_options, options, visualizer.RegionOptions)
+        self.assertFalse(options[visualizer.RegionOptions.BOTH_SIDES])
+        self.assertTrue(options[visualizer.RegionOptions.APPEND])
+        self.assertTrue(changed[visualizer.RegionOptions.APPEND])
+        self.assertTrue(changed[visualizer.RegionOptions.BOTH_SIDES])
+        self.assertFalse(changed[visualizer.RegionOptions.INCL_CHILDREN])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Here are several atlas navigation tools that I keep find myself needing:
- Region names are now entered automatically into the region navigator. Since the list is so long for atlases with many regions, it also has auto-complete so you can start typing in the name to bring it up quickly. Selecting a region brings you to it immediately, but you can check the "Append" option to build up multiple regions before navigating to them when unchecking the box.
- The atlas level slider now adjusts the atlas level at which regions are displayed when hovering over them in the viewers
- Next to the slider is a `Remap` button to remap the atlas labels to the selected level. This operation can take some time, so I have put it in a separate thread and added a progress bar to the status bar to remapping progress.
- Redrawing a viewer that has unsaved edits will now prompt the user to save before redrawing. This change will allow us to redraw automatically more often since we had avoided auto-redrawing to prevent unwanted loss of unsaved data.

There are also many changes under the hood, which may but hopefully haven't broken too many things:
- Atlas reference labels can now be loaded without loading any atlas images
- The full reference object is now stored instead of just its dictionary
- Registered images are loaded into `Image5d` objects to track additional metadata