### PR TITLE
Fix changes to large label IDs during registration

### DIFF
--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -65,6 +65,7 @@
 - Image registration now supports multiple labels images given as `--reg_suffixes annotation=<suffix1>,<suffix2>,...`, which will apply the same transformation to each of these images (#147)
 - Landmark distance measurements save the raw distances and no longer require spacing (#147)
 - Masks with angle planes can be constructed (#252)
+- Fixed changes to large label IDs during registration (#303)
 
 #### Cell detection
 

--- a/magmap/atlas/atlas_refiner.py
+++ b/magmap/atlas/atlas_refiner.py
@@ -1086,7 +1086,7 @@ def transpose_img(
         rotate_deg: Optional[Sequence[Dict[str, Any]]] = None,
         target_size: Optional[Union[float, Sequence[int]]] = None,
         target_size_res: Optional[Union[float, Sequence[int]]] = None,
-        flip: Optional[int] = None,
+        flip: Optional[Union[int, Sequence[int]]] = None,
         order: Optional[int] = None
 ) -> sitk.Image:
     """Transpose an image to a different plane or rotation.
@@ -1111,8 +1111,8 @@ def transpose_img(
         target_size_res: Same as ``target_size``, but applied to the image
             resolutions instead of changing the image itself. Defaults to
             None.
-        flip: Axis to flip after transposition;
-            defaults to None, in which case it will be based on ``plane``.
+        flip: Axis or sequence of axes to flip after transposition. Defaults
+            to None, where it will be based on ``plane``.
         order: Spline interpolation order; defaults to None.
     
     Returns:
@@ -1167,8 +1167,11 @@ def transpose_img(
         spacing, origin = arrs_1d
     
     if flip is not None:
-        # flip along given axis
-        transposed = np.flip(transposed, flip)
+        if not libmag.is_seq(flip):
+            flip = [flip]
+        for flip_ax in flip:
+            # flip along given axis
+            transposed = np.flip(transposed, flip_ax)
     
     if rotate:
         # rotate the final output image by 90 deg

--- a/magmap/atlas/atlas_refiner.py
+++ b/magmap/atlas/atlas_refiner.py
@@ -1158,6 +1158,7 @@ def transpose_img(
     spacing = img_sitk.GetSpacing()[::-1]
     origin = img_sitk.GetOrigin()[::-1]
     transposed = img
+    is_2d = transposed.ndim == 2
     
     if plane is not None and plane != config.PLANE[0]:
         # transpose planes and metadata
@@ -1177,10 +1178,11 @@ def transpose_img(
         # rotate the final output image by 90 deg
         # TODO: need to change origin? make axes accessible (eg (0, 2) for
         #   horizontal rotation)
-        transposed = np.rot90(transposed, rotate, (1, 2))
+        axes = (0, 1) if is_2d else (1, 2)
+        transposed = np.rot90(transposed, rotate, axes)
         if rotate % 2 != 0:
-            spacing = libmag.swap_elements(spacing, 1, 2)
-            origin = libmag.swap_elements(origin, 1, 2)
+            spacing = libmag.swap_elements(spacing, *axes)
+            origin = libmag.swap_elements(origin, *axes)
     
     if rotate_deg is not None:
         if any([r["angle"] % 90 != 0 for r in rotate_deg]):

--- a/magmap/io/sitk_io.py
+++ b/magmap/io/sitk_io.py
@@ -354,7 +354,7 @@ def load_registered_img(
     
     Args:
         img_path: Path as had been given to generate the registered
-            images, with the parent path of the registered images and base name 
+            images, with the parent path of the registered images and base name
             of the original image.
         reg_name: Atlas image suffix to open. Can be an absolute path,
             which will be used directly, ignoring ``img_path``.
@@ -365,9 +365,9 @@ def load_registered_img(
             was loaded; defaults to False.
     
     Returns:
-        Tuple of ``img``, the registered image as a Numpy array, or SimpleITK
-        Image if ``get_sitk`` is True, and ``path``, the loaded path if
-        ``return_path`` is True.
+        - ``reg_img``: the registered image as a Numpy array, or SimpleITK
+          Image if ``get_sitk`` is True
+        - If ``return_path`` is True: the loaded path
     
     Raises:
         ``FileNotFoundError`` if the path cannot be found.
@@ -379,18 +379,23 @@ def load_registered_img(
         # registered image extension matched to that of main image
         reg_img_path = reg_out_path(img_path, reg_name, True)
     reg_img, reg_img_path = read_sitk(reg_img_path)
+    
     if reg_img is None:
         # fallback to loading barren reg_name from img_path's dir
         reg_img_path = os.path.join(
-            os.path.dirname(img_path), 
+            os.path.dirname(img_path),
             libmag.match_ext(img_path, reg_name))
         reg_img, reg_img_path = read_sitk(reg_img_path)
         if reg_img is None:
             raise FileNotFoundError(
                 "could not find registered image from {} and {}"
                 .format(img_path, os.path.splitext(reg_name)[0]))
+    
     if not get_sitk:
+        # convert to ndarray
         reg_img = sitk.GetArrayFromImage(reg_img)
+    
+    # return image, including path if flagged
     return (reg_img, reg_img_path) if return_path else reg_img
 
 

--- a/magmap/plot/plot_support.py
+++ b/magmap/plot/plot_support.py
@@ -306,18 +306,18 @@ class ImageOverlayer:
         
         Args:
             img2d: 2D+/-channel array.
-            rotate: Counter-clockwise rotation in degrees.
+            rotate: Clockwise rotation in degrees.
 
         Returns:
             :attr:`self._transform` for chained calls.
 
         """
         if rotate is None:
-            # rotate in increments of 90 deg counter-clockwise
+            # rotate in increments of 90 deg clockwise
             rotate_n = config.transform[config.Transforms.ROTATE]
             rotate = rotate_n * 90 if rotate_n else 0
             
-            # rotate by specific deg counter-clockwise
+            # rotate by specific deg clockwise
             rotate_deg = config.transform[config.Transforms.ROTATE_DEG]
             if rotate_deg:
                 rotate += rotate_deg
@@ -601,7 +601,7 @@ class ImageOverlayer:
         return ax_imgs
     
     def annotate_labels(
-            self, labels_2d: np.ndarray, ref_lookup: Dict[int, Any],
+            self, labels_2d: np.ndarray, ref_lookup: Optional[Dict[int, Any]],
             level: Optional[int] = None,
             labels_annots: Optional[Dict[int, "axes.Axes.Text"]] = None,
             over_label: bool = True,
@@ -614,6 +614,8 @@ class ImageOverlayer:
         Args:
             labels_2d: 2D labels image.
             ref_lookup: Labels lookup dictionary of label IDs to label metadata.
+                Can be None if ``over_label`` is False and ``label_names`` is
+                given.
             level: Ontology level; defaults to None.
             labels_annots: Text artists from which new artists will be
                 re-created with the same name and positions. Takes precedence


### PR DESCRIPTION
Large label IDs may be lost when applying an Elastix Transformix filter. As a workaround suggested [here](https://github.com/SuperElastix/SimpleElastix/issues/205#issuecomment-718852030), this PR maps the label identities to their indices in their unique array, which minimizes the chance of having large values. Defaults to turning off this feature to avoid applying it to non-label images, such as when repeating a transformation to multiple intensity images.

I've bundled a few additional changes:
- Docs fixes/clarifications for loading registered images and Matplotlib-based image rotation and label annotation
- SimpleITK-based image transformer now supports multiple flips and fixes 90 degree 2D image rotation