### PR TITLE
Fix model fitting

### DIFF
--- a/clrstats/R/clrstats.R
+++ b/clrstats/R/clrstats.R
@@ -155,19 +155,23 @@ fitModel <- function(model, vals, genos, sides, ids=NULL) {
   # return if no stats
   if (is.null(result)) return(NULL)
   
-  # basic stats data frame in format for filterStats
-  coef.tab <- setupBasicStats()
-  effect <- result[[col.effect]]
-  coef.tab$Value <- c(effect)
+  # basic stats data frame in format for filterStats; default to save only
+  # first row since rest of stats expect a single row
+  # TODO: allow saving all rows
+  rows <- 1
+  coef.tab <- setupBasicStats(length(rows))
+  effect <- result[rows, col.effect]
+  coef.tab$Value <- effect
   stderr <- "Std. Error"
+  
   if (is.element(stderr, names(result))) {
     # use SEM for the "CI" values
-    ci <- result[[stderr]]
-    coef.tab$CI.low <- c(effect - ci)
-    coef.tab$CI.hi <- c(ci - effect)
+    ci <- result[rows, stderr]
+    coef.tab$CI.low <- effect - ci
+    coef.tab$CI.hi <- ci - effect
   }
-  coef.tab$P <- c(result[4])
-  coef.tab$N <- c(length(vals))
+  coef.tab$P <- result[rows, 4]
+  coef.tab$N <- length(vals)
   print(coef.tab)
   return(coef.tab)
 }
@@ -323,15 +327,23 @@ meansModel <- function(vals, conditions, model, paired=FALSE, reverse=FALSE) {
 }
 
 #' Setup a data frame for basic stats.
+#' 
+#' @param nrows Number of rows.
+#' @param cols Sequence of columns. Defaults to NULL, in which case a
+#'   set of columns for basic stats will be given.
 #'
 #' @return Data frame with columns for basic statistics such as mean and 
 #'   confidence intervals and a single empty row.
-setupBasicStats <- function() {
+setupBasicStats <- function(nrows=1, cols=NULL) {
   
-  cols <- c(
-    "N", "Value", "CI.low", "CI.hi", "Value.raw", "CI.low.raw", "CI.hi.raw",
-    "P")
-  coef.tab <- data.frame(matrix(nrow=1, ncol=length(cols)))
+  if (is.null(cols)) {
+    # default to basic stats columns
+    cols <- c(
+      "N", "Value", "CI.low", "CI.hi", "Value.raw", "CI.low.raw", "CI.hi.raw",
+      "P")
+  }
+  
+  coef.tab <- data.frame(matrix(nrow=nrows, ncol=length(cols)))
   names(coef.tab) <- cols
   rownames(coef.tab) <- "vals"
   return(coef.tab)

--- a/clrstats/R/clrstats.R
+++ b/clrstats/R/clrstats.R
@@ -678,14 +678,16 @@ filterStats <- function(stats, corr=NULL) {
   }
   
   for (interact in interactions) {
-    # only correct/adjust means stats with >= 2 vals
+    # only correct/adjust means stats with >= 2 vals and filter NAs from
+    # basic stats and p-vals
     filt.n <- filtered[[paste0(interact, ".n")]]
-    mask.corr <- filt.n > 1 & !is.na(filt.n) # eg NA from basic stats
+    col <- paste0(interact, ".p")
+    mask.corr <- filt.n > 1 & !is.na(filt.n) & !is.na(filtered[[col]])
     num.regions <- nrow(filtered[mask.corr, ])
+    
     col.for.log <- paste0(interact, ".pcorr")
     if (!is.null(corr) && num.regions > 0) {
       # apply correction based on number of comparisons
-      col <- paste0(interact, ".p")
       cat("correcting", col, "by", corr, "for", num.regions, "regions\n")
       filtered[mask.corr, col.for.log] <- p.adjust(
         filtered[mask.corr, col], method=corr, n=num.regions)

--- a/clrstats/R/clrstats.R
+++ b/clrstats/R/clrstats.R
@@ -168,7 +168,7 @@ fitModel <- function(model, vals, genos, sides, ids=NULL) {
     # use SEM for the "CI" values
     ci <- result[rows, stderr]
     coef.tab$CI.low <- effect - ci
-    coef.tab$CI.hi <- ci - effect
+    coef.tab$CI.hi <- effect + ci
   }
   coef.tab$P <- result[rows, 4]
   coef.tab$N <- length(vals)

--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -135,6 +135,7 @@
 - The Shapiro-Wilks test has been implemented in `meansModel` for consistent table output (#164)
 - Fixed t-test, which also provides Cohen's d as a standardized effect size through the `effectsize` package (#135)
 - Fixed jitter plot box plots to avoid covering labels (#147)
+- Fixed model fitting (#240)
 
 #### Code base and docs
 


### PR DESCRIPTION
The Clrstats model fitting function has given an error when extracting values into the basic results table, fixed here. Raw stats are also now printed to console for inspection. The grouping column can now also be customized through the new `SplitCol` environment setting, which can be set in a profile.