### PR TITLE
Integrate more transformations into the atlas transformer

### DIFF
--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -47,6 +47,8 @@
 - the `--transform interpolation=<n>` configures the type of interpolation when resizing images during stack export (#127)
 - Any axis can be flipped through `--transform flip=<axis>`, where `axis = 0` for the z-axis, 1 for the y-axis, and 2 for the x-axis (#147)
 - Density/heat maps can be specified through `--reg_suffixes density=<suffix>` (#129)
+- The atlas transformer handles more transformations, such as rotation to any angle, flipping along any axis, and resizing (#195)
+- Write point files for corresponding-point-based registration (#195)
 - Fixed to only remove the final extension from image paths, and paths given by the `--prefix <path>` CLI argument do not undergo any stripping (#115)
 
 #### Atlas refinement

--- a/magmap/atlas/atlas_refiner.py
+++ b/magmap/atlas/atlas_refiner.py
@@ -1193,7 +1193,11 @@ def transpose_img(
         shape = transposed.shape
         transposed = cv_nd.rescale_resize(
             transposed, target_size, preserve_range=True, order=order)
-        scaling = np.divide(transposed.shape, shape)
+        
+        # update spacing/origin by scaling factor or resize ratio
+        scaling = target_size
+        if libmag.is_seq(target_size):
+            scaling = np.divide(transposed.shape, shape)
         spacing = np.multiply(spacing, scaling)
         origin = np.multiply(origin, scaling)
     

--- a/magmap/atlas/atlas_refiner.py
+++ b/magmap/atlas/atlas_refiner.py
@@ -1180,8 +1180,8 @@ def transpose_img(
             # or flipped rotation (eg 90 or 180 deg)
             dtype = transposed.dtype
             transposed = cv_nd.make_isotropic(
-                transposed, 1, spacing).astype(dtype)
-            iso_factor = cv_nd.calc_isotropic_factor(1, spacing)
+                transposed, res=spacing).astype(dtype)
+            iso_factor = cv_nd.calc_isotropic_factor(res=spacing)
             spacing = np.divide(spacing, iso_factor)
             origin = np.divide(origin, iso_factor)
         

--- a/magmap/atlas/atlas_refiner.py
+++ b/magmap/atlas/atlas_refiner.py
@@ -1206,17 +1206,10 @@ def transpose_img(
                 origin = libmag.swap_elements(origin, *axes)
         
     if target_size is not None:
-        # rescale or resize
-        shape = transposed.shape
+        # rescale or resize, without updating spacing/origin since the size
+        # change is often to alter the physical dimensions
         transposed = cv_nd.rescale_resize(
             transposed, target_size, preserve_range=True, order=order)
-        
-        # update spacing/origin by scaling factor or resize ratio
-        scaling = target_size
-        if libmag.is_seq(target_size):
-            scaling = np.divide(transposed.shape, shape)
-        spacing = np.multiply(spacing, scaling)
-        origin = np.multiply(origin, scaling)
     
     # convert back to sitk image
     transposed = sitk.GetImageFromArray(transposed)

--- a/magmap/atlas/transformer.py
+++ b/magmap/atlas/transformer.py
@@ -50,53 +50,29 @@ class Downsampler(object):
         """Rescale or resize a sub-ROI.
         
         Args:
-            coord: Coordinates as a tuple of (z, y, x) of the sub-ROI within the 
+            coord: Coordinates as a tuple of (z, y, x) of the sub-ROI within the
                 chunked ROI.
             slices: Sequence of slices within :attr:``img`` defining the
                 sub-ROI.
-            rescale: Rescaling factor. Can be None, in which case 
+            rescale: Rescaling factor. Can be None, in which case
                 ``target_size`` will be used instead.
-            target_size: Target rescaling size for the given sub-ROI in 
-               (z, y, x). If ``rescale`` is not None, ``target_size`` 
+            target_size: Target rescaling size for the given sub-ROI in
+               (z, y, x). If ``rescale`` is not None, ``target_size``
                will be ignored.
             multichannel: True if the final dimension is for channels.
             sub_roi: Array chunk to rescale/resize;
                 defaults to None to extract from :attr:`img` if available.
         
         Return:
-            Tuple of ``coord`` and the rescaled sub-ROI, where 
-            ``coord`` is the same as the given parameter to identify 
+            Tuple of ``coord`` and the rescaled sub-ROI, where
+            ``coord`` is the same as the given parameter to identify
             where the sub-ROI is located during multiprocessing tasks.
         """
         if sub_roi is None and cls.img is not None:
             sub_roi = cls.img[slices]
         
-        rescaled = None
-        if rescale is not None:
-            # rescale the image by a given factor
-            args = {
-                "image": sub_roi,
-                "scale": rescale,
-                "mode": "reflect",
-            }
-            if multichannel:
-                # rescale multichannel image
-                try:
-                    # Scikit-image >= v0.19
-                    rescaled = transform.rescale(
-                        **args, channel_axis=sub_roi.ndim-1)
-                except TypeError:
-                    # Scikit-image < v0.19
-                    rescaled = transform.rescale(
-                        **args, multichannel=multichannel)
-            else:
-                # rescale single channel image
-                rescaled = transform.rescale(**args)
-        
-        elif target_size is not None:
-            # resize the image to a custom shape
-            rescaled = transform.resize(
-                sub_roi, target_size, mode="reflect", anti_aliasing=True)
+        rescaled = cv_nd.rescale_resize(
+            sub_roi, rescale, target_size, multichannel)
         
         return coord, rescaled
 

--- a/magmap/cv/cv_nd.py
+++ b/magmap/cv/cv_nd.py
@@ -1029,7 +1029,7 @@ def filter_adaptive_size(mask, fn_filter, filter_size, min_filter_size=1,
 
 
 def calc_isotropic_factor(
-        scale: Union[float, Sequence[float]],
+        scale: Union[float, Sequence[float]] = 1,
         res: Optional[Sequence[float]] = None) -> np.ndarray:
     """Calculate the isotropic factor based on the current image resolutions.
     
@@ -1040,6 +1040,7 @@ def calc_isotropic_factor(
     Args:
         scale: Float scalar or sequence of scaling factors in ``z, y, x`` by
             which to multiply the currently loaded image's resolutions.
+            Defaults to 1.
         res: Resolutions in the same order as for ``scale``. Default to None,
             in which case :attr:`magmap.settings.config.resolutions` will be
             used instead.
@@ -1057,7 +1058,7 @@ def calc_isotropic_factor(
 
 
 def make_isotropic(
-        roi: np.ndarray, scale: Union[float, Sequence[float]],
+        roi: np.ndarray, scale: Union[float, Sequence[float]] = 1,
         res: Optional[Sequence[float]] = None
 ) -> np.ndarray:
     """Make an array isotropic.
@@ -1066,6 +1067,7 @@ def make_isotropic(
         roi: Region of interest array in ``z, y, x`` format.
         scale: Float scalar or sequence of scaling factors in ``z, y, x`` by
             which to multiply the currently loaded image's resolutions.
+            Defaults to 1.
         res: Resolutions in the same order as for ``scale``. Default to None,
             in which case :attr:`magmap.settings.config.resolutions` will be
             used instead.
@@ -1086,9 +1088,7 @@ def make_isotropic(
         # causes multiprocessing Pool to hang since the exception isn't
         # raised), so need to change mode in this case
         mode = "edge"
-    return transform.resize(
-        roi, isotropic_shape, preserve_range=True, mode=mode,
-        anti_aliasing=True)
+    return rescale_resize(roi, isotropic_shape, preserve_range=True, mode=mode)
 
 
 def rescale_resize(

--- a/magmap/io/sitk_io.py
+++ b/magmap/io/sitk_io.py
@@ -525,6 +525,27 @@ def write_reg_images(imgs_write, prefix, copy_to_suffix=False, ext=None,
             print("also copied to", out_path_copy)
 
 
+def write_pts(path: str, pts: Sequence[Sequence[int]], pt_type: str = "index"):
+    """Write file for corresponding points in Elastix.
+    
+    See format described in the Elastix manual, section 4.2 (as of
+    Elastix 5.0.1).
+    
+    Args:
+        path: Output path.
+        pts: Points as a nested sequence of ints, in `x, y, [z]` order.
+        pt_type: Point type, either "index" (default) for points as image
+            indices, or "points" as physical coordinates.
+
+    """
+    with open(path, mode="w") as f:
+        f.write(f"{pt_type}\n")  # point type
+        f.write(f"{len(pts)}\n")  # number of points
+        for pt in pts:
+            # write space-delimited points
+            f.write(f"{' '.join([str(p) for p in pt])}\n")
+
+
 def merge_images(img_paths, reg_name, prefix=None, suffix=None, 
                  fn_combine=np.sum):
     """Merge images from multiple paths.

--- a/magmap/settings/atlas_prof.py
+++ b/magmap/settings/atlas_prof.py
@@ -72,7 +72,6 @@ class AtlasProfile(profiles.SettingsDict):
         # where metric will be used if the DSC falls below the threshold
         self["metric_sim_fallback"] = None
         self["groupwise_iter_max"] = "1024"
-        self["resize_factor"] = 0.7
         self["preprocess"] = False
         self["curate"] = True  # carve image; in-paint if generating atlas
 
@@ -349,23 +348,16 @@ class AtlasProfile(profiles.SettingsDict):
                 "target_size": (50, 50, 50),
             },
 
-            # atlas is big relative to the experimental image, so need to
-            # more aggressively downsize the atlas
-            "big": {
-                "resize_factor": 0.625,
-            },
-
             # new atlas generation: turn on preprocessing
             # TODO: likely remove since not using preprocessing currently
             "new": {
                 "preprocess": True,
             },
 
-            # registration to new atlas assumes images are roughly same size and
+            # registration to new atlas assumes images are roughly same
             # orientation (ie transposed) and already have mirrored labels aligned
             # with the fixed image toward the bottom of the z-dimension
             "generated": {
-                "resize_factor": 1.0,
                 "truncate_labels": (None, (0.18, 1.0), (0.2, 1.0)),
                 "labels_mirror": {RegKeys.ACTIVE: False},
                 "labels_edge": None,
@@ -380,7 +372,6 @@ class AtlasProfile(profiles.SettingsDict):
             # ABA E11pt5 specific settings
             "abae11pt5": {
                 "target_size": (345, 371, 158),
-                "resize_factor": None,  # turn off resizing
                 "labels_mirror": {RegKeys.ACTIVE: True, "start": 0.52},
                 "labels_edge": {RegKeys.ACTIVE: False, "start": None},
                 "log_atlas_thresh": True,
@@ -415,7 +406,6 @@ class AtlasProfile(profiles.SettingsDict):
             # ABA E13pt5 specific settings
             "abae13pt5": {
                 "target_size": (552, 673, 340),
-                "resize_factor": None,  # turn off resizing
                 "labels_mirror": {RegKeys.ACTIVE: True, "start": 0.48},
                 # small, default surr size to avoid capturing 3rd labeled area
                 # that becomes an artifact
@@ -441,7 +431,6 @@ class AtlasProfile(profiles.SettingsDict):
             # ABA E15pt5 specific settings
             "abae15pt5": {
                 "target_size": (704, 982, 386),
-                "resize_factor": None,  # turn off resizing
                 "labels_mirror": {RegKeys.ACTIVE: True, "start": 0.49},
                 "labels_edge": {
                     RegKeys.ACTIVE: True,
@@ -469,7 +458,6 @@ class AtlasProfile(profiles.SettingsDict):
             # ABA E18pt5 specific settings
             "abae18pt5": {
                 "target_size": (278, 581, 370),
-                "resize_factor": None,  # turn off resizing
                 "labels_mirror": {RegKeys.ACTIVE: True, "start": 0.525},
                 # start from smallest BG; remove spurious label pxs around
                 # medial pallium by smoothing
@@ -492,7 +480,6 @@ class AtlasProfile(profiles.SettingsDict):
             # ABA P4 specific settings
             "abap4": {
                 "target_size": (724, 403, 398),
-                "resize_factor": None,  # turn off resizing
                 "labels_mirror": {RegKeys.ACTIVE: True, "start": 0.487},
                 "labels_edge": {
                     RegKeys.ACTIVE: True,
@@ -518,7 +505,6 @@ class AtlasProfile(profiles.SettingsDict):
             # ABA P14 specific settings
             "abap14": {
                 "target_size": (390, 794, 469),
-                "resize_factor": None,  # turn off resizing
                 # will still cross midline since some regions only have labels
                 # past midline
                 "labels_mirror": {RegKeys.ACTIVE: True, "start": 0.5},
@@ -543,7 +529,6 @@ class AtlasProfile(profiles.SettingsDict):
             # ABA P28 specific settings
             "abap28": {
                 "target_size": (863, 480, 418),
-                "resize_factor": None,  # turn off resizing
                 # will still cross midline since some regions only have labels
                 # past midline
                 "labels_mirror": {RegKeys.ACTIVE: True, "start": 0.48},
@@ -573,7 +558,6 @@ class AtlasProfile(profiles.SettingsDict):
             # ABA P56 (developing mouse) specific settings
             "abap56": {
                 "target_size": (528, 320, 456),
-                "resize_factor": None,  # turn off resizing
                 # stained sections and labels almost but not symmetric
                 "labels_mirror": {RegKeys.ACTIVE: True, "start": 0.5},
                 "labels_edge": {
@@ -596,7 +580,6 @@ class AtlasProfile(profiles.SettingsDict):
             "abap56adult": {
                 # same atlas image as ABA P56dev
                 "target_size": (528, 320, 456),
-                "resize_factor": None,  # turn off resizing
                 # same stained sections as for P56dev;
                 # labels are already mirrored starting at z=228, but atlas is
                 # not here, so mirror starting at the same z-plane to make both
@@ -611,7 +594,6 @@ class AtlasProfile(profiles.SettingsDict):
             "abaccfv3": {
                 # for "25" image, which has same shape as ABA P56dev, P56adult
                 "target_size": (456, 528, 320),
-                "resize_factor": None,  # turn off resizing
                 # atlas is almost (though not perfectly) symmetric, so turn
                 # off mirroring but specify midline (z=228) to make those
                 # labels negative; no need to extend lateral edges
@@ -624,7 +606,6 @@ class AtlasProfile(profiles.SettingsDict):
             "whsrat": {
                 "target_size": (441, 1017, 383),
                 "pre_plane": config.PLANE[2],
-                "resize_factor": None,  # turn off resizing
                 # mirror, but no need to extend lateral edges
                 "labels_mirror": {RegKeys.ACTIVE: True, "start": 0.48},
                 "crop_to_labels": True,  # much extraneous, unlabeled tissue
@@ -636,7 +617,6 @@ class AtlasProfile(profiles.SettingsDict):
             "ahra": {
                 "target_size": (193, 229, 193),
                 "pre_plane": config.PLANE[2],
-                "resize_factor": None,  # turn off resizing
                 # mirror, but no need to extend lateral edges
                 "labels_mirror": {RegKeys.ACTIVE: True, "start": 0.5},
                 "crop_to_labels": True,  # strip skull

--- a/magmap/settings/config.py
+++ b/magmap/settings/config.py
@@ -600,7 +600,8 @@ class RegSuffixes(Enum):
 
 
 #: Dictionary of registered suffix names for each suffix type.
-reg_suffixes: Dict[RegSuffixes, Union[str, Sequence[str]]] = dict.fromkeys(
+reg_suffixes: Dict[
+    RegSuffixes, Optional[Union[str, Sequence[str]]]] = dict.fromkeys(
     RegSuffixes, None)
 
 

--- a/magmap/tests/test_cv_nd.py
+++ b/magmap/tests/test_cv_nd.py
@@ -12,9 +12,18 @@ from magmap.cv import cv_nd
 class TestCvNd(unittest.TestCase):
     
     def test_rescale_resize(self):
+        # set up test array
         img = np.zeros((2, 50, 200, 251, 3))
+        
+        # test rescaling array
         img_rescaled = cv_nd.rescale_resize(img[0], 0.5, multichannel=True)
         testing.assert_array_equal(img_rescaled.shape, (25, 100, 126, 3))
+        
+        # test resizing array
+        target_size = [22, 150, 300]
+        img_rescaled = cv_nd.rescale_resize(img[0], target_size, multichannel=True)
+        target_size.append(3)
+        testing.assert_array_equal(img_rescaled.shape, target_size)
 
 
 if __name__ == "__main__":

--- a/magmap/tests/test_cv_nd.py
+++ b/magmap/tests/test_cv_nd.py
@@ -1,0 +1,21 @@
+# MagellanMapper unit testing for cv_nd
+"""Unit testing for the MagellanMapper cv_nd module."""
+
+import unittest
+
+import numpy as np
+from numpy import testing
+
+from magmap.cv import cv_nd
+
+
+class TestCvNd(unittest.TestCase):
+    
+    def test_rescale_resize(self):
+        img = np.zeros((2, 50, 200, 251, 3))
+        img_rescaled = cv_nd.rescale_resize(img[0], 0.5, multichannel=True)
+        testing.assert_array_equal(img_rescaled.shape, (25, 100, 126, 3))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Image registration often requires atlas transformations. Currently, the registration entry point applies each transformation in several steps, including the atlas transformer, arbitrary rotation, and rescaling. Custom registration pipelines often skip this entry point, using the core registration function instead, but must handle transformations manually.

This PR integrates the arbitrary rotation and rescaling steps into the core atlas transformer to reduce this redundancy. The registration entry point has been left untouched, and future PRs will need to integrate this additional transformer functionality into this registration.

Highlights:
- The `flipud` parameter in the `atlas_refiner.transpose_img` atlas transposer function is now `flip` to allow flipping along any given axis
- Resizing/rescaling from `transformer.Downsampler` has been generalized to `cv_nd.rescale_resize` and incorporated into the atlas transposer, controlled by the `target_size` parameter and a new `order` parameter
- Arbitrary angle rotation added to the atlas transposer through the new `rotate_deg` parameter, with automatic interpolation to isotropy to avoid skew in anisotropic images
- Registration function added to apply Transformix from Elastix for repeated registrations
- Library function added to write a points file for corresponding-points-based registration in Elastix
- An `Image5d` instance can be loaded directly to a SimpleITK `Image` instance
- Functions to make an image isotropic now take a custom resolution