### PR TITLE
Fix error importing `annotations` in Python 3.6

### DIFF
--- a/magmap/settings/grid_search_prof.py
+++ b/magmap/settings/grid_search_prof.py
@@ -2,8 +2,6 @@
 # Author: David Young, 2019, 2020
 """Profile settings for grid search hyperparameter tuning."""
 
-# import annotations to allow sub-type hints
-from __future__ import annotations
 from collections import OrderedDict
 import dataclasses
 from typing import Dict, List, Sequence
@@ -65,7 +63,7 @@ class GridSearchProfile(profiles.SettingsDict):
     
     #: Ordered dictionary of hyperparameters, which should consist of key-pairs
     #: in the format: ``<ROIProfile-key>: <seq-of-param-vals>``.
-    hyperparams: OrderedDict[str, Sequence[float]] = dataclasses.field(
+    hyperparams: "OrderedDict[str, Sequence[float]]" = dataclasses.field(
         default_factory=OrderedDict)
 
     def __init__(self, *args, **kwargs):

--- a/magmap/stats/mlearn.py
+++ b/magmap/stats/mlearn.py
@@ -3,8 +3,6 @@
 """Machine learning and output for MagellanMapper.
 """
 
-# import annotations to allow sub-type hints
-from __future__ import annotations
 from collections import OrderedDict
 from enum import Enum
 from typing import Any, Callable, Dict, Sequence, Tuple
@@ -31,10 +29,10 @@ class GridSearchStats(Enum):
 
 
 def grid_search(
-        hyperparams: OrderedDict[str, Sequence[float]],
+        hyperparams: "OrderedDict[str, Sequence[float]]",
         fnc: Callable[[Any], Tuple[Any, Sequence]],
         *fnc_args
-) -> OrderedDict[str, Tuple[Sequence, Sequence, str, OrderedDict]]:
+) -> "OrderedDict[str, Tuple[Sequence, Sequence, str, OrderedDict]]":
     """Perform a grid search for hyperparameter optimization.
 
     A separate grid search will be performed for each item in ``roc_dict``.
@@ -110,7 +108,7 @@ def grid_search(
 
 
 def parse_grid_stats(
-        stats: OrderedDict[str, Tuple[Sequence, Sequence, str, OrderedDict]]
+        stats: "OrderedDict[str, Tuple[Sequence, Sequence, str, OrderedDict]]"
 ) -> Tuple[Dict[str, Tuple[Sequence, Sequence, Sequence]], pd.DataFrame]:
     """Parse stats from a grid search.
     


### PR DESCRIPTION
Fixes a regression where Python 3.6 cannot import `annotations`. This `__future__` feature was only added in Python 3.7. As a workaround, remove these imports and replace the type hints with string literals.