### PR TITLE
Fix plotting in PyCharm in Clrstats

### DIFF
--- a/clrstats/NAMESPACE
+++ b/clrstats/NAMESPACE
@@ -1,0 +1,1 @@
+exportPattern(".")

--- a/clrstats/R/clrstats.R
+++ b/clrstats/R/clrstats.R
@@ -111,7 +111,14 @@ fitModel <- function(model, vals, genos, sides, ids=NULL) {
     } else if (model == kModel[2]) {
       # linear regression
       # TODO: see whether need to factorize genos
-      fit <- lm(vals ~ genos * sides)
+      if (length(unique(genos)) < 2) {
+        lm.formula <- as.formula(vals ~ sides)
+      } else if (length(unique(sides)) < 2) {
+        lm.formula <- as.formula(vals ~ genos)
+      } else {
+        lm.formula <- as.formula(vals ~ genos * sides)
+      }
+      fit <- lm(lm.formula)
       result.summary <- summary.lm(fit)
       result <- result.summary$coefficients
       
@@ -154,9 +161,15 @@ fitModel <- function(model, vals, genos, sides, ids=NULL) {
       print(result.summary)
     }
     
-    # return result from try block
+    # convert result to dataframe
     result <- as.data.frame(result)
+    if (ncol(result) == 1) {
+      # vector gives single column; transpose to multi-column
+      result <- t(result)
+    }
     print(result)
+    
+    # return result from try block
     result
     
   }, error=function(e) {

--- a/clrstats/R/jitter_plot.R
+++ b/clrstats/R/jitter_plot.R
@@ -482,14 +482,25 @@ openPlotDevice <- function(dev.fn, path.out, plot.size) {
   }, include.full.call.stack=FALSE, include.compact.call.stack=TRUE)
 }
 
-resetDevice <- function() {
-  # Reset all graphics devices, including any stale ones from prior exceptions.
-
-  while (!is.null(dev.list())) {
-    # reset graphics
-    # TODO: calling in close proximity to plot commands appears to prevent
-    # their screen appearance, whether before or after plotting
-    dev.off()
+#' Reset all graphics devices, including any stale ones from prior exceptions.
+#' 
+#' @param keep Device names starting with these strings will not be reset.
+#'   Defaults to NULL, in which case "TheRPlugin" and "quartz" are kept.
+resetDevice <- function(keep=NULL) {
+  
+  if (is.null(keep)) {
+    # default to keep PyCharm R plugin and macOS Quartz devices
+    keep <- c("TheRPlugin", "quartz")
+  }
+  
+  # TODO: calling in close proximity to plot commands appears to prevent
+  # their screen appearance, whether before or after plotting
+  for (dev.name in names(dev.list())) {
+    if (!any(startsWith(dev.name, keep))) {
+      # reset the graphics device not starting with the keep values
+      dev <- dev.list()[dev.name]
+      dev.off(dev)
+    }
   }
 }
 

--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -135,9 +135,11 @@
 - Stats errors are caught rather than stopping the pipeline (#132)
 - The labels reference path has been moved to an environment variable, which can be configured through `--labels <path>` (#147)
 - The Shapiro-Wilks test has been implemented in `meansModel` for consistent table output (#164)
+- A basic `NAMESPACE` file is provided to fix installation and exporting functions (#303)
 - Fixed t-test, which also provides Cohen's d as a standardized effect size through the `effectsize` package (#135)
 - Fixed jitter plot box plots to avoid covering labels (#147)
-- Fixed model fitting (#240)
+- Fixed model fitting (#240, #304)
+- Fixed plotting in PyCharm (#304)
 
 #### Code base and docs
 


### PR DESCRIPTION
The Clrstats plot saver closes all graphics devices after plotting to ensure that devices are flushed and no stale devices persist, but this cleanup ends up closing the PyCharm R plugin and Quartz graphics devices. Plotting again causes the R plugin to crash, presumably since its graphics device no longer exists. This PR specifically retains these graphics devices during device closure.

Also bundled here:
- Added a basic `NAMESPACE` file to the package so that its functions are exported
- Fixed linear regression in the model fitting function when only one condition exists by removing this variable in these cases