### PR TITLE
Clean up colormaps and text labels

### DIFF
--- a/magmap/atlas/ontology.py
+++ b/magmap/atlas/ontology.py
@@ -401,8 +401,9 @@ def _mirror_label_ids(
     
     Args:
         label_ids: Single ID or sequence of IDs.
-        combine: True to return a list of ``label_ids`` along with
-            their mirrored IDs; defaults to False to return on the mirrored IDs.
+        combine: True to return a list of ``label_ids`` along with their
+            mirrored IDs. Defaults to False, where only the mirrored IDs
+            are returned.
 
     Returns:
         A single mirrored ID if ``label_ids`` is one ID and ``combine`` is
@@ -410,12 +411,18 @@ def _mirror_label_ids(
 
     """
     if libmag.is_seq(label_ids):
+        # sequence of IDs
         mirrored = [-1 * n for n in label_ids]
         if combine:
-            mirrored = list(label_ids).extend(mirrored)
+            # combine mirrored with original IDs
+            labels = list(label_ids)
+            labels.extend(mirrored)
+            mirrored = labels
     else:
+        # single ID
         mirrored = -1 * label_ids
         if combine:
+            # combine IDs
             mirrored = [label_ids, mirrored]
     return mirrored
 

--- a/magmap/io/export_regions.py
+++ b/magmap/io/export_regions.py
@@ -189,10 +189,11 @@ def make_density_image(
 ) -> Tuple[np.ndarray, str]:
     """Make a density image based on associated blobs.
     
-    Uses the size and resolutions of the original image stores in the blobs
+    Uses the size and/or resolutions of the original image stored in the blobs
     if available to determine scaling between the blobs and the output image.
-    Otherwise, uses the shape of the registered labels image to set 
-    the voxel sizes for the blobs.
+    Otherwise, attempts to load the original image or at least its metadata.
+    The voxel sizes for the blobs is determined by giving an output image
+    or shape.
     
     If ``matches`` is given, a heat map will be generated for each set
     of channels given in the dictionary. Otherwise, if the loaded blobs
@@ -204,12 +205,13 @@ def make_density_image(
         scale: Scaling factor between the blobs' space and the output space;
             defaults to None to use the register. Scaling is found by
             :meth:`magmap.np_io.find_scaling`.
-        shape: Output shape, used for scaling; defaults to None.
-        suffix: Modifier to append to end of ``img_path`` basename for 
-            registered image files that were output to a modified name; 
+        shape: Output shape. Defaults to None, in which case the shape will
+            match ``labels_img_sitk``.
+        suffix: Modifier to append to end of ``img_path`` basename for
+            registered image files that were output to a modified name;
             defaults to None.
-        labels_img_sitk: Labels image; defaults to None to load from a
-            registered labels image.
+        labels_img_sitk: Labels image. Defaults to None, in which case a
+            registered labels image will be loaded.
         channel: Sequence of channels to include in density image. For
             multiple channels, blobs from all these channels are combined
             into one heatmap.  Defaults to None to use all channels.
@@ -239,10 +241,12 @@ def make_density_image(
     # load blobs
     blobs = detector.Blobs().load_blobs(np_io.img_to_blobs_path(img_path))
     
+    # prepare output image
     is_2d = False
     if (shape is not None and blobs.roi_size is not None
             and blobs.resolutions is not None):
-        # prepare output image and scaling factor from it to the blobs
+        # use target shape provided directly; extract image size stored in
+        # blobs archive, assuming ROI size is full the full image
         scaling = np.divide(shape, blobs.roi_size)
         labels_spacing = np.divide(blobs.resolutions[0], scaling)
         labels_img = np.zeros(shape, dtype=np.uint8)
@@ -257,22 +261,29 @@ def make_density_image(
         labels_img = sitk.GetArrayFromImage(labels_img_sitk)
         
         is_2d = labels_img.ndim == 2
+        labels_res = list(labels_img_sitk.GetSpacing()[::-1])
         if is_2d:
             # temporarily convert 2D images to 3D
             labels_img = labels_img[None]
+            labels_res.insert(0, 1)
         
-        # find the scaling between the blobs and the labels image
-        target_size = (
-            None if atlas_profile is None else atlas_profile["target_size"])
-        scaling = np_io.find_scaling(
-            img_path, labels_img.shape, scale, target_size)[0]
+        if blobs.resolutions is not None:
+            # find scaling based on blob to labels image resolution ratio
+            scaling = np.divide(blobs.resolutions[0], labels_res)
+        
+        else:
+            # find the scaling between the blobs and the labels image
+            # TODO: remove target_size since it can be set by shape?
+            target_size = (
+                None if atlas_profile is None else atlas_profile["target_size"])
+            scaling = np_io.find_scaling(
+                img_path, labels_img.shape, scale, target_size)[0]
         
         if shape is not None:
             # scale blob coordinates and heat map to an alternative final shape
             scaling = np.divide(shape, np.divide(labels_img.shape, scaling))
             labels_spacing = np.multiply(
-                labels_img_sitk.GetSpacing()[::-1], 
-                np.divide(labels_img.shape, shape))
+                labels_res, np.divide(labels_img.shape, shape))
             labels_img = np.zeros(shape, dtype=labels_img.dtype)
             labels_img_sitk.SetSpacing(labels_spacing[::-1])
     _logger.debug("Using image scaling: {}".format(scaling))

--- a/magmap/plot/colormaps.py
+++ b/magmap/plot/colormaps.py
@@ -79,20 +79,20 @@ class DiscreteColormap(colors.ListedColormap):
                 mapped to each unique label. Defults to None, in which case 
                 no colormap will be generated.
             alpha: Transparency leve; defaults to 150 for semi-transparent.
-            index_direct: True if the colormap will be indexed directly, which 
-                assumes that the labels will serve as indexes to the colormap 
-                and should span sequentially from 0, 1, 2, ...; defaults to 
-                True. If False, a colormap will be generated for the full 
-                range of integers between the lowest and highest label values, 
+            index_direct: True if the colormap will be indexed directly, which
+                assumes that the labels will serve as indexes to the colormap
+                and should span sequentially from 0, 1, 2, ...; defaults to
+                True. If False, a colormap will be generated for the full
+                range of integers between the lowest and highest label values,
                 inclusive, with a :obj:`colors.BoundaryNorm`, which may
                 incur performance cost.
             max_val: Maximum value for random numbers; defaults to 255.
-            background: Tuple of (backround_label, (R, G, B, A)), where 
-                background_label is the label value specifying the background, 
-                and RGBA value will replace the color corresponding to that 
+            background: Tuple of ``(background_label, (R, G, B, A))``, where
+                ``background_label`` is the label value specifying the
+                background, and ``RGBA`` will replace the color for that
                 label. Defaults to None.
-            dup_for_neg: True to duplicate positive labels as negative 
-                labels to recreate the same set of labels as for a 
+            dup_for_neg: True to duplicate positive labels as negative
+                labels to recreate the same set of labels as for a
                 mirrored labels map. Defaults to False.
             symmetric_colors: True to make symmetric colors, assuming
                 symmetric labels centered on 0; defaults to False.
@@ -108,7 +108,7 @@ class DiscreteColormap(colors.ListedColormap):
         if labels is None: return
         labels_unique = np.unique(labels)
         if dup_for_neg and np.sum(labels_unique < 0) == 0:
-            # for labels that are only >= 0, duplicate the pos portion 
+            # for labels that are only >= 0, duplicate the pos portion
             # as neg so that images with or without negs use the same colors
             labels_unique = np.append(
                 -1 * labels_unique[labels_unique > 0][::-1], labels_unique)
@@ -235,17 +235,17 @@ def discrete_colormap(
         max_val: Union[int, float] = 255, min_any: Union[int, float] = 0,
         symmetric_colors: bool = False, dup_offset: int = 0, jitter: int = 0,
         mode: "DiscreteModes" = DiscreteModes.RANDOMN) -> np.ndarray:
-    """Make a discrete colormap using :attr:``config.colors`` as the 
+    """Make a discrete colormap using :attr:``config.colors`` as the
     starting colors and filling in the rest with randomly generated RGB values.
     
     Args:
         num_colors: Number of discrete colors to generate.
         alpha: Transparency level, from 0-255; defaults to 255.
-        prioritize_default: If True, the default colors from 
-            :attr:``config.colors`` will replace the initial colormap elements; 
-            defaults to True. Alternatively, `cn` can be given to use 
+        prioritize_default: If True, the default colors from
+            :attr:``config.colors`` will replace the initial colormap elements;
+            defaults to True. Alternatively, `cn` can be given to use
             the "CN" color spec instead.
-        seed: Random number seed; defaults to None, in which case no seed 
+        seed: Random number seed; defaults to None, in which case no seed
             will be set.
         min_val: Minimum value for random numbers; defaults to 0.
         max_val: Maximum value for random numbers; defaults to 255.
@@ -268,10 +268,10 @@ def discrete_colormap(
             :obj:`DiscreteModes.RANDOMN` mode.
     
     Returns:
-        2D Numpy array in the format ``[[R, G, B, alpha], ...]`` on a 
-        scale of 0-255. This colormap will need to be converted into a 
-        Matplotlib colormap using ``LinearSegmentedColormap.from_list`` 
-        to generate a map that can be used directly in functions such 
+        2D Numpy array in the format ``[[R, G, B, alpha], ...]`` on a
+        scale of 0-255. This colormap will need to be converted into a
+        Matplotlib colormap using ``LinearSegmentedColormap.from_list``
+        to generate a map that can be used directly in functions such
         as ``imshow``.
     
     """
@@ -326,13 +326,6 @@ def discrete_colormap(
             cmap[below_offset, axes] = np.multiply(
                 cmap[below_offset, axes], max_val / min_any)
     
-    if symmetric_colors:
-        # invert latter half onto former half, assuming that corresponding
-        # labels are mirrored (eg -5, 3, 0, 3, 5), with background centered as 0
-        cmap_len = len(cmap)
-        mid = cmap_len // 2
-        cmap[:mid] = cmap[:cmap_len-mid-1:-1] + dup_offset
-    cmap[:, -1] = alpha  # set transparency
     if prioritize_default is not False:
         # prioritize default colors by replacing first colors with default ones
         colors_default = config.colors
@@ -342,6 +335,16 @@ def discrete_colormap(
                 [colors.to_rgb("C{}".format(i)) for i in range(10)], 255)
         end = min((num_colors, len(colors_default)))
         cmap[:end, :3] = colors_default[:end]
+    
+    if symmetric_colors:
+        # invert latter half onto former half, assuming that corresponding
+        # labels are mirrored (eg -5, 3, 0, 3, 5), with background centered as 0
+        cmap_len = len(cmap)
+        mid = cmap_len // 2
+        cmap[:mid] = cmap[:cmap_len-mid-1:-1] + dup_offset
+    
+    cmap[:, -1] = alpha  # set transparency
+    
     return cmap
 
 

--- a/magmap/plot/plot_2d.py
+++ b/magmap/plot/plot_2d.py
@@ -1042,7 +1042,7 @@ def plot_swarm(
     """
     
     if sns is None:
-        raise ImportError("Seaborn is required for swarm plots, please install")
+        raise ImportError(config.format_import_err("seaborn", task="swarm plots"))
     
     df_vspan = df
     if x_order is not None:

--- a/magmap/plot/plot_support.py
+++ b/magmap/plot/plot_support.py
@@ -597,7 +597,7 @@ class ImageOverlayer:
             labels_annots: Optional[Dict[int, "axes.Axes.Text"]] = None,
             over_label: bool = True,
             cmap: Optional["colormaps.DiscreteColormap"] = None,
-            bbox_kwargs: Dict[str, Any] = None):
+            kwargs: Dict[str, Any] = None):
         """Annotate labels with acronyms.
         
         Args:
@@ -613,8 +613,8 @@ class ImageOverlayer:
                 useful for label edges.
             cmap: Discrete colormap to color the label based on its ID.
                 Defaults to None, in which case the color will be black.
-            bbox_kwargs: Dictionary of additional arguments for the bounding
-                box of each label. Defaults to None.
+            kwargs: Dictionary of additional arguments for the text artist.
+                Defaults to None.
 
         """
         if self.labels_annots:
@@ -657,16 +657,20 @@ class ImageOverlayer:
         # set args for artist bounding box
         bbox = dict(boxstyle="Round,pad=0.1", facecolor="xkcd:silver",
                     linewidth=0, alpha=0.3)
-        if bbox_kwargs is not None:
-            bbox.update(bbox_kwargs)
+        if kwargs is not None and "bbox" in kwargs:
+            # update from kwargs and remove from kwargs copy
+            bbox.update(kwargs["bbox"])
+            kwargs = {k: v for k, v in kwargs.items() if k != "bbox"}
         
+        args = dict(
+            fontsize="x-small", clip_on=True, horizontalalignment="center",
+            verticalalignment="center", bbox=bbox, transform=self._transform)
         for label_id, label in labels.items():
             # small annotations with subtle background in case label is dark
             color = cmap(cmap.convert_img_labels(label_id)) if cmap else "k"
-            text = self.ax.text(
-                *label, color=color, fontsize="x-small", clip_on=True,
-                horizontalalignment="center", verticalalignment="center",
-                bbox=bbox, transform=self._transform)
+            args["color"] = color
+            args.update(kwargs)
+            text = self.ax.text(*label, **args)
             self.labels_annots[label_id] = text
     
     def remove_labels(self):

--- a/magmap/settings/config.py
+++ b/magmap/settings/config.py
@@ -884,3 +884,28 @@ colors = np.array(
      [240, 228, 66],  # yellow
      [0, 0, 0]]  # black
 )
+
+
+def format_import_err(
+        dist_name: str, name: Optional[str] = None, task: Optional[str] = None
+) -> str:
+    """Format import error message.
+    
+    Args:
+        dist_name: Distribution name of package to install.
+        name: More descriptive name; if None (default), ``dist_name`` is
+            used with capitalization.
+        task: Description of task where this package is required; defaults
+            to None.
+
+    Returns:
+        Message to display for error.
+
+    """
+    
+    if name is None:
+        name = dist_name.capitalize()
+    task = "" if task is None else f"for {task}"
+    msg = f"{name} is required {task} but not installed. Please install, " \
+          f"eg with 'pip install {dist_name}'."
+    return msg

--- a/magmap/stats/clustering.py
+++ b/magmap/stats/clustering.py
@@ -23,10 +23,6 @@ from magmap.settings import profiles
 from magmap.io import sitk_io
 from magmap.io import df_io
 
-_SKLEARN_ERR = (
-    "Scikit-learn is not installed. Please install, eg with "
-    "'pip install scikit-learn'")
-
 
 def knn_dist(blobs, n, max_dist=None, max_pts=None, show=True):
     """Measure the k-nearest-neighbors distance.
@@ -65,7 +61,8 @@ def knn_dist(blobs, n, max_dist=None, max_pts=None, show=True):
         return df
     
     if not neighbors:
-        raise ImportError(_SKLEARN_ERR)
+        raise ImportError(
+            config.format_import_err("scikit-learn", task="kNN distances"))
 
     #blobs = blobs[::int(len(blobs) / 1000)]  # TESTING: small num of blobs
     knn = neighbors.NearestNeighbors(n, n_jobs=-1).fit(blobs)
@@ -268,7 +265,8 @@ def cluster_blobs(img_path, suffix=None):
 
     """
     if not cluster:
-        raise ImportError(_SKLEARN_ERR)
+        raise ImportError(
+            config.format_import_err("scikit-learn", task="blob clustering"))
     
     mod_path = img_path
     if suffix is not None:


### PR DESCRIPTION
Round-up PR for several miscellaneous changes:
- Consolidated colormap parameters
- Fixed symmetric colormaps with prioritized colors to make these colors symmetric as well
- Text labels for annotating regions can be colored
- Fixed mirroring label IDs when combining them with their original labels
- Density maps can use original image resolutions stored in blob archives instead of reloading the original image
- Starting to use a more consistent error message when dependencies are missing