### PR TITLE
Fix image loading

### DIFF
--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -94,7 +94,7 @@
 #### I/O
 
 - Images can be viewed as RGB(A) using the `RGB` button or the `--rgb` CLI argument (#142)
-- Some TIF files can be loaded directly, without importing the file first (#90)
+- Some TIF files can be loaded directly, without importing the file first (#90, #213)
 - The `--proc export_planes` task can export a subset of image planes specified by `--slice`, or an ROI specified by `--offset` and `--size`
 - Image metadata is stored in the `Image5d` image object (#115)
 - Better 2D image support

--- a/magmap/io/np_io.py
+++ b/magmap/io/np_io.py
@@ -247,7 +247,7 @@ def setup_images(
     config.labels_img_sitk = None
     config.labels_img_orig = None
     config.borders_img = None
-    config.labels_meta = None
+    config.labels_metadata = None
     config.labels_ref = None
     
     # reset blobs

--- a/magmap/io/sitk_io.py
+++ b/magmap/io/sitk_io.py
@@ -64,7 +64,8 @@ def reg_out_path(file_path, reg_name, match_ext=False):
         return file_path_base + "_" + reg_name
 
 
-def replace_sitk_with_numpy(img_sitk, img_np):
+def replace_sitk_with_numpy(
+        img_sitk: sitk.Image, img_np: np.ndarray) -> sitk.Image:
     """Generate a :class:``sitk.Image`` object based on another Image object,
     but replace its array with a new Numpy array.
     
@@ -75,11 +76,18 @@ def replace_sitk_with_numpy(img_sitk, img_np):
     Returns:
         New :class:``sitk.Image`` object with same spacing, origin, and 
         direction as that of ``img_sitk`` and array replaced with ``img_np``.
+    
     """
+    # get original settings
     spacing = img_sitk.GetSpacing()
     origin = img_sitk.GetOrigin()
     direction = img_sitk.GetDirection()
-    img_sitk_back = sitk.GetImageFromArray(img_np)
+    
+    # treat as vector (multichannel) image if source is multichannel
+    img_sitk_back = sitk.GetImageFromArray(
+        img_np, True if img_sitk.GetNumberOfComponentsPerPixel() > 1 else None)
+    
+    # transfer original settings to new sitk Image
     img_sitk_back.SetSpacing(spacing)
     img_sitk_back.SetOrigin(origin)
     img_sitk_back.SetDirection(direction)


### PR DESCRIPTION
Commit https://github.com/sanderslab/magellanmapper/commit/bbf6b0803fd3066f049346191b663713bbbad05a introduced a regression where multichannel SimpleITK images would be treated as single-channel images when updating them with a NumPy array. Keep the multichannel status based on the given SimpleITK image.

Additional fixes:
- Loading 2D/2D+channel images by adding a z-axis
- Avoids inadvertently overwriting the `config.labels_meta` module reference when setting up an image