### PR TITLE
Fix missing ROI border

### DIFF
--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -113,7 +113,7 @@
 
 #### Python stats and plots
 
-- Generate swarm plots in Seaborn (#137)
+- Generate swarm and category plots in Seaborn (#137, #253)
 - Color bars can be configured in ROI profiles using [settings in Matplotlib](https://matplotlib.org/3.5.0/api/_as_gen/matplotlib.pyplot.colorbar.html), update dynamically, and no longer repeat in animations (#128)
 - New plot label sub-arguments (#135):
   - `--plot labels err_col_abs=<col>`: plot error bars with a column of absolute rather than relative values, now that Clrstats gives absolute values for effect sizes

--- a/magmap/plot/plot_support.py
+++ b/magmap/plot/plot_support.py
@@ -972,12 +972,18 @@ def scroll_plane(event, z_overview, max_size, jump=None, max_scroll=None):
     return z_overview_new
 
 
-def hide_axes(ax):
+def hide_axes(ax: "axes.Axes", frame_off: bool = False):
     """Hides x- and y-axes and the axes frame.
+    
+    Args:
+        ax: Plot axes.
+        frame_off: True to turn off the frame; defaults to False.
+    
     """
     ax.get_xaxis().set_visible(False)
     ax.get_yaxis().set_visible(False)
-    ax.set_frame_on(False)
+    if frame_off:
+        ax.set_frame_on(False)
 
 
 def scale_axes(ax, scale_x=None, scale_y=None):

--- a/magmap/settings/config.py
+++ b/magmap/settings/config.py
@@ -318,6 +318,8 @@ class Plot2DTypes(Enum):
     SCATTER_PLOT = auto()
     LINE_PLOT = auto()
     SWARM_PLOT = auto()
+    #: Generate a category plot through Seaborn.
+    CAT_PLOT = auto()
     
 
 plot_2d_type = None


### PR DESCRIPTION
The ROI Editor has shown a border around the zoomed plot that corresponds to the plane shown in the overview plots. This border was inadvertently lost when turning off the axes frame, fixed here.

Additional plot-related (but otherwise miscellaneous) changes:
- Added a 2D plot task to generate category plots in Seaborn
- Plot Editor label names can be customized
- Labels level image generation defaults to using the globally set image if no image path is given