### PR TITLE
Back up blob archives and fix saving blob columns

### DIFF
--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -72,11 +72,13 @@
 - `ctrl+[n]+click` to add a channel now sets the channel directly to `n` rather than to the `n`th seleted channel (#109)
 - Added a slider to choose the fraction of 3D blobs to display (#121)
 - Improved blob size slider range and readability (#121)
-- Blob columns can be customized, including excluding or reordering columns (#133)
+- Blob columns can be customized, including excluding or reordering columns (#133, #216)
+- Existing blob archives are backed up before saving (#216) 
 - Fixed to scale blobs' radii when viewing blobs detections on a downsampled image (#121)
 - Fixed getting atlas colors for blobs for ROIs inside the main image (#121)
 - Fixed blob segmentation for newer versions of Scikit-image (#91)
 - Fixed verifying and resaving blobs
+- Fixed loading blobs in the GUI with no blobs in the ROI or channels selected (#216)
 
 ##### Colocalization
 

--- a/magmap/cv/chunking.py
+++ b/magmap/cv/chunking.py
@@ -358,7 +358,6 @@ def get_split_stack_total_shape(sub_rois, overlap=None):
     channel_dim = 3
     if len(shape_sub_roi) > channel_dim:
         final_shape[channel_dim] = shape_sub_roi[channel_dim]
-    libmag.printv("final_shape: {}".format(final_shape))
     return final_shape
 
 

--- a/magmap/cv/detector.py
+++ b/magmap/cv/detector.py
@@ -300,7 +300,13 @@ class Blobs:
             it is an array of blobs.
 
         """
-        if blob.ndim > 1:
+        is_multi_d = blob.ndim > 1
+        if col is None:
+            # no column indicates that this column has not been set up for the
+            # blob, so return None or an empty ndarray
+            return np.array([]) if is_multi_d else None
+        
+        if is_multi_d:
             return blob[..., col]
         return blob[col]
     

--- a/magmap/cv/detector.py
+++ b/magmap/cv/detector.py
@@ -399,7 +399,9 @@ class Blobs:
     @classmethod
     def set_blob_col(
             cls, blob: np.ndarray, col: Union[int, Sequence[int]],
-            val: Union[float, Sequence[float]]
+            val: Union[float, Sequence[float]],
+            mask: Union[
+                np.ndarray, np.lib.index_tricks.IndexExpression] = np.s_[:], **kwargs
     ) -> np.ndarray:
         """Set the value for the given column of a blob or blobs.
 
@@ -408,68 +410,75 @@ class Blobs:
             col: Column index in ``blob``.
             val: New value. If ``blob`` is 2D, can be an array the length
                 of ``blob``.
+            mask: Mask for the first axis; defaults to an index expression
+                for all values. Only used for multidimensional arrays.
 
         Returns:
             ``blob`` after modifications.
 
         """
         if blob.ndim > 1:
-            blob[..., col] = val
+            # set value for col in last axis, applying mask for first axis
+            blob[mask, ..., col] = val
         else:
             blob[col] = val
         return blob
     
     @classmethod
     def set_blob_confirmed(
-            cls, blob: np.ndarray, val: Union[int, np.ndarray]) -> np.ndarray:
+            cls, blob: np.ndarray, *args, **kwargs) -> np.ndarray:
         """Set the confirmed flag of a blob or blobs.
 
         Args:
             blob: 1D blob array or 2D array of blobs.
-            val: Confirmed value. If ``blob`` is 2D, can be an array the length
-                of ``blob``.
+            args: Positional arguments passed to :meth:`set_blob_col`.
+            kwargs: Named arguments passed to :meth:`set_blob_col`.
 
         Returns:
             ``blob`` after modifications.
 
         """
-        return cls.set_blob_col(blob, cls.col_inds[cls.Cols.CONFIRMED], val)
+        return cls.set_blob_col(
+            blob, cls.col_inds[cls.Cols.CONFIRMED], *args, **kwargs)
     
     @classmethod
     def set_blob_truth(
-            cls, blob: np.ndarray, val: Union[int, np.ndarray]) -> np.ndarray:
+            cls, blob: np.ndarray, *args, **kwargs) -> np.ndarray:
         """Set the truth flag of a blob or blobs.
 
         Args:
             blob: 1D blob array or 2D array of blobs.
-            val: Truth value. If ``blob`` is 2D, can be an array the length
-                of ``blob``.
+            args: Positional arguments passed to :meth:`set_blob_col`.
+            kwargs: Named arguments passed to :meth:`set_blob_col`.
 
         Returns:
             ``blob`` after modifications.
 
         """
-        return cls.set_blob_col(blob, cls.col_inds[cls.Cols.TRUTH], val)
+        return cls.set_blob_col(
+            blob, cls.col_inds[cls.Cols.TRUTH], *args, **kwargs)
     
     @classmethod
     def set_blob_channel(
-            cls, blob: np.ndarray, val: Union[int, np.ndarray]) -> np.ndarray:
+            cls, blob: np.ndarray, *args, **kwargs) -> np.ndarray:
         """Set the channel of a blob or blobs.
 
         Args:
             blob: 1D blob array or 2D array of blobs.
-            val: Channel value. If ``blob`` is 2D, can be an array the length
-                of ``blob``.
+            args: Positional arguments passed to :meth:`set_blob_col`.
+            kwargs: Named arguments passed to :meth:`set_blob_col`.
 
         Returns:
             ``blob`` after modifications.
 
         """
-        return cls.set_blob_col(blob, cls.col_inds[cls.Cols.CHANNEL], val)
+        return cls.set_blob_col(
+            blob, cls.col_inds[cls.Cols.CHANNEL], *args, **kwargs)
     
     @classmethod
     def set_blob_abs_coords(
-            cls, blobs: np.ndarray, coords: Sequence[int]) -> np.ndarray:
+            cls, blobs: np.ndarray, coords: Sequence[int], *args, **kwargs
+    ) -> np.ndarray:
         """Set blob absolute coordinates.
         
         Args:
@@ -481,7 +490,7 @@ class Blobs:
             Modified ``blobs``.
 
         """
-        cls.set_blob_col(blobs, cls._get_abs_inds(), coords)
+        cls.set_blob_col(blobs, cls._get_abs_inds(), coords, *args, **kwargs)
         return blobs
     
     @classmethod

--- a/magmap/cv/detector.py
+++ b/magmap/cv/detector.py
@@ -201,6 +201,8 @@ class Blobs:
     def save_archive(self, to_add=None, update=False):
         """Save the blobs Numpy archive file to :attr:`path`.
         
+        Backs up any existing file before saving.
+        
         Args:
             to_add (dict): Dictionary of items to add; defaults to None
                 to use the current attributes.
@@ -235,6 +237,9 @@ class Blobs:
                 # load archive, convert to dict, and update dict
                 blobs_arc = np_io.read_np_archive(archive)
                 blobs_arc.update(to_add)
+        
+        # back up any existing file
+        libmag.backup_file(self.path)
         
         with open(self.path, "wb") as archive:
             # save as uncompressed zip Numpy archive file

--- a/magmap/cv/stack_detect.py
+++ b/magmap/cv/stack_detect.py
@@ -110,9 +110,8 @@ class StackDetector(object):
             cli.process_cli_args()
             _, orig_info = importer.make_filenames(img_path)
             importer.load_metadata(orig_info)
-        print("detecting blobs in sub-ROI at {} of {}, offset {}, shape {}..."
-              .format(coord, last_coord, tuple(offset.astype(int)),
-                      sub_roi.shape))
+        _logger.info(
+            "Detecting blobs in sub-ROI at %s of %s", coord, last_coord)
         
         if denoise_max_shape is not None:
             # further split sub-ROI for preprocessing locally
@@ -124,10 +123,8 @@ class StackDetector(object):
                         denoise_coord = (z, y, x)
                         denoise_roi = sub_roi[denoise_roi_slices[denoise_coord]]
                         _logger.debug(
-                            f"preprocessing sub-sub-ROI {denoise_coord} of "
-                            f"{np.subtract(denoise_roi_slices.shape, 1)} "
-                            f"(shape {denoise_roi.shape} within sub-ROI shape "
-                            f"{sub_roi.shape})")
+                            f"Preprocessing sub-sub-ROI {denoise_coord} of "
+                            f"{np.subtract(denoise_roi_slices.shape, 1)}")
                         denoise_roi = plot_3d.saturate_roi(
                             denoise_roi, channel=channel)
                         denoise_roi = plot_3d.denoise_roi(

--- a/magmap/gui/roi_editor.py
+++ b/magmap/gui/roi_editor.py
@@ -1011,6 +1011,7 @@ class ROIEditor(plot_support.ImageSyncMixin):
                 and only used if :attr:``config.savefig`` is set to a file
                 extension.
         """
+        # TODO: replace with modularized version from plot_2d_stack?
         fig = plt.figure()
         # fig.suptitle(title)
         # total number of z-planes
@@ -1024,11 +1025,10 @@ class ROIEditor(plot_support.ImageSyncMixin):
             zoom_plot_cols += 1
             zoom_plot_rows = math.ceil(z_planes / zoom_plot_cols)
             col_remainder = z_planes % zoom_plot_cols
-        roi_size = roi.shape[::-1]
+        roi_size = roi.shape[:3][::-1]
         zoom_offset = [0, 0, 0]
         gs = gridspec.GridSpec(
             zoom_plot_rows, zoom_plot_cols, wspace=0.1, hspace=0.1)
-        image5d = importer.roi_to_image5d(roi)
 
         # plot the fully zoomed plots
         for i in range(zoom_plot_rows):

--- a/magmap/gui/roi_editor.py
+++ b/magmap/gui/roi_editor.py
@@ -271,8 +271,6 @@ class ROIEditor(plot_support.ImageSyncMixin):
         ZLevels (:obj:`Enum`): Enum denoting the possible positions of the
             z-plane shown in the overview plots.
         fig (:obj:`figure.figure`): Matplotlib figure.
-        image5d (:obj:`np.ndarray`): Main image array in ``t,z,y,x[,c]``
-            format; defaults to None.
         labels_img (:obj:`np.ndarray`): Atlas labels image in ``z,y,x`` format;
             defaults to None.
         img_region (:obj:`np.ndarray`): 3D boolean or binary array with the
@@ -335,7 +333,9 @@ class ROIEditor(plot_support.ImageSyncMixin):
         """Initialize the editor."""
         super().__init__(img5d)
         print("Initiating ROI Editor")
-        self.image5d = self.img5d.img if self.img5d else None
+        #: Image instance to display.
+        self.image5d: Optional[
+            "np_io.Image5d"] = None if self.img5d is None else self.img5d.img
         self.labels_img: Optional[np.ndarray] = labels_img
         if img_region is not None:
             # invert region selection image to opacify areas outside of the

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -2501,7 +2501,7 @@ class Visualization(HasTraits):
         # are relative to offset
         colocs = None
         if config.blobs is None or config.blobs.blobs is None:
-            # on-the-fly blob detection, which includes border but not 
+            # on-the-fly blob detection, which includes border but not
             # padding region; already in relative coordinates
             roi = self.roi
             if config.roi_profile["thresholding"]:
@@ -2521,7 +2521,7 @@ class Visualization(HasTraits):
                     # TODO: include all channel combos
                     self.blobs.blob_matches = matches[tuple(matches.keys())[0]]
         else:
-            # get all previously processed blobs in ROI plus additional 
+            # get all previously processed blobs in ROI plus additional
             # padding region to show surrounding blobs
             # TODO: set segs_all to None rather than empty list if no blobs?
             print("Selecting blobs in ROI from loaded blobs")
@@ -2581,7 +2581,7 @@ class Visualization(HasTraits):
             segs = detector.Blobs.blobs_in_channel(segs, chls)
             segs_all = np.concatenate((segs, segs_outside), axis=0)
             
-        if segs_all is not None:
+        if segs_all is not None and len(segs_all) > 0:
             # set confirmation flag to user-selected label for any
             # un-annotated blob
             confirmed = detector.Blobs.get_blob_confirmed(segs_all)

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -2481,8 +2481,11 @@ class Visualization(HasTraits):
         self.blobs.blob_matches = blob_matches
         cli.update_profiles()
         
-        # get selected channels for blob detection
+        # get selected channels for blob detection; must have at least 1
         chls = sorted([int(n) for n in self._segs_chls])
+        if len(chls) == 0:
+            self.segs_feedback = "Please select a channel for blob detection"
+            return
         
         # process ROI in prep for showing filtered 2D view and segmenting
         self._segs_visible = [BlobsVisibilityOptions.VISIBLE.value]

--- a/magmap/io/export_rois.py
+++ b/magmap/io/export_rois.py
@@ -161,9 +161,10 @@ def export_rois(
             print("sitk img:\n{}".format(img3d_back[0]))
             '''
             sitk.WriteImage(img3d_sitk, path_img_nifti, False)
-            roi_ed = roi_editor.ROIEditor(img5d.img)
+            roi_ed = roi_editor.ROIEditor(img5d)
+            print("shape", img3d.shape)
             roi_ed.plot_roi(
-                img3d, blobs, channel, show=False,
+                img3d, blobs, [channel], show=False,
                 title=os.path.splitext(path_img)[0])
             libmag.show_full_arrays()
             

--- a/magmap/plot/plot_3d.py
+++ b/magmap/plot/plot_3d.py
@@ -4,7 +4,7 @@
 
 Prepare volumetric image stacks for plotting.
 """
-from typing import Optional, Sequence
+from typing import Optional, Sequence, Tuple
 
 import numpy as np
 from skimage import draw
@@ -19,22 +19,24 @@ from magmap.cv import cv_nd
 from magmap.cv import segmenter
 
 
-def setup_channels(roi, channel, dim_channel):
+def setup_channels(
+        roi: np.ndarray, channel: Sequence[int], dim_channel: int
+) -> Tuple[bool, Sequence[int]]:
     """Setup channels array for the given ROI dimensions.
     
     Args:
-        roi (:obj:`np.ndarray`): Region of interest, which is either a 3D
-            or 4D array in the formate ``[[z, y, x, (c)], ...]``.
-        channel (List[int]): Channels to select, which can be None to indicate
-            all channels.
-        dim_channel (int): Index of the channel dimension.
+        roi: Region of interest, a 3/4D array in the order, ``z, y, x, [c]``.
+        channel: Channels to select, which can be None to indicate all channels.
+        dim_channel: Index of the channel dimension.
     
     Returns:
-        bool, List[int]: A boolean value where True indicates that
-        the ROI is multichannel (ie 4D) and an array of the channel indices
-        of ``roi`` to include, which is the same as ``channel`` for
-        multichannel ROIs or only the first element if ``roi`` is single
-        channel.
+        A tuple of:
+        - ``multichannel``: boolean value where True indicates that the
+          ROI is multichannel (ie 4D)
+        - ``channels``: an array of the channel indices of ``roi`` to include,
+          which is the same as ``channel`` for multichannel ROIs or only the
+          first element if ``roi`` is single channel
+    
     """
     multichannel = roi.ndim > dim_channel
     channels = channel

--- a/magmap/plot/plot_3d.py
+++ b/magmap/plot/plot_3d.py
@@ -20,7 +20,7 @@ from magmap.cv import segmenter
 
 
 def setup_channels(
-        roi: np.ndarray, channel: Sequence[int], dim_channel: int
+        roi: np.ndarray, channel: Optional[Sequence[int]], dim_channel: int
 ) -> Tuple[bool, Sequence[int]]:
     """Setup channels array for the given ROI dimensions.
     

--- a/magmap/plot/plot_support.py
+++ b/magmap/plot/plot_support.py
@@ -324,7 +324,7 @@ class ImageOverlayer:
     
     def imshow_multichannel(
             self, img2d: np.ndarray,
-            channel: Optional[Union[int, Sequence[int]]],
+            channel: Optional[Sequence[int]],
             cmaps: Sequence[Union[str, "colors.Colormap"]],
             alpha: Optional[Union[float, Sequence[float]]] = None,
             vmin: Optional[Union[float, Sequence[float]]] = None,
@@ -345,7 +345,8 @@ class ImageOverlayer:
     
         Args:
             img2d: 2D image either as 2D (y, x) or 3D (y, x, channel) array.
-            channel: Channel to display; if None, all channels will be shown.
+            channel: Sequence of channels to display; if None, all channels
+                will be shown.
             cmaps: List of colormaps corresponding to each channel. Colormaps 
                 can be the names of specific maps in :mod:``config``.
             alpha: Transparency level for all channels or 

--- a/magmap/settings/config.py
+++ b/magmap/settings/config.py
@@ -120,8 +120,8 @@ metadatas = None
 series = None
 #: list[int]: List of image series/tiles.
 series_list = None
-#: int: Channel of interest, where None specifies all channels.
-channel = None
+#: Channel(s) of interest, where None specifies all channels.
+channel: Optional[Sequence[int]] = None
 
 #: CLI flag to open images in RGB(A) mode if True; defaults to False.
 rgb: bool = False

--- a/magmap/settings/config.py
+++ b/magmap/settings/config.py
@@ -249,21 +249,37 @@ class PreProcessKeys(Enum):
 
 class ProcessTypes(Enum):
     """Whole image processing task enumerations."""
-    IMPORT_ONLY = auto()  # imports image stack
-    DETECT = auto()  # whole image blob detection
-    DETECT_COLOC = auto()  # detection with colocalization by intensity
-    COLOC_MATCH = auto()  # colocalization by blob matching
-    LOAD = auto()  # DEPRECATED: load previously processed images and blobs
-    EXTRACT = auto()  # extract single plane using the z-val from offset
-    EXPORT_ROIS = auto()  # export ROIs from current database to serial 2D plots
-    TRANSFORM = auto()  # transform image (see transformer.transpose_img)
-    ANIMATED = auto()  # generate an animated GIF
-    EXPORT_BLOBS = auto()  # export blob coordinates/radii to compressed CSV
-    EXPORT_PLANES = auto()  # export a 3D+ image to individual planes
-    EXPORT_PLANES_CHANNELS = auto()  # also export channels to separate files
-    EXPORT_RAW = auto()  # export an array as a raw data file
-    EXPORT_TIF = auto()  # export an array as TIF files for each channel
-    PREPROCESS = auto()  # pre-process whole image
+    #: Import image stack to NumPy format.
+    IMPORT_ONLY = auto()
+    #: Detect blobs in the whole image.
+    DETECT = auto()
+    #: Detect blobs along with intensity-based colocalization.
+    DETECT_COLOC = auto()
+    #: Detect blobs along with match-based colocalization.
+    COLOC_MATCH = auto()
+    #: Load previously processed images and blobs. DEPRECATED: use ``--load``
+    #: CLI parameter instead.
+    LOAD = auto()
+    #: Extract a single plane defined by the z-value in ``--offset``.
+    EXTRACT = auto()
+    #: Export ROIs from the database to serial 2D plots.
+    EXPORT_ROIS = auto()
+    #: Transform an image (see :meth:`magmap.atlas.transformer.transpose_img``).
+    TRANSFORM = auto()
+    #: Generate an animated GIF of successive planes in an image.
+    ANIMATED = auto()
+    #: Export blobs to a CSV file.
+    EXPORT_BLOBS = auto()
+    #: Export a 3/4D image to individual planes.
+    EXPORT_PLANES = auto()
+    # Export image planes to separate files for each channel.
+    EXPORT_PLANES_CHANNELS = auto()
+    #: Export an array as a raw data file.
+    EXPORT_RAW = auto()
+    #: Export an array as TIF files for each channel.
+    EXPORT_TIF = auto()
+    #: Pre-process the whole image.
+    PREPROCESS = auto()
 
 
 #: Processing tasks.


### PR DESCRIPTION
We're splitting out the blob changes from the classifier branch (#199) here for modularity and to integrate them sooner.

- Blob archives are backed up before overwriting
- Fixed saving additional blob columns
- Fixed blob accessors/setters
- Fixed blob detections in the GUI with no selected channels or loaded blobs but none in the ROI
- Fixed exporting ROIs
- Reduced debug messages during blob detection