### PR TITLE
Increase flexibility of the figure save wrapper

### DIFF
--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -115,6 +115,7 @@
   - `--plot labels err_col_abs=<col>`: plot error bars with a column of absolute rather than relative values, now that Clrstats gives absolute values for effect sizes
   - `--plot_labels background=<color>`: change plot background color with a Matplotlib color string
   - `--plot_labels vspan_col=<col> vspan_format=<str>`: column denoting vertical span groups and string format for them, respectively (#135, 137)
+- The figure save wrapper (`plot_support.save_fig`) is more flexible (#215)
 - Fixed errors when generating labels difference heat maps, and conditions can be set through `--plot_labels condition=cond1,cond2,...` (#132)
 - Fixed alignment of headers and columns in data frames printed to console (#109)
 

--- a/magmap/atlas/labels_meta.py
+++ b/magmap/atlas/labels_meta.py
@@ -70,7 +70,11 @@ class LabelsMeta:
                 labels_ref_out = libmag.combine_paths(
                     self.prefix, labels_ref_name, check_dir=True)
                 labels_ref_name = pathlib.Path(labels_ref_out).name
-            libmag.copy_backup(self.path_ref, labels_ref_out)
+            
+            if not pathlib.Path(labels_ref_out).exists():
+                # copy file only if not already present; assumes that any
+                # existing file is correct and does not back it up
+                libmag.copy_backup(self.path_ref, labels_ref_out)
         
         # save metadata as YAML file
         meta = {

--- a/magmap/plot/plot_support.py
+++ b/magmap/plot/plot_support.py
@@ -1252,7 +1252,8 @@ def setup_images_for_plane(plane, arrs_3d):
 
 def save_fig(
         path: Union[str, pathlib.Path], ext: Optional[str] = None,
-        modifier: str = "", fig: Optional["figure.Figure"] = None, **kwargs
+        modifier: str = "", fig: Optional["figure.Figure"] = None,
+        backup: bool = True, **kwargs
 ) -> Optional[str]:
     """Save figure with support for backup and alternative file formats.
     
@@ -1272,6 +1273,7 @@ def save_fig(
             defaults to an empty string.
         fig: Figure; defaults to None to use the current figure.
         kwargs: Additional arguments to :meth:`matplotlib.figure.savefig`.
+        backup: True (default) to back up any existing file before saving.
     
     Returns:
         The output path, or None if the file was not saved.
@@ -1321,9 +1323,10 @@ def save_fig(
             f"save extension")
         return None
     
-    # backup any existing file
     plot_path = f"{path}{modifier}.{ext}"
-    libmag.backup_file(plot_path)
+    if backup:
+        # backup any existing file
+        libmag.backup_file(plot_path)
     
     fig.savefig(plot_path, **kwargs)
     _logger.info(f"Exported figure to {plot_path}")

--- a/magmap/plot/plot_support.py
+++ b/magmap/plot/plot_support.py
@@ -1260,7 +1260,7 @@ def save_fig(
     Dots per inch is set by :attr:`config.plot_labels[config.PlotLabels.DPI]`.
     Backs up any existing file before saving. If the found extension is
     not for a supported format for the figure's backend, the figure is not
-    saved.
+    saved. Any non-existing parents folders will be created.
 
     Args:
         path: Base path to use, with or without extension.
@@ -1327,6 +1327,9 @@ def save_fig(
     if backup:
         # backup any existing file
         libmag.backup_file(plot_path)
+    
+    # make parent directories if necessary
+    os.makedirs(os.path.dirname(path), exist_ok=True)
     
     fig.savefig(plot_path, **kwargs)
     _logger.info(f"Exported figure to {plot_path}")


### PR DESCRIPTION
The save figure function wraps the Matplotlib `savefig` with path finding and incorporating config settings. This RP adds:
- Support additional arguments directly to `savefig` through `kwargs`
- The extension can now contain a preceding `.` since it is often included with other functions, such as `os.path.splitext`
- Backup before saving can be turned off if desired (on by default) to avoid generating excessive files
- Parent directories are generated since otherwise `savefig` will generate an error, and the parents are presumably desired

Similarly to the backup change, labels reference files are no longer backed up when saving labels metadata if the file already exists. If so, the file will simply be assumed to be correct and will not be copied to avoid overwriting it.