### PR TITLE
Customize atlas edge thickness

### DIFF
--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -59,6 +59,7 @@
 #### Atlas refinement
 
 - The atlas transformer (`atlas_refiner.transpose_img`) provides a more comprehensive set of typical transformations before atlas refinement or registration, such as rotation to any angle, flipping along any axis, and resizing (#195, #214)
+- Edge/perimeter thickness can be customized (#307)
 
 #### Atlas registration
 

--- a/magmap/atlas/edge_seg.py
+++ b/magmap/atlas/edge_seg.py
@@ -531,7 +531,7 @@ def edge_distances(labels, atlas_edge=None, path=None, spacing=None):
             path, config.RegNames.IMG_ATLAS_EDGE.value)
     
     # create distance map between edges of original and new segmentations
-    labels_edge = vols.make_labels_edge(labels)
+    labels_edge = vols.LabelToEdge.make_labels_edge(labels)
     dist_to_orig, _, _ = cv_nd.borders_distance(
         atlas_edge != 0, labels_edge != 0, spacing=spacing)
     

--- a/magmap/cv/cv_nd.py
+++ b/magmap/cv/cv_nd.py
@@ -278,27 +278,35 @@ def affine_nd(img_np, axis_along, axis_shift, shift, bounds, axis_attach=None,
     return affined
 
 
-def perimeter_nd(img_np, largest_only=False):
+def perimeter_nd(
+        img_np: np.ndarray, largest_only: bool = False,
+        footprint: Optional[Sequence[int]] = None) -> np.ndarray:
     """Get perimeter of image subtracting eroded image from given image.
     
     Args:
-        img_np (:obj:`np.ndarray`): Numpy array of arbitrary dimensions.
-        largest_only (bool): True to retain only the largest connected
+        img_np: Numpy array of arbitrary dimensions.
+        largest_only : True to retain only the largest connected
             component, typically the outer border; defaults to False.
+        footprint: Structure element for eroding the interior, which sets
+            the border thickness; defaults to None.
     
     Returns:
-        :obj:`np.ndarray`: The perimeter as a boolean array where True
+        The perimeter as a boolean array where True
         represents the border that would have been eroded.
+    
     """
-    interior = morphology.binary_erosion(img_np)
+    # get interior by eroding the image, where footprint determines the border
+    # thickness, and subtracting the interior from the full image
+    interior = morphology.binary_erosion(img_np, footprint)
     img_border = np.logical_xor(img_np, interior)
+    
     if largest_only:
         # retain only the largest perimeter based on pixel count
         labeled = measure.label(img_border)
         labels, counts = np.unique(labeled[labeled != 0], return_counts=True)
         labels = labels[np.argsort(counts)]
         img_border[labeled != labels[-1]] = False
-    #print("perimeter:\n{}".format(img_border))
+    
     return img_border
 
 

--- a/magmap/io/df_io.py
+++ b/magmap/io/df_io.py
@@ -625,24 +625,25 @@ def dict_to_data_frame(
 
 
 def data_frames_to_csv(
-        data_frames: List[pd.DataFrame], path: str = None,
-        sort_cols: Optional[Union[str, List[str]]] = None,
+        data_frames: Union[pd.DataFrame, Sequence[pd.DataFrame]],
+        path: str = None, sort_cols: Optional[Union[str, List[str]]] = None,
         show: Optional[Union[str, bool]] = None, index: bool = False):
     """Combine and export multiple data frames to CSV file.
     
     Args:
-        data_frames: List of data frames to concatenate, or a single 
+        data_frames: List of data frames to concatenate, or a single
             ``DataFrame``.
-        path: Output path; defaults to None, in which case the data frame 
+        path: Output path; defaults to None, in which case the data frame
             will not be saved.
         sort_cols: Column(s) by which to sort; defaults to None for no sorting.
-        show: True or " " to print the data frame with a space-separated 
-            table, or can provide an alternate separator. Defaults to None 
+        show: True or " " to print the data frame with a space-separated
+            table, or can provide an alternate separator. Defaults to None
             to not print the data frame.
         index: True to include the index; defaults to False.
     
     Returns:
         The combined data frame.
+    
     """
     ext = ".csv"
     if path:

--- a/magmap/io/export_regions.py
+++ b/magmap/io/export_regions.py
@@ -467,7 +467,8 @@ def make_labels_diff_img(img_path, df_path, meas, fn_avg, prefix=None,
 
 def make_labels_level_img(
         img_path: Optional[str], level: int, prefix: Optional[str] = None,
-        show: bool = False) -> Dict[str, sitk.Image]:
+        show: bool = False
+) -> Dict[str, sitk.Image]:
     """Replace labels in an image with their parents at the given level.
     
     Labels that do not fall within a parent at that level will remain in place.
@@ -501,7 +502,7 @@ def make_labels_level_img(
     labels_level_sitk = sitk_io.replace_sitk_with_numpy(labels_sitk, labels_np)
     
     # generate an edge image at this level
-    labels_edge = vols.make_labels_edge(labels_np)
+    labels_edge = vols.LabelToEdge.make_labels_edge(labels_np)
     labels_edge_sitk = sitk_io.replace_sitk_with_numpy(labels_sitk, labels_edge)
     
     # write and optionally display labels level image

--- a/magmap/io/libmag.py
+++ b/magmap/io/libmag.py
@@ -274,7 +274,7 @@ def get_filename_without_ext(path: str) -> str:
 def combine_paths(
         base_path: str, suffix: str, sep: str = "_", ext: str = None,
         check_dir: bool = False, keep_ext: bool = False):
-    """Merge two paths by appending ``suffix``, replacing the extention 
+    """Merge two paths by appending ``suffix``, replacing the extension
     in ``base_path``.
     
     Args:
@@ -284,7 +284,7 @@ def combine_paths(
             to ``suffix``.
         suffix: Replacement including new extension.
         sep: Separator between ``base_path`` and ``suffix``.
-        ext: Extension to add or substitute; defaults to None to use 
+        ext: Extension to add or substitute; defaults to None to use
             the extension in ``suffix``.
         check_dir: True to check if ``base_path`` is an existing directory,
             in which case it is simply joined to ``suffix``; defaults to False.
@@ -484,36 +484,26 @@ def series_as_str(series):
     return str(series).zfill(5)
 
 
-def splice_before(base, search, splice, post_splice="_"):
+def splice_before(
+        base: str, search: str, splice: str, post_splice: str = "") -> str:
     """Splice in a string before a given substring.
     
     Args:
         base: String in which to splice.
-        search: Splice before this substring.
-        splice: Splice in this string; falls back to a "." if not found.
-        post_splice: String to add after the spliced string if found. If 
-            only a "." is found, ``post_splice`` will be added before 
-            ``splice`` instead. Defaults to "_".
+        search: Splice before this substring. If not found, ``splice`` is
+            simply appended to ``base``.
+        splice: Splice in this string.
+        post_splice: String to add after the spliced string; defaults to "".
     
     Returns:
-        ``base`` with ``splice`` spliced in before ``search`` if found, 
-        separated by ``post_splice``, falling back to splicing before 
-        the first "." with ``post_splice`` placed in front of ``splice`` 
-        instead. If neither ``search`` nor ``.`` are found, simply 
-        returns ``base``.
+        Spliced string.
+    
     """
     i = base.rfind(search)
     if i == -1:
-        # fallback to splicing before extension
-        i = base.rfind(".")
-        if i == -1:
-            return base
-        else:
-            # turn post-splice into pre-splice delimiter, assuming that the 
-            # absence of search string means delimiter is not before the ext
-            splice = post_splice + splice
-            post_splice = ""
-    return base[0:i] + splice + post_splice + base[i:]
+        # default to append
+        i = len(base)
+    return base[:i] + splice + post_splice + base[i:]
 
 
 def str_to_disp(s):

--- a/magmap/plot/plot_2d.py
+++ b/magmap/plot/plot_2d.py
@@ -1254,34 +1254,43 @@ def plot_image(img, path=None, show=False):
     plt.close()  # prevent display during next show call
 
 
-def decorate_plot(ax, title=None, xlabel=None, ylabel=None, xunit=None,
-                  yunit=None, xlim=None, ylim=None, xscale=None, yscale=None,
-                  **kwargs):
+def decorate_plot(
+        ax: "axes.Axes", title: Optional[str] = None,
+        xlabel: Optional[str] = None, ylabel: Optional[str] = None,
+        xunit: Optional[str] = None, yunit: Optional[str] = None,
+        xlim: Optional[Sequence[float]] = None,
+        ylim: Optional[Sequence[float]] = None,
+        xscale: Optional[str] = None, yscale: Optional[str] = None,
+        xticks: Optional[Sequence[Any]] = None,
+        yticks: Optional[Sequence[Any]] = None,
+        **kwargs) -> "axes.Axes":
     """Decorate a plot with text and configure limits and scaling.
 
     Args:
-        ax (:class:`matplotlib.image.Axes`): Matplotlib plot.
-        title (str): Title of figure; defaults to None.
-        xlabel (str): X-axis label; defaults to None to use
+        ax: Matplotlib plot.
+        title: Title of figure; defaults to None.
+        xlabel: X-axis label; defaults to None to use
             :attr:`config.plot_labels`. Can explicitly set to None to prevent
             unit display.
-        ylabel (str): Y-axis label; defaults to None to use
+        ylabel: Y-axis label; defaults to None to use
             :attr:`config.plot_labels`. Can explicitly set to None to prevent
             unit display.
-        xunit (str): X-axis label unit; defaults to None.
-        yunit (str): Y-axis label unit; defaults to None.:
-        xlim (Sequence[float]): Sequence of min and max boundaries for the
+        xunit: X-axis label unit; defaults to None.
+        yunit: Y-axis label unit; defaults to None.:
+        xlim: Sequence of min and max boundaries for the
             x-axis; defaults to None.
-        ylim (Sequence[float]): Sequence of min and max boundaries for the
+        ylim: Sequence of min and max boundaries for the
             y-axis; defaults to None.
-        xscale (str): Scale mode for :meth:`plot_support.scale_axes` x-axis;
+        xscale: Scale mode for :meth:`plot_support.scale_axes` x-axis;
             defaults to None to ignore.
-        yscale (str): Scale mode for :meth:`plot_support.scale_axes` y-axis;
+        yscale: Scale mode for :meth:`plot_support.scale_axes` y-axis;
             defaults to None to ignore.
-        **kwargs (Any): Additional arguments, which will be ignored.
+        xticks: Arguments to :meth:`axes.Axes.set_xticks`; defaults to None.
+        yticks: Arguments to :meth:`axes.Axes.set_yticks`; defaults to None.
+        **kwargs: Additional arguments, which will be ignored.
 
     Returns:
-        :class:`matplotlib.image.Axes`: Matplotlib plot.
+        Matplotlib plot.
 
     """
     if kwargs:
@@ -1293,6 +1302,14 @@ def decorate_plot(ax, title=None, xlabel=None, ylabel=None, xunit=None,
     if xlim: ax.set_xlim(xlim)
     if ylim: ax.set_ylim(ylim)
     
+    if xticks:
+        # set x-tick positions and labels
+        ax.set_xticks(*xticks)
+
+    if yticks:
+        # set y-tick positions and labels
+        ax.set_yticks(*yticks)
+
     # axes scaling must follow after scientific notation since non-linear
     # formatters are not compatible with scinot
     plot_support.set_scinot(ax, lbls=(ylabel, xlabel), units=(yunit, xunit))

--- a/magmap/tests/test_libmag.py
+++ b/magmap/tests/test_libmag.py
@@ -76,11 +76,13 @@ class TestLibmag(unittest.TestCase):
         
     def test_splice_before(self):
         self.assertEqual(
-            libmag.splice_before("base", "file", "edit"), "base")
+            libmag.splice_before("base", "file", "edit"), "baseedit")
         self.assertEqual(libmag.splice_before(
-            "foo/bar/item.py", "item", "file"), "foo/bar/file_item.py")
+            "foo/bar/item.py", "item", "file"), "foo/bar/fileitem.py")
         self.assertEqual(libmag.splice_before(
-            "foo/bar/item.py", "edit", "file"), "foo/bar/item_file.py")
+            "foo/bar/item.py", "edit", "file"), "foo/bar/item.pyfile")
+        self.assertEqual(libmag.splice_before(
+            "foo/bar/item.py", ".", "file"), "foo/bar/itemfile.py")
         self.assertEqual(libmag.splice_before(
             "foo/bar/item.py", "item", "file", "/"), "foo/bar/file/item.py")
         


### PR DESCRIPTION
This PR is a round-up of several small changes:
- The atlas perimeter function accepts a thickness parameter
- The Matplotlib plot decorations wrapper takes x/y-tick modifications
- The `libmag.splice_before` function to splice a string before a substring is simpler, with fewer assumptions