### PR TITLE
Ignore custom packages in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,7 @@ updates:
     directory: "/envs/" # Location of package manifests
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: "python-bioformats"
+      - dependency-name: "javabridge"
+      - dependency-name: "SimpleITK"


### PR DESCRIPTION
Prevent alerts for custom built packages, which follow a separate release schedule.