### PR TITLE
Fix image rotation

### DIFF
--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -51,11 +51,12 @@
 - the `--transform interpolation=<n>` configures the type of interpolation when resizing images during stack export (#127)
 - Any axis can be flipped through `--transform flip=<axis>`, where `axis = 0` for the z-axis, 1 for the y-axis, and 2 for the x-axis (#147)
 - Density/heat maps can be specified through `--reg_suffixes density=<suffix>` (#129)
-- The atlas transformer handles more transformations, such as rotation to any angle, flipping along any axis, and resizing (#195)
 - Write point files for corresponding-point-based registration (#195)
 - Fixed to only remove the final extension from image paths, and paths given by the `--prefix <path>` CLI argument do not undergo any stripping (#115)
 
 #### Atlas refinement
+
+- The atlas transformer (`atlas_refiner.transpose_img`) provides a more comprehensive set of typical transformations before atlas refinement or registration, such as rotation to any angle, flipping along any axis, and resizing (#195, #214)
 
 #### Atlas registration
 

--- a/magmap/atlas/atlas_refiner.py
+++ b/magmap/atlas/atlas_refiner.py
@@ -1085,6 +1085,7 @@ def transpose_img(
         rotate: Optional[int] = None,
         rotate_deg: Optional[Sequence[Dict[str, Any]]] = None,
         target_size: Optional[Union[float, Sequence[int]]] = None,
+        target_size_res: Optional[Union[float, Sequence[int]]] = None,
         flip: Optional[int] = None,
         order: Optional[int] = None
 ) -> sitk.Image:
@@ -1107,6 +1108,9 @@ def transpose_img(
             Defaults to None.
         target_size: Size of target in `z, y, x` order, or a single rescaling
             factor. Defaults to None.
+        target_size_res: Same as ``target_size``, but applied to the image
+            resolutions instead of changing the image itself. Defaults to
+            None.
         flip: Axis to flip after transposition;
             defaults to None, in which case it will be based on ``plane``.
         order: Spline interpolation order; defaults to None.
@@ -1210,6 +1214,12 @@ def transpose_img(
         # change is often to alter the physical dimensions
         transposed = cv_nd.rescale_resize(
             transposed, target_size, preserve_range=True, order=order)
+    
+    if target_size_res is not None:
+        # rescale or resize by adjusting resolution, without changing the image
+        if libmag.is_seq(target_size_res):
+            target_size_res = target_size_res
+        spacing = np.multiply(spacing, target_size_res)
     
     # convert back to sitk image
     transposed = sitk.GetImageFromArray(transposed)

--- a/magmap/atlas/atlas_refiner.py
+++ b/magmap/atlas/atlas_refiner.py
@@ -1145,10 +1145,11 @@ def transpose_img(
     rotate = rotate_num
     _logger.info(
         "Image transformation settings: plane: %s, num of rotations: %s, "
-        "target_size: %s, flip axis: %s",
-        plane, rotate, target_size, flip)
+        "rotate_deg: %s, target_size: %s, target_size_res: %s, flip axis: %s",
+        plane, rotate, rotate_deg, target_size, target_size_res, flip)
     if ((not plane or plane == config.PLANE[0]) and not rotate and
-            not rotate_deg and target_size is None and flip is None):
+            not rotate_deg and target_size is None and target_size_res is None
+            and flip is None):
         _logger.info("No transformations to apply, skipping")
         return img_sitk
     
@@ -1184,7 +1185,7 @@ def transpose_img(
             # or flipped rotation (eg 90 or 180 deg)
             dtype = transposed.dtype
             transposed = cv_nd.make_isotropic(
-                transposed, res=spacing).astype(dtype)
+                transposed, res=spacing, order=order).astype(dtype)
             iso_factor = cv_nd.calc_isotropic_factor(res=spacing)
             spacing = np.divide(spacing, iso_factor)
             origin = np.divide(origin, iso_factor)
@@ -1192,8 +1193,8 @@ def transpose_img(
         # rotate by arbitrary degrees along each set of axes
         for rot in rotate_deg:
             # rotation arguments given as dict
-            if "order" not in rot:
-                # default to use given order
+            if "order" not in rot or rot["order"] is None:
+                # default to use order from main parameter
                 rot["order"] = order
             transposed = cv_nd.rotate_nd(transposed, **rot)
             

--- a/magmap/cv/cv_nd.py
+++ b/magmap/cv/cv_nd.py
@@ -1121,6 +1121,11 @@ def rescale_resize(
     }
     args.update(kwargs)
     
+    if "order" in args and args["order"] == 0 and "anti_aliasing" not in args:
+        # default to turn off anti-aliasing when order is 0 to preserve the
+        # exact original values
+        args["anti_aliasing"] = False
+    
     if libmag.is_seq(target_size):
         # resize the image to a custom shape
         args["output_shape"] = target_size

--- a/magmap/cv/cv_nd.py
+++ b/magmap/cv/cv_nd.py
@@ -1059,7 +1059,7 @@ def calc_isotropic_factor(
 
 def make_isotropic(
         roi: np.ndarray, scale: Union[float, Sequence[float]] = 1,
-        res: Optional[Sequence[float]] = None
+        res: Optional[Sequence[float]] = None, **kwargs
 ) -> np.ndarray:
     """Make an array isotropic.
     
@@ -1071,6 +1071,7 @@ def make_isotropic(
         res: Resolutions in the same order as for ``scale``. Default to None,
             in which case :attr:`magmap.settings.config.resolutions` will be
             used instead.
+        kwargs: Additional arguments to :meth:`rescale_resize`.
 
     Returns:
         Isotropic version of ``roi``.
@@ -1081,6 +1082,7 @@ def make_isotropic(
     isotropic_shape[:3] = (isotropic_shape[:3] * resize_factor).astype(np.int)
     libmag.printv("original ROI shape: {}, isotropic: {}"
                   .format(roi.shape, isotropic_shape))
+    
     mode = "reflect"
     if np.any(np.array(roi.shape) == 1):
         # may crash with floating point exception if 1px thick (see
@@ -1088,7 +1090,11 @@ def make_isotropic(
         # causes multiprocessing Pool to hang since the exception isn't
         # raised), so need to change mode in this case
         mode = "edge"
-    return rescale_resize(roi, isotropic_shape, preserve_range=True, mode=mode)
+    
+    # additional args override defaults
+    args = dict(preserve_range=True, mode=mode)
+    args.update(kwargs)
+    return rescale_resize(roi, isotropic_shape, **args)
 
 
 def rescale_resize(
@@ -1107,7 +1113,7 @@ def rescale_resize(
         preserve_range: True to preserve the range of ``roi``; defaults to
             False.
         kwargs: Additional arguments passed to :meth:`transform.rescale`
-            or :meth:`transform.resize`.
+            or :meth:`transform.resize`, such as ``order`` for label images.
 
     Returns:
         Rescaled array.

--- a/magmap/settings/config.py
+++ b/magmap/settings/config.py
@@ -348,6 +348,8 @@ class Transforms(Enum):
     """Image transformation keys for command-line parsing."""
     #: Rotate by 90 deg the number of specified times.
     ROTATE = auto()
+    #: Rotate by specific degrees clockwise.
+    ROTATE_DEG = auto()
     #: Flip the image vertically if 1, no flip if 0.
     FLIP_VERT = auto()
     #: Flip the image horizontally if 1, no flip if 0.


### PR DESCRIPTION
This PR enhances and fixes image rotation in several ways:
- Plot Editor axes are transformed rather than rotating the underlying data
- The atlas transformer supports an alternative rescaling/resizing by changing the rotation rather than the underlying data
- Fixed a regression in preserving the original label identities when rescaling/resizing images and during degree rotation in the atlas transformer