### PR TITLE
Round-up for general CV updates

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,6 +64,8 @@ jobs:
       - name: Test with pytest
         run: |
           python -u -m magmap.tests.test_chunking
+          python -u -m magmap.tests.test_classifier
+          python -u -m magmap.tests.test_cv_nd
           python -u -m magmap.tests.test_detector
           python -u -m magmap.tests.test_libmag
           # TODO: add UI testing

--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -63,6 +63,7 @@
 
 - Image registration now supports multiple labels images given as `--reg_suffixes annotation=<suffix1>,<suffix2>,...`, which will apply the same transformation to each of these images (#147)
 - Landmark distance measurements save the raw distances and no longer require spacing (#147)
+- Masks with angle planes can be constructed (#252)
 
 #### Cell detection
 

--- a/magmap/cv/classifier.py
+++ b/magmap/cv/classifier.py
@@ -80,7 +80,7 @@ def classify_patches(model, x: np.ndarray, thresh: float = 0.5
 def setup_classification_roi(
         image5d: np.ndarray, subimg_offset: Sequence[int],
         subimg_size: Sequence[int],
-        blobs: "detector.Blobs", patch_size: int, blobs_relative: bool
+        blobs: "detector.Blobs", patch_size: int, blobs_relative: bool = False
 ) -> Tuple[np.ndarray, np.ndarray, Sequence[int]]:
     """Set up ROI for blob classification.
     
@@ -91,10 +91,13 @@ def setup_classification_roi(
     patches.
     
     Args:
+        image5d: 4/5D array as ``t, z, y, x[, c]``.
         subimg_offset: Subimage offset in ``z, y, x``.
         subimg_size: Subimage size in ``z, y, x``.
         blobs: Blobs instance.
         patch_size: Patch size as an int for both width and height.
+        blobs_relative: True if ``blobs`` coordinates are relative; defaults
+            to False.
     
     Returns:
         Tuple of:

--- a/magmap/cv/cv_nd.py
+++ b/magmap/cv/cv_nd.py
@@ -1159,6 +1159,41 @@ def rescale_resize(
     return rescaled
 
 
+def angle_indices(
+        shape: Sequence[int], offset: Sequence[int], size: Sequence[int],
+        nsteps: Optional[int] = None):
+    """Generate indices for an angled plane or other shape.
+    
+    Can be used to construct a polygon mask with angled faces. Indices
+    co-vary so that as ``offset_z`` -> ``offset_z + size_z``,
+    ``offset_y`` -> ``offset_y + size_y``, etc.
+    
+    Args:
+        shape: Shape of object containing the desired plane.
+        offset: Offset within the object in the orderr ``z, y, x``.
+        size: Size within the object corresponding to elements in ``offset``.
+        nsteps: Number of steps to interpolate. Defaults to None, where
+            the max of ``shape`` x 10 is used to reduce chance of gaps.
+
+    Returns:
+        Indices in the same order as for ``shape``.
+    
+    Examples:
+        See :meth:`magmap.tests.test_cv_nd.test_angle_indices`.
+
+    """
+    if nsteps is None:
+        # default to more steps than max dimension to minimize chance of gaps
+        nsteps = max(shape) * 10
+    
+    inds = [np.s_[:]] * len(shape)
+    for i, (off, siz) in enumerate(zip(offset, size)):
+        # make indices for given dimension with consistent step count
+        inds[i] = np.linspace(off, siz, nsteps, False).astype(int)
+    
+    return inds
+
+
 def get_selem(ndim):
     """Get structuring element appropriate for the number of dimensions.
     

--- a/magmap/cv/cv_nd.py
+++ b/magmap/cv/cv_nd.py
@@ -79,12 +79,12 @@ def carve(roi, thresh=None, holes_area=None, return_unfilled=False):
 
 
 def rotate_nd(
-        img_np: np.ndarray, angle, axis: int = 0, order: int = 1,
+        img_np: np.ndarray, angle: float, axis: int = 0, order: int = 1,
         resize: bool = False) -> np.ndarray:
     """Rotate an image of arbitrary dimensions along a given axis.
     
-    This function is essentially a wrapper of 
-    :func:`skimage.transform.rotate`, applied to each 2D plane along a 
+    This function is essentially a wrapper of
+    :func:`skimage.transform.rotate`, applied to each 2D plane along a
     given axis for volumetric rotation.
     
     Args:
@@ -98,6 +98,7 @@ def rotate_nd(
     
     Returns:
         The rotated image.
+    
     """
     is_2d = img_np.ndim == 2
     if is_2d:

--- a/magmap/tests/test_cv_nd.py
+++ b/magmap/tests/test_cv_nd.py
@@ -24,6 +24,35 @@ class TestCvNd(unittest.TestCase):
         img_rescaled = cv_nd.rescale_resize(img[0], target_size, multichannel=True)
         target_size.append(3)
         testing.assert_array_equal(img_rescaled.shape, target_size)
+    
+    def test_angle_indices(self):
+        # set up mask
+        mask = np.zeros((3, 4, 5), dtype=np.uint8)
+        shape = mask.shape
+
+        # fill angled planes in z-axis direction, starting with an xy-like
+        # plane positioned at z = 0, y = 0 and angled to z = 3, y = 2
+        for i in range(0, shape[0]):
+            mask_inds = cv_nd.angle_indices(shape, (i, 0), (shape[0], 3))
+            mask[mask_inds[0], mask_inds[1], mask_inds[2]] = 1
+        
+        # test equality to reference
+        print(mask)
+        ref = np.array(
+            [[[1, 1, 1, 1, 1],
+              [0, 0, 0, 0, 0],
+              [0, 0, 0, 0, 0],
+              [0, 0, 0, 0, 0]],
+             [[1, 1, 1, 1, 1],
+              [1, 1, 1, 1, 1],
+              [0, 0, 0, 0, 0],
+              [0, 0, 0, 0, 0]],
+             [[1, 1, 1, 1, 1],
+              [1, 1, 1, 1, 1],
+              [1, 1, 1, 1, 1],
+              [0, 0, 0, 0, 0]]]
+        )
+        testing.assert_array_equal(mask, ref)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Here's a round-up of several changes to the general computer vision library:
- Added a function to generate angled planes, which can be used to construct registration masks that do not fit a simple cuboid shape
- The CLAHE wrapper uses the nD implementation in Scikit-image now that it has been added
- The CI will run unit tests for the `detector` and `classifier` modules
- Small doc fixes