### PR TITLE
Verifier viewer to adjust or confirm classifications

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,6 +60,7 @@ jobs:
       - name: Test with pytest
         run: |
           python -u -m magmap.tests.test_chunking
+          python -u -m magmap.tests.test_detector
           python -u -m magmap.tests.test_libmag
           # TODO: add UI testing
           #python -u -m magmap.tests.test_visualizer

--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -33,6 +33,7 @@
 - Registered image and region names are truncated in the middle to prevent expanding the sidebar for long names (#147)
 - "Show all" in the Regions section of the ROI panel shows names for all labels (#145)
 - Atlas Editor planes can be reordered or turned off (#180)
+- New viewer that displays each blob separately to verify blob classifications (#193)
 - Fixed to reset the ROI selector when redrawing (#115)
 - Fixed to reorient the camera after clearing the 3D space (#121)
 - Fixed to turn off the minimum intensity slider's auto setting when manually changing the slider (#126) 

--- a/magmap/cv/detector.py
+++ b/magmap/cv/detector.py
@@ -287,7 +287,8 @@ class Blobs:
 
     @classmethod
     def get_blob_col(
-            cls, blob: np.ndarray, col: int) -> Union[int, float, np.ndarray]:
+            cls, blob: np.ndarray, col: Union[int, Sequence[int]]
+    ) -> Union[int, float, np.ndarray]:
         """Get the value for the given column of a blob or blobs.
 
         Args:
@@ -370,17 +371,19 @@ class Blobs:
         """Get blob absolute coordinates.
         
         Args:
-            blobs: 2D array of blobs.
+            blobs: 1D blob array or 2D array of blobs.
 
         Returns:
-            2D array of absolute coordinates.
+            Array of absolute coordinates, with dimensions corresponding to
+            ``blobs``.
 
         """
-        return blobs[:, cls._get_abs_inds()]
+        return cls.get_blob_col(blobs, cls._get_abs_inds())
 
     @classmethod
     def set_blob_col(
-            cls, blob: np.ndarray, col: int, val: Union[int, np.ndarray]
+            cls, blob: np.ndarray, col: Union[int, Sequence[int]],
+            val: Union[float, Sequence[float]]
     ) -> np.ndarray:
         """Set the value for the given column of a blob or blobs.
 
@@ -449,7 +452,8 @@ class Blobs:
         return cls.set_blob_col(blob, cls.col_inds[cls.Cols.CHANNEL], val)
     
     @classmethod
-    def set_blob_abs_coords(cls, blobs: np.ndarray, coords: np.ndarray) -> np.ndarray:
+    def set_blob_abs_coords(
+            cls, blobs: np.ndarray, coords: Sequence[int]) -> np.ndarray:
         """Set blob absolute coordinates.
         
         Args:
@@ -461,7 +465,7 @@ class Blobs:
             Modified ``blobs``.
 
         """
-        blobs[:, cls._get_abs_inds()] = coords
+        cls.set_blob_col(blobs, cls._get_abs_inds(), coords)
         return blobs
     
     @classmethod

--- a/magmap/gui/atlas_editor.py
+++ b/magmap/gui/atlas_editor.py
@@ -243,6 +243,7 @@ class AtlasEditor(plot_support.ImageSyncMixin):
             evt (:obj:`matplotlib.backend_bases.CloseEvent`): Close event.
 
         """
+        self.on_close()
         self.fn_close_listener(evt, self)
 
     def on_key_press(self, event):

--- a/magmap/gui/plot_editor.py
+++ b/magmap/gui/plot_editor.py
@@ -248,9 +248,10 @@ class PlotEditor:
         listeners = [
             self.cidpress, self.cidrelease, self.cidmotion, self.cidenter,
             self.cidleave, self.cidkeypress]
+        canvas = self.axes.figure.canvas
         for listener in listeners:
-            if listener and self._ax_img_labels is not None:
-                self._ax_img_labels.figure.canvas.mpl_disconnect(listener)
+            if listener:
+                canvas.mpl_disconnect(listener)
         self.connected = False
 
     def update_coord(self, coord=None):

--- a/magmap/gui/plot_editor.py
+++ b/magmap/gui/plot_editor.py
@@ -275,7 +275,9 @@ class PlotEditor:
         if self._show_crosslines:
             self.draw_crosslines()
 
-    def translate_coord(self, coord, up=False, coord_slice=None):
+    def translate_coord(
+            self, coord: Sequence[int], up: bool = False,
+            coord_slice: Optional[Sequence[slice]] = None) -> Sequence[int]:
         """Translate coordinate based on downsampling factor of the main image.
 
         Coordinates sent to and received from the Atlas Editor are assumed to
@@ -283,10 +285,10 @@ class PlotEditor:
         resized to the shape of the main image.
 
         Args:
-            coord (List[int]): Coordinates in z,y,x.
-            up (bool): True to upsample; defaults to False to adjust
+            coord: Coordinates in z,y,x.
+            up: True to upsample; defaults to False to adjust
                 coordinates for downsampled images.
-            coord_slice (slice): Slice of each set of coordinates to
+            coord_slice: Slice of each set of coordinates to
                 transpose. Defaults to None, which gives a slice starting
                 at 1 so that the z-value will not be adjusted on the
                 assumption that downsampling is only performed in ``x,y``.
@@ -599,12 +601,12 @@ class PlotEditor:
     def update_plane_slider(self, val):
         self._update_overview(int(val))
 
-    def view_subimg(self, offset, size):
+    def view_subimg(self, offset: Sequence[int], size: Sequence[int]):
         """View a sub-image.
 
         Args:
-            offset (List[int]): Sub-image offset in ``y, x``.
-            size (List[int]): Sub-image size in ``y, x``.
+            offset: Sub-image offset in ``y, x``.
+            size: Sub-image size in ``y, x``.
 
         """
         coord_slice = slice(0, None)

--- a/magmap/gui/roi_editor.py
+++ b/magmap/gui/roi_editor.py
@@ -833,6 +833,7 @@ class ROIEditor(plot_support.ImageSyncMixin):
         fig.canvas.mpl_connect("scroll_event", scroll_overview)
         fig.canvas.mpl_connect("key_press_event", key_press)
         fig.canvas.mpl_connect("button_release_event", key_press)
+        fig.canvas.mpl_connect("close_event", self.on_close)
         # fig.canvas.mpl_connect("draw_event", lambda x: print("redraw"))
         
         if self.fn_redraw:

--- a/magmap/gui/verifier_editor.py
+++ b/magmap/gui/verifier_editor.py
@@ -181,14 +181,15 @@ class VerifierEditor(plot_support.ImageSyncMixin):
                 # reset if the index exceeds the flag list
                 i = 0
             
-            # update the blob's flag and show in axes title
-            blob_orig = np.copy(view.blob)
+            # update the blob's flag and show in axes title, which will update
+            # the underlying blobs array since this blob is a view, not a copy
             self.blobs.set_blob_confirmed(view.blob, self._blob_flags[i])
             self._set_ax_title(view)
             
             if self.fn_update_blob:
-                # handle any blob changes
-                self.fn_update_blob(view.blob, blob_orig)
+                # handle any blob changes with the same updated blob as both
+                # new and old blobs since blobs array has already been updated
+                self.fn_update_blob(view.blob, view.blob)
             
     def _set_ax_title(self, view: "BlobView"):
         """Set the axes title for a blob view.

--- a/magmap/gui/verifier_editor.py
+++ b/magmap/gui/verifier_editor.py
@@ -1,0 +1,77 @@
+# Viewer for verifying blobs
+"""Blob verifier viewer GUI."""
+
+from typing import Optional
+
+from matplotlib import pyplot as plt
+from matplotlib import figure
+from matplotlib import gridspec
+
+from magmap.cv import detector
+from magmap.gui import plot_editor
+from magmap.io import libmag
+from magmap.plot import plot_3d, plot_support
+from magmap.settings import config
+
+
+class VerifierEditor(plot_support.ImageSyncMixin):
+    """Editor to verify blobs."""
+
+    def __init__(self, img5d, blobs, title=None, fig=None):
+        """Initialize the viewer."""
+        super().__init__(img5d)
+        self.blobs: "detector.Blobs" = blobs
+        self.title: Optional[str] = title
+        self.fig: Optional[figure.Figure] = fig
+        
+    def show_fig(self):
+        """Set up the figure."""
+        # set up the figure
+        if self.fig is None:
+            fig = figure.Figure(self.title)
+            self.fig = fig
+        else:
+            fig = self.fig
+        fig.clear()
+        nrows = 3
+        ncols = 3
+        gs = gridspec.GridSpec(
+            nrows, ncols, wspace=0.1, hspace=0.1, figure=fig,
+            left=0.06, right=0.94, bottom=0.02, top=0.98)
+        
+        # get blobs with confirmation flags
+        blobs = self.blobs.blobs
+        blobs = blobs[self.blobs.get_blob_confirmed(blobs) >= 0]
+        nblobs = len(blobs)
+        offsets = self.blobs.get_blob_abs_coords(blobs).astype(int)
+        subimg_shape = (50, 50)
+        for row in range(nrows):
+            for col in range(ncols):
+                # add axes
+                ax = fig.add_subplot(gs[row, col])
+                plot_support.hide_axes(ax)
+                aspect, origin = plot_support.get_aspect_ratio(config.PLANE[0])
+                
+                # get offset from blob's absolute coordinates
+                n = row * ncols + col
+                if n >= nblobs:
+                    break
+                offset = offsets[n]
+        
+                # display plot editor centered on blob
+                overlayer = plot_support.ImageOverlayer(
+                    ax, aspect, origin, rgb=config.rgb)
+                plot_ed = plot_editor.PlotEditor(
+                    overlayer, self.img5d.img[0], None, None)
+                plot_ed.coord = offset
+                plot_ed.show_overview()
+                offset_ctr = plot_3d.roi_center_to_offset(
+                    offset[1:], subimg_shape)
+                plot_ed.view_subimg(offset_ctr, subimg_shape)
+                self.plot_eds[n] = plot_ed
+        
+        # attach listeners
+        fig.canvas.mpl_connect("close_event", self.on_close)
+        
+        plt.ion()  # avoid the need for draw calls
+        self.fig.canvas.draw_idle()

--- a/magmap/gui/verifier_editor.py
+++ b/magmap/gui/verifier_editor.py
@@ -1,7 +1,10 @@
 # Viewer for verifying blobs
 """Blob verifier viewer GUI."""
 
-from typing import Optional
+import dataclasses
+from typing import Optional, Dict, Sequence, Any
+
+import numpy as np
 
 from matplotlib import pyplot as plt
 from matplotlib import figure
@@ -16,13 +19,24 @@ from magmap.settings import config
 
 class VerifierEditor(plot_support.ImageSyncMixin):
     """Editor to verify blobs."""
-
+    
+    @dataclasses.dataclass
+    class BlobView:
+        """Storage class for each view."""
+        #: Plot Editor.
+        plot_ed: "plot_editor.PlotEditor"
+        #: Displayed blob.
+        blob: np.ndarray
+    
     def __init__(self, img5d, blobs, title=None, fig=None):
         """Initialize the viewer."""
         super().__init__(img5d)
         self.blobs: "detector.Blobs" = blobs
         self.title: Optional[str] = title
         self.fig: Optional[figure.Figure] = fig
+        
+        self._blob_flags: Sequence[Any] = []
+        self._blob_views: Dict[int, "VerifierEditor.BlobView"] = {}
         
     def show_fig(self):
         """Set up the figure."""
@@ -42,36 +56,73 @@ class VerifierEditor(plot_support.ImageSyncMixin):
         # get blobs with confirmation flags
         blobs = self.blobs.blobs
         blobs = blobs[self.blobs.get_blob_confirmed(blobs) >= 0]
+        self._blob_flags = sorted(np.unique(
+            self.blobs.get_blob_confirmed(blobs).astype(int)))
         nblobs = len(blobs)
         offsets = self.blobs.get_blob_abs_coords(blobs).astype(int)
         subimg_shape = (50, 50)
         for row in range(nrows):
             for col in range(ncols):
-                # add axes
-                ax = fig.add_subplot(gs[row, col])
-                plot_support.hide_axes(ax)
-                aspect, origin = plot_support.get_aspect_ratio(config.PLANE[0])
-                
                 # get offset from blob's absolute coordinates
                 n = row * ncols + col
                 if n >= nblobs:
                     break
-                offset = offsets[n]
-        
+                blob = blobs[n]
+                
+                # add axes
+                ax = fig.add_subplot(gs[row, col])
+                plot_support.hide_axes(ax)
+                aspect, origin = plot_support.get_aspect_ratio(config.PLANE[0])
+
                 # display plot editor centered on blob
                 overlayer = plot_support.ImageOverlayer(
                     ax, aspect, origin, rgb=config.rgb)
                 plot_ed = plot_editor.PlotEditor(
                     overlayer, self.img5d.img[0], None, None)
+                offset = offsets[n]
                 plot_ed.coord = offset
                 plot_ed.show_overview()
                 offset_ctr = plot_3d.roi_center_to_offset(
                     offset[1:], subimg_shape)
                 plot_ed.view_subimg(offset_ctr, subimg_shape)
                 self.plot_eds[n] = plot_ed
+                
+                blob_view = self.BlobView(plot_ed, blob)
+                self._set_ax_title(blob_view)
+                self._blob_views[n] = blob_view
         
         # attach listeners
+        fig.canvas.mpl_connect("button_press_event", self.on_btn_press)
         fig.canvas.mpl_connect("close_event", self.on_close)
         
         plt.ion()  # avoid the need for draw calls
         self.fig.canvas.draw_idle()
+
+    def on_btn_press(self, evt):
+        """Respond to mouse button press events."""
+        for key, view in self._blob_views.items():
+            # ignore presses outside the given plot
+            if evt.inaxes != view.plot_ed.axes: continue
+            
+            # get the index of the current blob confirmed flag and increment
+            i = np.argwhere(self._blob_flags == self.blobs.get_blob_confirmed(
+                view.blob))[0][0] + 1
+            if i >= len(self._blob_flags):
+                # reset if the index exceeds the flag list
+                i = 0
+            
+            # update the blob's flag and show in axes title
+            self.blobs.set_blob_confirmed(view.blob, self._blob_flags[i])
+            self._set_ax_title(view)
+            
+    def _set_ax_title(self, view: "BlobView"):
+        """Set the axes title for a blob view.
+        
+        Args:
+            view: Blob view.
+
+        """
+        # show the blob's confirmed flag in the title
+        view.plot_ed.axes.set_title(
+            f"Class: {self.blobs.get_blob_confirmed(view.blob).astype(int)}")
+    

--- a/magmap/gui/verifier_editor.py
+++ b/magmap/gui/verifier_editor.py
@@ -113,11 +113,17 @@ class VerifierEditor(plot_support.ImageSyncMixin):
     
     def _setup_blobs(self):
         """Set up blobs."""
-        # get blobs with confirmation flags set by user (ie non-neg)
         blobs = self.blobs.blobs
-        self._blobs_show = self.blobs.get_blob_confirmed(blobs) >= 0
-        self._blob_flags = sorted(np.unique(
-            self.blobs.get_blob_confirmed(blobs[self._blobs_show]).astype(int)))
+        if blobs is None:
+            # reset blobs setup
+            self._blobs_show = []
+            self._blob_flags = []
+        else:
+            # get blobs with confirmation flags set by user (ie non-neg)
+            self._blobs_show = self.blobs.get_blob_confirmed(blobs) >= 0
+            self._blob_flags = sorted(np.unique(
+                self.blobs.get_blob_confirmed(
+                    blobs[self._blobs_show]).astype(int)))
     
     def show_views(self):
         """Show blob views."""

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -3085,7 +3085,9 @@ class Visualization(HasTraits):
     @observe("_btn_verifier")
     def _launch_verifier_editor(self, evt):
         verifier_ed = verifier_editor.VerifierEditor(
-            config.img5d, self.blobs, "Verifier", self._roi_ed_fig)
+            config.img5d, self.blobs, "Verifier", self._roi_ed_fig,
+            # necessary for immediate table refresh rather than after scroll
+            self.update_segment)
         verifier_ed.show_fig()
         self.verifier_ed = verifier_ed
     

--- a/magmap/plot/plot_3d.py
+++ b/magmap/plot/plot_3d.py
@@ -377,20 +377,22 @@ def prepare_roi(image5d, roi_offset, roi_size, ndim_base=5):
     return prepare_subimg(image5d, roi_offset[::-1], roi_size[::-1], ndim_base)
 
 
-def roi_center_to_offset(offset, shape, reverse=False):
+def roi_center_to_offset(
+        offset: Sequence[int], shape: Sequence[int], reverse: bool = False
+) -> Sequence[int]:
     """Convert an ROI offset given as the center of the ROI to the
     coordinates of the upper left hand corner of the ROI.
     
     Args:
-        offset (list[int]): Offset taken as the center of the ROI in any
+        offset: Offset taken as the center of the ROI in any
             order, typically either ``x,y,z`` or ``z,y,x``.
-        shape (list[int]): ROI shape in the same order as that of ``offset``.
-        reverse (bool): True to treat ``offset`` as the upper left hand
+        shape: ROI shape in the same order as that of ``offset``.
+        reverse: True to treat ``offset`` as the upper left hand
             corner of the ROI and to obtain the center coordinates of
             this ROI; defaults to False.
 
     Returns:
-        list[int]: Coordinates of the upper left corner of the ROI, or the
+        Coordinates of the upper left corner of the ROI, or the
         center of the ROI if ``reverse`` is True.
 
     """

--- a/magmap/plot/plot_support.py
+++ b/magmap/plot/plot_support.py
@@ -195,6 +195,65 @@ class ImageSyncMixin:
                 ed.max_intens_proj = n
                 if display: ed.update_coord()
     
+    @staticmethod
+    def enable_btn(btn, enable=True, color=None, max_color=0.99):
+        """Display a button or other widget as enabled or disabled.
+
+        Note that the button's active state will not change since doing so 
+        prevents the coloration from changing.
+
+        Args:
+            btn (:class:`matplotlib.widgets.AxesWidget`): Widget to change,
+                which must have ``color`` and ``hovercolor`` attributes.
+            enable (bool): True to enable (default), False to disable.
+            color (float): Intensity value from 0-1 for the main color. The
+                hovercolor will be just above this value, while the disabled
+                main and hovercolors will be just below this value. Defaults
+                to None, which will use :attr:`config.widget_color`.
+            max_color (float): Max intensity value for hover color; defaults
+                to 0.99 to provide at least some contrast with white backgrounds.
+        """
+        if color is None:
+            color = config.widget_color
+        if enable:
+            # "enable" button by changing to default grayscale color intensities
+            btn.color = str(color)
+            hover = color + 0.1
+            if hover > max_color:
+                # intensities > 1 appear to recycle, so clip to max allowable val
+                hover = max_color
+            btn.hovercolor = str(hover)
+        else:
+            # "disable" button by making darker and no hover response
+            color_disabled = color - 0.2
+            if color_disabled < 0: color_disabled = 0
+            color_disabled = str(color_disabled)
+            btn.color = color_disabled
+            btn.hovercolor = color_disabled
+
+    @staticmethod
+    def toggle_btn(btn, on=True, shift=0.2, text=None):
+        """Toggle a button between on/off modes.
+
+        Args:
+            btn: Button widget to change.
+            on: True to display the button as on, False as off.
+            shift: Float of amount to shift the button color intensity;
+                defaults to 0.2.
+            text: Tuple of ``(on_text, off_text)`` for the button label;
+                defaults to None to keep the original text.
+        """
+        if on:
+            # turn button "on" by darkening intensities and updating label
+            btn.color = str(float(btn.color) - shift)
+            btn.hovercolor = str(float(btn.hovercolor) - shift)
+            if text: btn.label.set_text(text[1])
+        else:
+            # turn button "off" by lightening intensities and updating label
+            btn.color = str(float(btn.color) + shift)
+            btn.hovercolor = str(float(btn.hovercolor) + shift)
+            if text: btn.label.set_text(text[0])
+
     def on_close(self):
         """Figure close handler.
         

--- a/magmap/plot/plot_support.py
+++ b/magmap/plot/plot_support.py
@@ -194,6 +194,15 @@ class ImageSyncMixin:
             if n != ed.max_intens_proj:
                 ed.max_intens_proj = n
                 if display: ed.update_coord()
+    
+    def on_close(self):
+        """Figure close handler.
+        
+        Disconnects all Plot Editors.
+
+        """
+        for plot_ed in self.plot_eds.values():
+            plot_ed.disconnect()
 
 
 class ImageOverlayer:

--- a/magmap/tests/test_detector.py
+++ b/magmap/tests/test_detector.py
@@ -1,0 +1,53 @@
+# MagellanMapper unit testing for detector
+"""Unit testing for the MagellanMapper detector module."""
+
+import unittest
+
+import numpy as np
+
+from magmap.cv import detector
+
+
+class TestDetector(unittest.TestCase):
+    
+    def test_blob_accessors(self):
+        # set up random blobs
+        blobs = np.random.rand(20).reshape((5, 4))
+        blobs[:, 0:3] = np.multiply(blobs[:, 0:3], 100).astype(int)
+        blobs[:, 3] = blobs[:, 3] * 10
+        bl = detector.Blobs(blobs)
+        bl.blobs = bl.format_blobs(bl.blobs)
+        print(f"Blobs:\n{bl.blobs}")
+
+        # test blob confirmation flag
+        np.testing.assert_array_equal(
+            bl.get_blob_confirmed(bl.blobs), bl.blobs[:, 4])
+        conf_flag = 1
+        bl.set_blob_confirmed(bl.blobs, conf_flag)
+        self.assertTrue(np.all(bl.get_blob_confirmed(bl.blobs) == conf_flag))
+        
+        # test blob truth flag
+        np.testing.assert_array_equal(
+            bl.get_blob_truth(bl.blobs), bl.blobs[:, 5])
+        truth_flag = 2
+        bl.set_blob_truth(bl.blobs, truth_flag)
+        self.assertTrue(np.all(bl.get_blob_truth(bl.blobs) == truth_flag))
+
+        # test blob channel
+        np.testing.assert_array_equal(
+            bl.get_blobs_channel(bl.blobs), bl.blobs[:, 6])
+        channel = 3
+        bl.set_blob_channel(bl.blobs, channel)
+        self.assertTrue(np.all(bl.get_blobs_channel(bl.blobs) == channel))
+
+        # test blob absolute coordinates
+        np.testing.assert_array_equal(
+            bl.get_blob_abs_coords(bl.blobs), bl.blobs[:, 7:10])
+        abs_coords = (1, 2, 3)
+        bl.set_blob_abs_coords(bl.blobs, abs_coords)
+        self.assertTrue(all(np.all(
+            bl.get_blob_abs_coords(bl.blobs) == abs_coords, axis=1)))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The ROI Editor provides tools to flag blobs as different classes by showing all the blobs within a given region of interest, but it may also be useful to view and adjust blob classes individually. This PR adds a viewer that displays blobs in separate subplots arranged as a grid. The user can click on each subplot to change the blob's classification and scroll to additional pages of blobs. Blobs are synchronized with the blobs table and can be saved to the database using the existing save blobs button.