### PR TITLE
Plane selectors for the plots in the Atlas Editor

### DIFF
--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -20,6 +20,7 @@
 - Registered image suffixes with variable endings (eg `annotationEdgeLevel<n>`) now show up in the dropdown boxes (#142)
 - Registered image and region names are truncated in the middle to prevent expanding the sidebar for long names (#147)
 - "Show all" in the Regions section of the ROI panel shows names for all labels (#145)
+- Atlas Editor planes can be reordered or turned off (#180)
 - Fixed to reset the ROI selector when redrawing (#115)
 - Fixed to reorient the camera after clearing the 3D space (#121)
 - Fixed to turn off the minimum intensity slider's auto setting when manually changing the slider (#126) 

--- a/magmap/gui/roi_editor.py
+++ b/magmap/gui/roi_editor.py
@@ -652,8 +652,7 @@ class ROIEditor(plot_support.ImageSyncMixin):
         scaling = config.labels_scaling
         if scaling is not None: scaling = [scaling]
         max_sizes = plot_support.get_downsample_max_sizes()
-        max_size = max_sizes[plot_support.get_plane_axis(
-            self.plane, get_index=True)] if max_sizes else None
+        max_size = max_sizes[self.plane] if max_sizes else None
 
         # plot layout depending on number of z-planes
         if single_roi_row:

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -3061,9 +3061,9 @@ class Visualization(HasTraits):
         
         self._atlas_ed_plot_ignore = True
         for key, val in viewers.items():
-            if val == evt.new and key != evt.name:
-                # swap out any other dropdown set to the new selection from
-                # the triggering dropdown with its prior selection
+            if evt.new and evt.new[0] and val == evt.new and key != evt.name:
+                # for a non-empty new selection already in another dropdown,
+                # swap it with the old selection
                 if key == "_atlas_ed_plot_left":
                     self._atlas_ed_plot_left = evt.old
                 elif key == "_atlas_ed_plot_right_up":

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -279,7 +279,9 @@ class Visualization(HasTraits):
 
     # File selection
 
-    _filename = File  # file browser
+    _filename = File(
+        tooltip="Load an image. If the file format requires import, the\n"
+                "Import tab will open automatically.")
     _channel_names = Instance(TraitsList)
     _channel = List  # selected channels, 0-based
     _rgb = Bool(config.rgb, tooltip="Show image as RGB(A)")
@@ -532,7 +534,7 @@ class Visualization(HasTraits):
     _region_names = Instance(TraitsList)
     # tooltip for both text box and options since options group has no main
     # label to display a tooltip
-    _region_id = Str(  
+    _region_id = Str(
         tooltip="IDs: IDs of labels to navigate to. Add +/- to including both\n"
                 "sides. Separate multiple IDs by commas.\n"
                 "Both sides: include correspondings labels from opposite sides"
@@ -560,8 +562,9 @@ class Visualization(HasTraits):
     panel_roi_selector = VGroup(
         VGroup(
             HGroup(
-                Item("_filename", label="File", style="simple",
+                Item("_filename", show_label=False, style="simple",
                      editor=FileEditor(entries=10, allow_dir=False)),
+                label="Image path",
             ),
             HGroup(
                 Item("_channel", label="Channels", style="custom",
@@ -570,7 +573,6 @@ class Visualization(HasTraits):
                          name="object._channel_names.selections", cols=8)),
                 Item("_rgb", label="RGB", enabled_when="_rgb_enabled"),
             ),
-            label="Image path",
         ),
         VGroup(
             HGroup(
@@ -595,9 +597,12 @@ class Visualization(HasTraits):
             label="Registered Images",
         ),
         VGroup(
-            Item("rois_check_list", label="ROIs",
-                 editor=CheckListEditor(
-                     name="object._rois_selections.selections")),
+            HGroup(
+                Item("rois_check_list", show_label=False,
+                     editor=CheckListEditor(
+                         name="object._rois_selections.selections")),
+                label="Regions",
+            ),
             HGroup(
                 Item("roi_array", label="Size (x,y,z)"),
                 Item("_roi_center", label="Center",
@@ -618,27 +623,29 @@ class Visualization(HasTraits):
                      low_name="z_low",
                      high_name="z_high",
                      mode="slider")),
-            label="Region of Interest",
         ),
         VGroup(
-            Item("_check_list_2d", style="custom", label="ROI Editor",
-                 editor=CheckListEditor(
-                     values=_DEFAULTS_2D, cols=5, format_func=lambda x: x)),
-            HGroup(
-                Item("_circles_2d", style="simple", show_label=False,
+            VGroup(
+                Item("_check_list_2d", style="custom", label="ROI Editor",
                      editor=CheckListEditor(
-                         values=[e.value for e in
-                                 roi_editor.ROIEditor.CircleStyles],
-                         format_func=lambda x: x)),
-                Item("_planes_2d", style="simple", show_label=False,
-                     editor=CheckListEditor(
-                         values=_DEFAULTS_PLANES_2D,
-                         format_func=lambda x: "Plane {}".format(x.upper()))),
-                Item("_styles_2d", style="simple", show_label=False,
-                     springy=True,
-                     editor=CheckListEditor(
-                         values=[e.value for e in Styles2D],
-                         format_func=lambda x: x)),
+                         values=_DEFAULTS_2D, cols=5, format_func=lambda x: x)),
+                HGroup(
+                    Item("_circles_2d", style="simple", show_label=False,
+                         editor=CheckListEditor(
+                             values=[e.value for e in
+                                     roi_editor.ROIEditor.CircleStyles],
+                             format_func=lambda x: x)),
+                    Item("_planes_2d", style="simple", show_label=False,
+                         editor=CheckListEditor(
+                             values=_DEFAULTS_PLANES_2D,
+                             format_func=lambda x: "Plane {}".format(x.upper()))),
+                    Item("_styles_2d", style="simple", show_label=False,
+                         springy=True,
+                         editor=CheckListEditor(
+                             values=[e.value for e in Styles2D],
+                             format_func=lambda x: x)),
+                ),
+                show_border=True,
             ),
             VGroup(
                 HGroup(
@@ -663,16 +670,13 @@ class Visualization(HasTraits):
                 ),
                 show_border=True,
             ),
+            VGroup(
+                Item("_check_list_3d", style="custom", label="3D Viewer",
                      editor=CheckListEditor(
-                         values=[e.value for e in AtlasEditorOptions],
-                         cols=len(AtlasEditorOptions),
-                         format_func=lambda x: x)),
+                         values=[e.value for e in Vis3dOptions],
+                         cols=len(Vis3dOptions), format_func=lambda x: x)),
+                show_border=True,
             ),
-            Item("_check_list_3d", style="custom", label="3D Viewer",
-                 editor=CheckListEditor(
-                     values=[e.value for e in Vis3dOptions],
-                     cols=len(Vis3dOptions), format_func=lambda x: x)),
-            label="Viewer Options",
         ),
         # give initial focus to text editor that does not trigger any events to
         # avoid inadvertent actions by the user when the window first displays;

--- a/magmap/io/sitk_io.py
+++ b/magmap/io/sitk_io.py
@@ -172,7 +172,7 @@ def read_sitk(path, dryrun=False):
 
 
 def _load_reg_img_to_combine(path, reg_name, img_nps):
-    # load registered image in sitk format to combine with other images 
+    # load registered image in sitk format to combine with other images
     # by resizing to the shape of the first image
     img_np_base = None
     if img_nps:
@@ -260,18 +260,24 @@ def read_sitk_files(
         if not libmag.is_seq(reg_names):
             reg_names = [reg_names]
         for reg_name in reg_names:
-            # load each registered suffix into list of images with same shape, 
+            # load each registered suffix into list of images with same shape,
             # keeping first image in sitk format
             img, path = _load_reg_img_to_combine(
                 filename_sitk, reg_name, img_nps)
             if img_sitk is None:
                 img_sitk = img
                 loaded_path = path
+        
         if len(img_nps) > 1:
             # merge images into separate channels
             img_np = np.stack(img_nps, axis=img_nps[0].ndim)
         else:
             img_np = img_nps[0]
+        
+        if img_sitk:
+            # update sitk image with np array
+            img_sitk = replace_sitk_with_numpy(img_sitk, img_np)
+    
     else:
         # load filename_sitk directly
         if not os.path.exists(filename_sitk):

--- a/magmap/plot/plot_support.py
+++ b/magmap/plot/plot_support.py
@@ -1226,14 +1226,15 @@ def show():
     plt.show()
 
 
-def get_downsample_max_sizes():
+def get_downsample_max_sizes() -> Dict[str, int]:
     """Get the maximum sizes by axis to keep an image within size limits
     during downsampling as set in the current atlas profile based on whether
-    the images is loaded as a Numpy memmapped array or not.
+    the image is loaded as a NumPy memmapped array or not.
 
     Returns:
-        List[int]: Sequence of maximum sizes by axis set in the current profile
-        if it is also set to downsample images loaded by Numpy, otherwise None.
+        Dictionary of plane in `xy` format to maximum sizes by axis set in
+        the current profile if it is also set to downsample images loaded by
+        NumPy, otherwise None.
 
     """
     max_sizes = None
@@ -1241,7 +1242,12 @@ def get_downsample_max_sizes():
     if downsample_io and config.img5d and config.img5d.img_io in downsample_io:
         max_sizes = config.atlas_profile["editor_max_sizes"]
         if max_sizes:
+            # reverse order to z,y,x since profile is in x,y,z order
             max_sizes = max_sizes[::-1]
+    
+    if max_sizes:
+        # map to planes in xy format
+        max_sizes = {p: m for p, m in zip(config.PLANE, max_sizes)}
     return max_sizes
 
 

--- a/magmap/settings/atlas_prof.py
+++ b/magmap/settings/atlas_prof.py
@@ -26,6 +26,7 @@ class RegParamMap(dict):
         # but leave False to use area around mask for the registration
         # (see Elastix manual section 5.4)
         self["erode_mask"] = None
+        # True to use point-based registration during b-spline reg
         self["point_based"] = False
         
         # update with args
@@ -73,8 +74,6 @@ class AtlasProfile(profiles.SettingsDict):
         self["groupwise_iter_max"] = "1024"
         self["resize_factor"] = 0.7
         self["preprocess"] = False
-        # True to use point-based registration during b-spline reg
-        self["point_based"] = False
         self["curate"] = True  # carve image; in-paint if generating atlas
 
         # erase labels outside of ((x_start, x_end), (y_start, ...) ...)


### PR DESCRIPTION
The Atlas Editor currently has three views to show 3D images. The order of these views has been fixed as `z`, `y`, and `x` moving clockwise from the left. The left view is the largest, taking up the full vertical space, while the right views are split into upper and lower views. Some images lend happen to lend themselves to a large z-plane in the left view, while others may show a small image there while compressing a larger image in one of the right views.

This PR adds dropdown selectors for the user the select the planes shown in each of the views:
- Each view has a separate dropdown in the ROI panel to select the plane to show in that view
- Selecting a plane currently selected in another dropdown swaps those selection automatically
- A blank option for each view turns off the view and expands the other views to fill the space
- Blanking out the left view creates two larger views on top of one another, while blanking either of the right views creates two larger views side-by-side
- To group the viewer controls better in the ROI panel, each set of viewer controls is now demarcated with a bordered group
- Since these groups take up more vertical space, a few ROI panel labels have been merged into the next line

A few additional, unrelated changes have been bundled here:
- The `register_duo` core registration function now accepts `RegParamMap` objects for registration types
- 3D surface areas can generate errors from inappropriate thresholding and now provides feedback
- Fixed loading multiple registered intensity images