### PR TITLE
Fix restoring image adjustment opacity when scrolling through planes

### DIFF
--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -23,7 +23,6 @@
 #### GUI
 
 - More preferences are saved, such as the figure save location and ROI Editor layout (#138, #201)
-- "Blend" option in the image adjustment panel to visualize alignment in overlaid images
 - Drag and remove loaded profiles in the Profiles tab table
 - "Help" buttons added to open the online documentation (#109)
 - Default confirmation labels can be set before detection (#115)
@@ -34,12 +33,15 @@
 - "Show all" in the Regions section of the ROI panel shows names for all labels (#145)
 - Atlas Editor planes can be reordered or turned off (#180)
 - New viewer that displays each blob separately to verify blob classifications (#193)
+- Image adjustment
+  - "Blend" option in the image adjustment panel to visualize alignment in overlaid images (#89)
+  - Image adjustment channels are radio buttons for easier selection (#212)
+  - Fixed synchronization between the ROI Editor and image adjustment controls after initialization (#142)
 - Fixed to reset the ROI selector when redrawing (#115)
 - Fixed to reorient the camera after clearing the 3D space (#121)
 - Fixed to turn off the minimum intensity slider's auto setting when manually changing the slider (#126) 
 - Fixed error window when moving the atlas level slider before a 3D image has been rendered (#139)
 - Fixed saving blobs in an ROI using the first displayed ROI or after moving the sliders without redrawing (#139)
-- Fixed synchronization between the ROI Editor and image adjustment controls after initialization (#142)
 - Fixed browsing for files or directories in some environments (#201)
 - Fixed clearing the import path (#201)
 

--- a/magmap/gui/plot_editor.py
+++ b/magmap/gui/plot_editor.py
@@ -830,8 +830,9 @@ class PlotEditor:
             PlotEditor.change_brightness_contrast(
                 plot_ax_img, brightness, contrast)
         if alpha is not None:
-            # adjust opacity
+            # adjust and store opacity
             plot_ax_img.ax_img.set_alpha(alpha)
+            plot_ax_img.alpha = alpha
         return plot_ax_img
 
     def update_alpha_blend(
@@ -867,7 +868,7 @@ class PlotEditor:
             maximum: float = np.nan, brightness: Optional[float] = None,
             contrast: Optional[float] = None, alpha: Optional[float] = None,
             alpha_blend: Optional[float] = None) -> PlotAxImg:
-        """Update dislayed image settings.
+        """Update displayed image settings.
 
         Args:
             imgi: Index of image group.

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -825,9 +825,10 @@ class Visualization(HasTraits):
             Item("_imgadj_name", label="Image",
                  editor=CheckListEditor(
                      name="object._imgadj_names.selections")),
-            Item("_imgadj_chls", label="Channel",
-                 editor=CheckListEditor(
-                     name="object._imgadj_chls_names.selections")),
+            # use EnumEditor for radio buttons
+            Item("_imgadj_chls", label="Channel", style="custom",
+                 editor=EnumEditor(
+                     name="object._imgadj_chls_names.selections", cols=8)),
         ),
         HGroup(
             Item("_imgadj_min", label="Minimum", editor=RangeEditor(


### PR DESCRIPTION
Commit https://github.com/sanderslab/magellanmapper/commit/5c32b8449d6b8a5e3f1fa0ec2a2c8d22e8d8c291 introduced a regression where adjustments to Plot Editor images' opacity level were forgotten when scrolling through planes, fixe here.

Also, the image adjustment channel selector now uses radio buttons instead of a dropdown list to reduce the number clicks since the channel can be selected immediately instead of first opening the dropdown.