### PR TITLE
Add `imagecodecs` as a dependency

### DIFF
--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -119,6 +119,7 @@
 - Python 3.8 is the default version now that Python 3.6 has reached End-of-Life
 - The `dataclasses` backport is installed for Python < 3.7
 - `Tifffile` is now a direct dependency, previously already installed as a sub-dependency of other required packages
+- `Imagecodecs` is optional for `tifffile` but required for its uses here as of `tifffile v2022.7.28` and thus added as a dependency (#153)
 - Updated to use the `axis_channel` parameter in Scikit-image's `transform.rescale` function (#115)
 - Seaborn as an optional dependency for additional plot support (currently only swarm plots, #137)
 - Scikit-learn is an optional rather than a required dependency (#150)

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,8 @@ config = {
         # part of stdlib in Python >= 3.8
         "importlib-metadata >= 1.0 ; python_version < '3.8'",
         "tifffile",
+        # required with tifffile >= 2022.7.28
+        "imagecodecs",
         # part of stdlib in Python >= 3.7
         "dataclasses ; python_version < '3.7'",
     ], 


### PR DESCRIPTION
Fixes #130. The `imagecodecs` library is an optional dependency for `tifffile` but now leads to an error when loading `skimage.io` as of Tifffile v2022.7.28. This package is also required to load some types of single-plane images.

Note that the Conda `tifffile` package installs `imagecodecs` as a dependency. We won't add it to the Conda environment script since we don't import `imagecodes` directly, but only through Tifffile.