### PR TITLE
More direct TIF loading support

### DIFF
--- a/bin/sample_cmds_bash.ipynb
+++ b/bin/sample_cmds_bash.ipynb
@@ -104,7 +104,7 @@
    "source": [
     "## Image import\n",
     "\n",
-    "MagellanMapper typically requires images to be imported into a NumPy format for faster access and lower memory usage. We use BioFormats to import from many formats, including proprietary microscopy formats."
+    "MagellanMapper typically requires images to be imported into a NumPy format (NPY) for faster access and lower memory usage. We use BioFormats to import from many formats, including proprietary microscopy formats."
    ]
   },
   {
@@ -154,6 +154,7 @@
    "metadata": {},
    "source": [
     "### Import a series of TIF files\n",
+    "<a id=\"import-tif\"></a>\n",
     "\n",
     "Both single- and multi-plane TIF files can be imported into a volumetric NumPy file.\n",
     "\n",
@@ -207,6 +208,36 @@
    "outputs": [],
    "source": [
     "./run.py --img \"$img\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fdb7456f-a8ea-45b3-a812-b107d1a273d9",
+   "metadata": {},
+   "source": [
+    "### View a TIF file without import\n",
+    "\n",
+    "*EXPERIMENTAL*: v1.6 introduced preliminary support for loading TIF files without importing them to NPY format.\n",
+    "\n",
+    "Bypass import by including the `.tif` extension when loading the image:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8fa9bcae-396c-4ebd-a3fe-db22ef976a66",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mm \"${img}.tif\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "06e10318-4228-4c0f-84f8-4e9485de35a2",
+   "metadata": {},
+   "source": [
+    "To import the TIF file instead, include the `--proc import_only` argument as [above](#import-tif)."
    ]
   },
   {

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -211,6 +211,13 @@ napoleon_use_param = True
 napoleon_use_rtype = True
 
 
+# -- Options for MyST parsing -------------------------
+
+# auto-generate header anchors, similarly to GitHub anchors for compatibility
+# with viewing Markdown pages in GitHub or RTD
+myst_heading_anchors = 4
+
+
 # automate building API .rst files, necessary for ReadTheDocs, as inspired by:
 # https://github.com/readthedocs/readthedocs.org/issues/1139#issuecomment-398083449
 def run_apidoc(_):

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,6 +11,7 @@ Welcome to MagellanMapper's documentation!
    :caption: Contents:
 
    install.md
+   load.md
    viewers.md
    cli.md
    settings.md

--- a/docs/load.md
+++ b/docs/load.md
@@ -1,0 +1,28 @@
+# Load MagellanMapper and Image Files
+
+## Start MagellanMapper
+
+Once you've [installed](install.md) MagellanMapper, activate its environment and launch the app:
+
+```shell
+conda activate mag
+mm
+```
+
+Replace the `conda` command if you are using another type of virtual environment.
+
+The graphical user interface (GUI) should open, allowing you to load images using the browsing controls.
+
+## Import images
+
+Importing image files allows them to be read on-the-fly for lower memory requirements. The "Import" panel in the GUI allows you to select files to import, specify metadata, and load them into a NumPy (NPY) format.
+
+TODO: add details
+
+## Load TIF files directly
+
+v1.6 added *EXPERIMENTAL* support for loading TIF images similarly to NPY images but without requiring prior import. Loading a `.tif` file in the "ROI > Image path" controls will attempt to load the image directly.
+
+## Using the CLI
+
+See our [Jupyter Notebook](https://github.com/sanderslab/magellanmapper/blob/master/bin/sample_cmds_bash.ipynb) for examples of loading and viewing various types of images in MagellanMapper using the command-line interface (CLI).

--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -98,7 +98,7 @@
 #### I/O
 
 - Images can be viewed as RGB(A) using the `RGB` button or the `--rgb` CLI argument (#142)
-- Some TIF files can be loaded directly, without importing the file first (#90, #213)
+- EXPERIMENTAL: Some TIF files can be loaded directly, without importing the file first (#90, #213, #242)
 - The `--proc export_planes` task can export a subset of image planes specified by `--slice`, or an ROI specified by `--offset` and `--size`
 - Image metadata is stored in the `Image5d` image object (#115)
 - Better 2D image support

--- a/magmap/io/np_io.py
+++ b/magmap/io/np_io.py
@@ -596,6 +596,7 @@ def read_tif(
     tif = tifffile.TiffFile(path)
     md = dict.fromkeys(config.MetaKeys)
     axes = tif.series[0].axes.lower()
+    _logger.debug("TIF axes: %s", axes)
     if tif.ome_metadata:
         # read OME-XML metadata
         names, sizes, md = importer.parse_ome_raw(tif.ome_metadata)
@@ -626,6 +627,9 @@ def read_tif(
     if "z" not in axes:
         # add a z-axis for 2D images
         tif_memmap = np.expand_dims(tif_memmap, axis=0)
+    if axes[0] == "c":
+        # move channel dimension to end
+        tif_memmap = np.swapaxes(tif_memmap, 2, -1)
     
     _logger.debug("Parsed TIF metadata: %s", md)
     _logger.debug("Loaded TIF into shape: %s", tif_memmap.shape)

--- a/magmap/io/np_io.py
+++ b/magmap/io/np_io.py
@@ -4,6 +4,7 @@
 """
 import os
 import pathlib
+import pprint
 from typing import Any, Dict, Optional, Sequence, Tuple, TYPE_CHECKING, Union
 
 import numpy as np
@@ -606,7 +607,10 @@ def read_tif(
         # parse resolutions
         res = np.ones((1, 3))
         if tif.imagej_metadata:
-            _logger.debug("ImageJ TIF metadata: %s", tif.imagej_metadata)
+            if config.verbose:
+                _logger.debug(
+                    "ImageJ TIF metadata:\n%s",
+                    pprint.pformat(tif.imagej_metadata))
             if "spacing" in tif.imagej_metadata:
                 # ImageJ format holds z-resolution as spacing
                 res[0, 0] = tif.imagej_metadata["spacing"]
@@ -631,8 +635,9 @@ def read_tif(
         # move channel dimension to end
         tif_memmap = np.swapaxes(tif_memmap, 2, -1)
     
-    _logger.debug("Parsed TIF metadata: %s", md)
-    _logger.debug("Loaded TIF into shape: %s", tif_memmap.shape)
+    if config.verbose:
+        _logger.debug("Parsed TIF metadata:\n%s", pprint.pformat(md))
+        _logger.debug("Loaded TIF into shape: %s", tif_memmap.shape)
     
     # add image to Image5d instance
     img5d.img = tif_memmap

--- a/magmap/settings/atlas_prof.py
+++ b/magmap/settings/atlas_prof.py
@@ -260,10 +260,13 @@ class AtlasProfile(profiles.SettingsDict):
 
         # ATLAS EDITOR
 
-        # downsample images shown in the Atlas Editor to improve performance
-        # when loaded through these I/O packages; default to Numpy because
-        # its memory mapping reduces memory but is slower to load x-planes
-        self["editor_downsample_io"] = [config.LoadIO.NP]
+        # downsample images loaded by these I/O packages in the Atlas Editor
+        # to improve performance; defaults to images loaded by memmapping
+        self["editor_downsample_io"] = [
+            config.LoadIO.NP,
+            config.LoadIO.TIFFFILE,
+        ]
+        
         # downsample image planes with an edge size exceeding these values,
         # given as edge sizes of x,y,z-planes; decrease sizes to improve
         # performance, especially in x


### PR DESCRIPTION
Direct TIF support (ie without importing the file) is still in experimental stage, but here goes for a few more basic features:
- TIFs with the channel as the first axis are now loaded properly
- The Atlas Editor will downsample TIFs loaded this way since they are memory mapped and would reduce disk loading time when only a subset of data is requested
- TIF metadata may included `Rotate=<n>` values, which are now implemented through 90º rotation