### PR TITLE
Fix browsing for files or directories

### DIFF
--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -22,7 +22,7 @@
 
 #### GUI
 
-- More preferences are saved, such as the figure save location and ROI Editor layout (#138)
+- More preferences are saved, such as the figure save location and ROI Editor layout (#138, #201)
 - "Blend" option in the image adjustment panel to visualize alignment in overlaid images
 - Drag and remove loaded profiles in the Profiles tab table
 - "Help" buttons added to open the online documentation (#109)
@@ -40,6 +40,8 @@
 - Fixed error window when moving the atlas level slider before a 3D image has been rendered (#139)
 - Fixed saving blobs in an ROI using the first displayed ROI or after moving the sliders without redrawing (#139)
 - Fixed synchronization between the ROI Editor and image adjustment controls after initialization (#142)
+- Fixed browsing for files or directories in some environments (#201)
+- Fixed clearing the import path (#201)
 
 #### CLI
 
@@ -96,6 +98,7 @@
 - Better 2D image support
   - Extended zero-crossing detection to 2D cases (#142)
   - Unit factor conversions adapts to image dimensions (eg 2D vs 3D) (#132)
+- Multiple multiplane image files can be selected directly instead of relying on file auto-detection (#201)
 - Fixed re-importing an image after loading it (#117)
 - Fixed to store the image path when loading a registered image as the main image, which fixes saving the experiment name used when saving blobs (#139)
 

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -431,13 +431,18 @@ class Visualization(HasTraits):
 
     # Image import panel
 
-    _import_browser = Str(
-        tooltip="Select a file a file or directory to import:\n"
-                "- File: typically multiplane images; all matching files will"
-                "  also be added\n"
-                "- Dir: a directory of single plane images")
-    _import_file_btn = Button("File")
-    _import_dir_btn = Button("Dir")
+    _import_browser = Str
+    _import_file_btn = Button(
+        "File",
+        tooltip="Select a file to import, typically a multiplane image.\n"
+                "Files with matching names but '_ch_x' before the end will\n"
+                "also be added (eg 'img_ch_0.tif', 'img_ch_1.tif').")
+    _import_dir_btn = Button(
+        "Dir",
+        tooltip="Select a directory of single-plane images to import.\n"
+                "Files will be sorted alphabetically, and files ending with\n"
+                "'_ch_x' are sorted into the given channel. Any file that\n"
+                "cannot be loaded will be simply ignored.")
     _import_table = TabularEditor(
         adapter=ImportFilesArrayAdapter(), editable=True, auto_resize_rows=True,
         stretch_last_section=False)
@@ -862,14 +867,12 @@ class Visualization(HasTraits):
     # import panel
     panel_import = VGroup(
         VGroup(
-            HGroup(
-                Item("_import_browser", label="File/dir to import",
-                     style="simple"),
-                Item("_import_file_btn", show_label=False),
-                Item("_import_dir_btn", show_label=False),
-            ),
-            Item("_import_paths", editor=_import_table, show_label=False),
+            Item("_import_file_btn", label="Multiplane file(s) to import"),
+            Item("_import_dir_btn", label="Directory of single-plane images"),
             label="Import File Selection"
+        ),
+        VGroup(
+            Item("_import_paths", editor=_import_table, show_label=False),
         ),
         VGroup(
             Item("_import_res", label="Resolutions (x,y,z)", format_str="%.4g"),

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -3927,7 +3927,11 @@ class Visualization(HasTraits):
                 lambda: self.update_filename(self._import_prefix))
             self._import_thread.start()
     
-    @on_trait_change("_import_clear_btn")
+    @observe("_import_clear_btn")
+    def _clear_import_files_fired(self, evt):
+        """Handle clearing import fields."""
+        self._clear_import_files()
+    
     def _clear_import_files(self, clear_import_browser=True):
         """Reset import setup.
         

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -279,9 +279,10 @@ class Visualization(HasTraits):
 
     # File selection
 
-    _filename = File(
+    _filename = Str(
         tooltip="Load an image. If the file format requires import, the\n"
                 "Import tab will open automatically.")
+    _filename_btn = Button("Browse")
     _channel_names = Instance(TraitsList)
     _channel = List  # selected channels, 0-based
     _rgb = Bool(config.rgb, tooltip="Show image as RGB(A)")
@@ -568,9 +569,8 @@ class Visualization(HasTraits):
     panel_roi_selector = VGroup(
         VGroup(
             HGroup(
-                Item("_filename", show_label=False, style="simple",
-                     editor=FileEditor(entries=10, allow_dir=False)),
-                label="Image path",
+                Item("_filename", label="Image path", style="simple"),
+                Item("_filename_btn", show_label=False),
             ),
             HGroup(
                 Item("_channel", label="Channels", style="custom",
@@ -2099,6 +2099,15 @@ class Visualization(HasTraits):
             # load the image in the empty current app window
             self.update_filename(filename)
     
+    @observe("_filename_btn")
+    def _filename_updated(self, evt):
+        """Open a Pyface file dialog to set the main image path."""
+        open_dialog = FileDialog(
+            action="open", default_path=os.path.dirname(self._filename))
+        if open_dialog.open() == OK:
+            # get user selected path
+            self._filename = open_dialog.path
+
     @on_trait_change("_filename")
     def _image_path_updated(self):
         """Update the selected filename and load the corresponding image.

--- a/magmap/settings/prefs_prof.py
+++ b/magmap/settings/prefs_prof.py
@@ -20,7 +20,10 @@ class PrefsProfile(profiles.SettingsDict):
     
     #: Figure save directory path.
     fig_save_dir: str = ""
-    
+
+    #: Import directory path.
+    import_dir: str = ""
+
     def __init__(self, *args, **kwargs):
         """Initialize a preferences profile dictionary.
         


### PR DESCRIPTION
Fixes #200.

Swaps out the TraitsUI `FileEditor` for the Pyface `FileDialog` and `DirectoryDialog` as recommended [here](https://stackoverflow.com/a/26170183/1911852). The Pyface versions appear to work more reliably for file selection.

A separate button is required for directory selection since there does not appear to be a single dialog that allows selecting both files and directories. This turns out to not be such an issue since separate MM import pathways are used for importing files vs directories, so I've taken advantage of these separate buttons to clarify their different behaviors with separate labels and tooltips.

For more intuitive behavior, the import file browser now accepts multiple paths instead of relying on auto-detecting related image files. The old behavior is still applied when the user selects a single behavior, but selecting multiple files will import only them, without attempting to auto-detect additional files.

The TraitsUI file browser also has an issue with setting the initial path (see https://github.com/enthought/traitsui/issues/1429), whereas the Pyface dialog works. I've added a preference entry to store the last loaded imported path, which is used to initialize the file or directory browser when opening it again.

Another small fix is that clearing the import fields did not clear the underlying import path, which prevented a response when selecting the same file. The button handler now properly resets this path.