### PR TITLE
Change Sphinx docs theme to Furo

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -74,7 +74,7 @@ release = libmag.get_version(True)
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -93,7 +93,7 @@ todo_include_todos = False
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'nature'
+html_theme = "furo"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -111,16 +111,19 @@ html_static_path = ['_static']
 #
 # This is required for the alabaster theme
 # refs: http://alabaster.readthedocs.io/en/latest/installation.html#sidebars
-html_sidebars = {
-    '**': [
-        #'about.html',
-        #'navigation.html',
-        'globaltoc.html',  # show all pages' headers
-        'relations.html',  # needs 'show_related': True theme option to display
-        'searchbox.html',
-        #'donate.html',
-    ]
-}
+# html_sidebars = {
+#     '**': [
+#         #'about.html',
+#         #'navigation.html',
+#         'globaltoc.html',  # show all pages' headers
+#         'relations.html',  # needs 'show_related': True theme option to display
+#         'searchbox.html',
+#         #'donate.html',
+#     ]
+# }
+
+# Change table of contents formatting
+# toc_object_entries_show_parents = "domain"
 
 
 # -- Options for HTMLHelp output ------------------------------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,6 +16,7 @@ Welcome to MagellanMapper's documentation!
    settings.md
    pipelines.md
    cloud_aws.md
+   release/index
    API documentation <genindex>
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,6 +16,7 @@ Welcome to MagellanMapper's documentation!
    settings.md
    pipelines.md
    cloud_aws.md
+   API documentation <genindex>
 
 
 

--- a/docs/release/index.md
+++ b/docs/release/index.md
@@ -1,0 +1,16 @@
+# Releases
+
+Release notes for MagellanMapper versions.
+
+```{toctree}
+:hidden:
+
+v1.6<release_v1.6>
+v1.5<release_v1.5>
+v1.4<release_v1.4>
+v1.3<release_v1.3>
+v1.2<release_v1.2>
+v1.1<release_v1.1>
+v1.0<release_v1.0>
+v0.9<release_v0.9>
+```

--- a/docs/release/release_v1.5.md
+++ b/docs/release/release_v1.5.md
@@ -1,44 +1,5 @@
 # MagellanMapper v1.5 Release Notes
 
-## MagellanMapper v1.5.1
-
-### Highlights
-
-### Changes
-
-#### Installation
-
-#### GUI
-
-#### CLI
-
-#### Atlas refinement
-
-#### Atlas registration
-
-#### Cell detection
-
-#### Volumetric image processing
-
-#### I/O
-
-#### Server pipelines
-
-#### Python stats and plots
-
-#### R stats and plots
-
-#### Code base and docs
-
-### Dependency Updates
-
-#### Python Dependency Changes
-
-#### R Dependency Changes
-
-#### Server dependency Changes
-
-
 ## MagellanMapper v1.5.0
 
 ### Highlights

--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -139,6 +139,7 @@
 - Blob column accessors are encapsulated in the `Blobs` class, which allows for flexibility in column inclusion and order (#133)
 - Settings profiles are being migrated from dictionaries to data classes to document and configure settings more easily (#138)
 - Jupyter Notebook as a tutorial for running various tasks in the CLI (#122)
+- Documentation is now [hosted on ReadTheDocs](https://magellanmapper.readthedocs.io/en/latest/index.html), using the Furo theme (#225)
 
 ### Dependency Updates
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,12 @@ _EXTRAS_PANDAS = [
 _EXTRAS_AWS = ["boto3", "awscli"]
 
 # optional dependencies to build API documentation
-_EXTRAS_DOCS = ["sphinx", "sphinx-autodoc-typehints", "myst-parser"]
+_EXTRAS_DOCS = [
+    "sphinx",
+    "sphinx-autodoc-typehints",
+    "myst-parser",
+    "furo",  # theme
+]
 
 # optional dependencies for Jupyter notebooks
 _EXTRAS_JUPYTER = ["jupyterlab", "bash_kernel"]


### PR DESCRIPTION
The [Furo](https://github.com/pradyunsg/furo) theme provides a minimalist and yet modern interface, including light/dark color support and the new table of contents entries for API docs. Switching to this themes will improve navigation and readability of our ReadTheDocs.