### PR TITLE
Make Scikit-learn and AWS-related dependencies optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ MagellanMapper is a graphical imaging informatics suite for 3D reconstruction an
 
 ![ROI Editor and Atlas Editor screenshots](https://user-images.githubusercontent.com/1258953/83934132-f699aa00-a7e0-11ea-932c-0e58366d5061.png)
 
-<img align="right" width="200" src="https://currentprotocols.onlinelibrary.wiley.com/cms/asset/14209f75-4368-40c9-b83b-1bb866991a8b/cpns76-gra-0001-m.jpg" title="Current Protocols cover image">
+<a href="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7781073/"><img align="right" width="200" src="https://user-images.githubusercontent.com/1258953/179440433-0326c4d5-9a9b-4bae-92c7-d09416375bc5.png" title="Current Protocols cover image"></a>
 
 Related publications and datasets:
 - For more information on the methods used for 3D atlas construction, please see: https://elifesciences.org/articles/61408

--- a/bin/setup_venv.sh
+++ b/bin/setup_venv.sh
@@ -184,7 +184,7 @@ if [[ -n "$reqs" ]]; then
   pip install "${args_update[@]}" -r "$reqs" -e .
 else
   # import based on setup.py
-  pip install "${args_update[@]}" -e .[all] --extra-index-url \
+  pip install "${args_update[@]}" -e .[most] --extra-index-url \
     https://pypi.fury.io/dd8/
 fi
 

--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -121,6 +121,8 @@
 - `Tifffile` is now a direct dependency, previously already installed as a sub-dependency of other required packages
 - Updated to use the `axis_channel` parameter in Scikit-image's `transform.rescale` function (#115)
 - Seaborn as an optional dependency for additional plot support (currently only swarm plots, #137)
+- Scikit-learn is an optional rather than a required dependency (#150)
+- The AWS-related dependencies (`boto3`, `awscli`) are also no longer installed in Conda environments (#150)
 
 #### R Dependency Changes
 

--- a/environment.yml
+++ b/environment.yml
@@ -11,9 +11,6 @@ dependencies:
   - pandas
   - openpyxl
   - scikit-image
-  - scikit-learn
-  - boto3
-  - awscli
   - openjdk=8
   - pyqt
   - pyface

--- a/envs/environment_light.yml
+++ b/envs/environment_light.yml
@@ -8,7 +8,6 @@ dependencies:
   - pyamg
   - pandas
   - scikit-image
-  - scikit-learn
   - appdirs
   - tifffile
   - pip:

--- a/magmap/stats/clustering.py
+++ b/magmap/stats/clustering.py
@@ -6,8 +6,12 @@ import os
 
 import numpy as np
 import pandas as pd
-from sklearn import cluster
-from sklearn import neighbors
+try:
+    from sklearn import cluster
+    from sklearn import neighbors
+except ImportError:
+    cluster = None
+    neighbors = None
 
 from magmap.cv import chunking, detector
 from magmap.settings import config
@@ -18,6 +22,10 @@ from magmap.plot import plot_2d
 from magmap.settings import profiles
 from magmap.io import sitk_io
 from magmap.io import df_io
+
+_SKLEARN_ERR = (
+    "Scikit-learn is not installed. Please install, eg with "
+    "'pip install scikit-learn'")
 
 
 def knn_dist(blobs, n, max_dist=None, max_pts=None, show=True):
@@ -56,6 +64,9 @@ def knn_dist(blobs, n, max_dist=None, max_pts=None, show=True):
             title=config.plot_labels[config.PlotLabels.TITLE])
         return df
     
+    if not neighbors:
+        raise ImportError(_SKLEARN_ERR)
+
     #blobs = blobs[::int(len(blobs) / 1000)]  # TESTING: small num of blobs
     knn = neighbors.NearestNeighbors(n, n_jobs=-1).fit(blobs)
     print(knn)
@@ -256,6 +267,9 @@ def cluster_blobs(img_path, suffix=None):
     Returns:
 
     """
+    if not cluster:
+        raise ImportError(_SKLEARN_ERR)
+    
     mod_path = img_path
     if suffix is not None:
         mod_path = libmag.insert_before_ext(img_path, suffix)

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,6 @@ config = {
         "PyQt5",
         "pyface",
         "traitsui",
-        "scikit-learn",
         "simpleitk==2.0.2rc2.dev785+g8ac4f",  # pre-built SimpleElastix
         "PyYAML",
         "appdirs",
@@ -63,9 +62,10 @@ config = {
             "matplotlib_scalebar", 
             "pyamg",  # for Random-Walker segmentation "cg_mg" mode
             "seaborn",  # for Seaborn-based plots
+            "scikit-learn",
             *_EXTRAS_PANDAS,
-            *_EXTRAS_IMPORT,  
-            *_EXTRAS_AWS, 
+            *_EXTRAS_IMPORT,
+            *_EXTRAS_AWS,
         ]
     }, 
 }

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,15 @@ config = {
         "aws": _EXTRAS_AWS,
         "pandas_plus": _EXTRAS_PANDAS,
         "docs": _EXTRAS_DOCS,
+        
+        # dependencies for most common tasks
+        "most": [
+            "matplotlib_scalebar", 
+            "pyamg",  # for Random-Walker segmentation "cg_mg" mode
+            *_EXTRAS_IMPORT,
+        ],
+        
+        # (almost) all optional dependencies
         "all": [
             "matplotlib_scalebar", 
             "pyamg",  # for Random-Walker segmentation "cg_mg" mode


### PR DESCRIPTION
Scikit-learn, Boto3, and AWS CLI are not core dependencies and therefore can be moved to become optional.

- Pip installs: The `all` groups remains functionally the same, while a new `most` group is like `all` but without the above packages. The `setup_venv.sh` script now uses the `most` group by default.
- Conda installs: The above packages have been removed.

In either case, the packages can be installed manually by `pip` afterward.