### PR TITLE
Fix stale editor listeners

### DIFF
--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -45,6 +45,7 @@
 - Fixed saving blobs in an ROI using the first displayed ROI or after moving the sliders without redrawing (#139)
 - Fixed browsing for files or directories in some environments (#201)
 - Fixed clearing the import path (#201)
+- Fixed saving additional, old figures when using the save shortcut (#256)
 
 #### CLI
 

--- a/magmap/gui/atlas_editor.py
+++ b/magmap/gui/atlas_editor.py
@@ -213,10 +213,14 @@ class AtlasEditor(plot_support.ImageSyncMixin):
         self.set_show_crosslines(True)
         
         # attach listeners
-        fig.canvas.mpl_connect("scroll_event", self.scroll_overview)
-        fig.canvas.mpl_connect("key_press_event", self.on_key_press)
-        fig.canvas.mpl_connect("close_event", self._close)
-        fig.canvas.mpl_connect("axes_leave_event", self.axes_exit)
+        self._listeners.append(
+            fig.canvas.mpl_connect("scroll_event", self.scroll_overview))
+        self._listeners.append(
+            fig.canvas.mpl_connect("key_press_event", self.on_key_press))
+        self._listeners.append(
+            fig.canvas.mpl_connect("close_event", self._close))
+        self._listeners.append(
+            fig.canvas.mpl_connect("axes_leave_event", self.axes_exit))
         
         self.alpha_slider.on_changed(self.alpha_update)
         self.alpha_reset_btn.on_clicked(self.alpha_reset)

--- a/magmap/gui/roi_editor.py
+++ b/magmap/gui/roi_editor.py
@@ -739,6 +739,10 @@ class ROIEditor(plot_support.ImageSyncMixin):
             else:
                 # default to scrolling commands for up/down/right arrows
                 scroll_overview(event)
+        
+        def on_btn_release_scroll(event):
+            # scroll the overview plot to the selected zoomed plot
+            scroll_overview(event)
 
         def on_btn_release(event):
             # respond to mouse button presses for DraggableCircle management
@@ -832,8 +836,8 @@ class ROIEditor(plot_support.ImageSyncMixin):
         # key events but are with mouse events
         fig.canvas.mpl_connect("scroll_event", scroll_overview)
         fig.canvas.mpl_connect("key_press_event", key_press)
-        fig.canvas.mpl_connect("button_release_event", key_press)
         fig.canvas.mpl_connect("close_event", self.on_close)
+        fig.canvas.mpl_connect("button_release_event", on_btn_release_scroll)
         # fig.canvas.mpl_connect("draw_event", lambda x: print("redraw"))
         
         if self.fn_redraw:

--- a/magmap/gui/verifier_editor.py
+++ b/magmap/gui/verifier_editor.py
@@ -98,8 +98,10 @@ class VerifierEditor(plot_support.ImageSyncMixin):
         self.show_views()
         
         # attach listeners
-        self.fig.canvas.mpl_connect("button_press_event", self._on_mouse_press)
-        self.fig.canvas.mpl_connect("close_event", self.on_close)
+        self._listeners.append(self.fig.canvas.mpl_connect(
+            "button_press_event", self._on_mouse_press))
+        self._listeners.append(self.fig.canvas.mpl_connect(
+            "close_event", self.on_close))
         
         # attach handlers
         self._row_slider.on_changed(self._change_row)

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -2420,15 +2420,28 @@ class Visualization(HasTraits):
 
         # redraw the currently selected viewer tab
         if self.selected_viewer_tab is vis_handler.ViewerTabs.ROI_ED:
+            # disconnect existing ROI and Verifier Editors, which share the fig
             if self.roi_ed:
                 self.roi_ed.on_close()
+            if self.verifier_ed:
+                self.verifier_ed.on_close()
+            
+            # launch ROI Editor
             self._launch_roi_editor()
+        
         elif self.selected_viewer_tab is vis_handler.ViewerTabs.ATLAS_ED:
             if self.atlas_eds:
+                # disconnect and reset existing Atlas Editors
                 # TODO: re-support multiple Atlas Editor windows
+                for ed in self.atlas_eds:
+                    ed.on_close()
                 self.atlas_eds = []
+            
+            # launch Atlas Editor
             self.launch_atlas_editor()
+        
         elif self.selected_viewer_tab is vis_handler.ViewerTabs.MAYAVI:
+            # launch 3D Viewer
             self.show_3d()
             self._post_3d_display()
     
@@ -3140,6 +3153,10 @@ class Visualization(HasTraits):
     
     @observe("_btn_verifier")
     def _launch_verifier_editor(self, evt):
+        if self.verifier_ed:
+            # disconnect existing editor since launched outside of refresh btn
+            self.verifier_ed.on_close()
+        
         verifier_ed = verifier_editor.VerifierEditor(
             config.img5d, self.blobs, "Verifier", self._roi_ed_fig,
             # necessary for immediate table refresh rather than after scroll

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -1096,7 +1096,7 @@ class Visualization(HasTraits):
         
         # set up ROI and Atlas Editor figures without constrained layout
         # because of performance impact at least as of Matplotlib 3.2
-        self.roi_ed = None
+        self.roi_ed: Optional["roi_editor.ROIEditor"] = None
         self._roi_ed_fig = figure.Figure()
         self._atlas_ed_fig = figure.Figure()
         
@@ -2420,6 +2420,8 @@ class Visualization(HasTraits):
 
         # redraw the currently selected viewer tab
         if self.selected_viewer_tab is vis_handler.ViewerTabs.ROI_ED:
+            if self.roi_ed:
+                self.roi_ed.on_close()
             self._launch_roi_editor()
         elif self.selected_viewer_tab is vis_handler.ViewerTabs.ATLAS_ED:
             if self.atlas_eds:
@@ -2830,7 +2832,7 @@ class Visualization(HasTraits):
         if config.image5d is None:
             print("Main image has not been loaded, cannot show ROI Editor")
             return
-
+        
         if (not self._circles_opened_type 
                 or self._circles_opened_type ==
                 roi_editor.ROIEditor.CircleStyles.NO_CIRCLES):


### PR DESCRIPTION
The main viewers (ROI, Atlas, and Verifier Editors) have Matplotlib listeners attached to handle keyboard shortcuts and other actions. When the editors are refreshed, the listeners are not automatically detached, however, causing them to continue to respond to user events. Saving plots with `ctrl/cmd-s`, for example, saves a separate file for each time the figure has been fully refreshed.

This PR stores the listeners in the underlying mixin class and disposes of them when closing/refreshing the figure. Another unrelated fix is to ensure that 2D planes are within the range of the image to avoid an error when displaying 2D images with certain layouts.