### PR TITLE
Speed up region labels interaction and fix placement during zoom

### DIFF
--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -38,6 +38,8 @@
   - "Blend" option in the image adjustment panel to visualize alignment in overlaid images (#89)
   - Image adjustment channels are radio buttons for easier selection (#212)
   - Fixed synchronization between the ROI Editor and image adjustment controls after initialization (#142)
+- Faster atlas label display when hovering over regions (#317)
+- Atlas labels adapt better in zoomed images to stay within each plot (#317)
 - Fixed to reset the ROI selector when redrawing (#115)
 - Fixed to reorient the camera after clearing the 3D space (#121)
 - Fixed to turn off the minimum intensity slider's auto setting when manually changing the slider (#126) 

--- a/magmap/gui/atlas_editor.py
+++ b/magmap/gui/atlas_editor.py
@@ -13,7 +13,7 @@ from matplotlib import gridspec
 from matplotlib.widgets import Slider, Button, TextBox
 
 from magmap.cv import cv_nd
-from magmap.gui import plot_editor
+from magmap.gui import image_viewer, plot_editor
 from magmap.io import libmag, naming, sitk_io
 from magmap.plot import colormaps, plot_support
 from magmap.settings import config
@@ -106,6 +106,7 @@ class AtlasEditor(plot_support.ImageSyncMixin):
             left=0.06, right=0.94, bottom=0.02, top=0.98)
         gs_viewers = gridspec.GridSpecFromSubplotSpec(
             2, 2, subplot_spec=gs[0, 0])
+        blitter = image_viewer.Blitter(fig)
         
         # lay out plot editors based on number shown
         planes = [p for p in self.planes if p]
@@ -198,11 +199,12 @@ class AtlasEditor(plot_support.ImageSyncMixin):
                 overlayer, img3d_tr, labels_img_tr, config.cmap_labels,
                 plane, self.update_coords, self.refresh_images,
                 scaling, plane_slider, img3d_borders=borders_img_tr,
-                cmap_borders=cmap_borders, 
+                cmap_borders=cmap_borders,
                 fn_show_label_3d=self.fn_show_label_3d,
                 interp_planes=self.interp_planes,
                 fn_update_intensity=self.update_color_picker,
                 max_size=max_size, fn_status_bar=self.fn_status_bar)
+            plot_ed.blitter = blitter
             return plot_ed
         
         # set up plot editors for the given orthogonal planes

--- a/magmap/gui/atlas_editor.py
+++ b/magmap/gui/atlas_editor.py
@@ -368,15 +368,6 @@ class AtlasEditor(plot_support.ImageSyncMixin):
         """
         self.alpha_slider.reset()
     
-    def axes_exit(self, event):
-        """Trigger axes exit for all plot editors.
-        
-        Args:
-            event: Axes exit event.
-        """
-        for key in self.plot_eds:
-            self.plot_eds[key].on_axes_exit(event)
-    
     def interpolate(self, event):
         """Interpolate planes using :attr:`interp_planes`.
         

--- a/magmap/gui/image_viewer.py
+++ b/magmap/gui/image_viewer.py
@@ -17,7 +17,8 @@ class Blitter:
     Improves interactive graphics performance by reducing repetitive drawing.
     
     """
-    def __init__(self, fig, artists):
+    def __init__(self, fig, artists=None):
+        """Initialized the blit controller."""
         #: Matplotlib figure.
         self.fig: "figure.Figure" = fig
         #: Internal representation of tracked artists.
@@ -41,8 +42,8 @@ class Blitter:
         """Set tracked artists.
         
         Args:
-            vals: Artists to add. Only artists in :attr:`fig` will be added.
-                Can be None, which will reset artists to an empty list.
+            vals: Artists to add. Can be None, which will reset artists to an
+                empty list.
 
         """
         if vals is None:
@@ -51,16 +52,28 @@ class Blitter:
             return
         
         for val in vals:
-            if val.figure != self.fig:
-                # skip artists in other figs
-                _logger.warn(
-                    f"Artist from different figure added for blitting: {val}")
-                continue
-            
-            # flag as animated for update, which appears to prevent updating
-            # non-animated artists as well
-            val.set_animated(True)
-            self._artists.append(val)
+            # add artist
+            self.add_artist(val)
+    
+    def add_artist(self, arist: "artist.Artist"):
+        """Add tracked artist.
+        
+        Args:
+            arist: Artist to track. Only artists in :attr:`fig` will be added.
+
+        Returns:
+
+        """
+        if arist.figure != self.fig:
+            # skip artists in other figs
+            _logger.warn(
+                f"Artist from different figure added for blitting: {arist}")
+            return
+        
+        # flag as animated for update, which appears to prevent updating
+        # non-animated artists as well
+        arist.set_animated(True)
+        self._artists.append(arist)
     
     def on_draw(self, evt: Optional["backend_bases.DrawEvent"]):
         """Recapture backgrouna and draw the figure canvas."""

--- a/magmap/gui/image_viewer.py
+++ b/magmap/gui/image_viewer.py
@@ -1,0 +1,94 @@
+"""Image viewer support"""
+from typing import List, Optional, Sequence, TYPE_CHECKING
+
+from magmap.settings import config
+
+if TYPE_CHECKING:
+    from matplotlib import artist, backend_bases, figure
+
+_logger = config.logger.getChild(__name__)
+
+
+# inspired by Matplotlib example:
+# https://matplotlib.org/stable/tutorials/advanced/blitting.html#class-based-example
+class Blitter:
+    """Controller for blitting in Matplotlib graphics.
+    
+    Improves interactive graphics performance by reducing repetitive drawing.
+    
+    """
+    def __init__(self, fig, artists):
+        #: Matplotlib figure.
+        self.fig: "figure.Figure" = fig
+        #: Internal representation of tracked artists.
+        self._artists = []
+        self.artists = artists
+        #: Canvas background.
+        self._bkgd = None
+        
+        #: Event listener IDs.
+        self._listeners: List[int] = [
+            fig.canvas.mpl_connect("draw_event", self.on_draw)
+        ]
+    
+    @property
+    def artists(self) -> List["artist.Artist"]:
+        """Tracked artists for blitting."""
+        return self._artists
+    
+    @artists.setter
+    def artists(self, vals: Optional[Sequence["artist.Artist"]]):
+        """Set tracked artists.
+        
+        Args:
+            vals: Artists to add. Only artists in :attr:`fig` will be added.
+                Can be None, which will reset artists to an empty list.
+
+        """
+        if vals is None:
+            # reset artists to empty list
+            self._artists = []
+            return
+        
+        for val in vals:
+            if val.figure != self.fig:
+                # skip artists in other figs
+                _logger.warn(
+                    f"Artist from different figure added for blitting: {val}")
+                continue
+            
+            # flag as animated for update, which appears to prevent updating
+            # non-animated artists as well
+            val.set_animated(True)
+            self._artists.append(val)
+    
+    def on_draw(self, evt: Optional["backend_bases.DrawEvent"]):
+        """Recapture backgrouna and draw the figure canvas."""
+        canvas = self.fig.canvas
+        if evt and evt.canvas != canvas:
+            # skip drawing if event is from another canvas
+            return
+        
+        # recapture the canvas background and draw artists
+        self._bkgd = canvas.copy_from_bbox(self.fig.bbox)
+        self._draw_artists()
+    
+    def _draw_artists(self):
+        """Draw arists."""
+        for art in self.artists:
+            self.fig.draw_artist(art)
+    
+    def update(self):
+        """Update the canvas."""
+        canvas = self.fig.canvas
+        if self._bkgd is None:
+            # get background if not yet set
+            self.on_draw(None)
+        else:
+            # restore saved background, draw artists, and copy to GUI state
+            canvas.restore_region(self._bkgd)
+            self._draw_artists()
+            canvas.blit(self.fig.bbox)
+        
+        # flush GUI events and repaint if necessary
+        canvas.flush_events()

--- a/magmap/gui/plot_editor.py
+++ b/magmap/gui/plot_editor.py
@@ -13,7 +13,7 @@ from matplotlib import patches
 import numpy as np
 from skimage import draw
 
-from magmap.gui import pixel_display
+from magmap.gui import image_viewer, pixel_display
 from magmap.io import libmag
 from magmap.settings import config
 from magmap.atlas import ontology
@@ -188,6 +188,8 @@ class PlotEditor:
         self.enable_painting = True
         #: Ontology level at which to show region names.
         self.labels_level: Optional[int] = None
+        #: Blit manager.
+        self.blitter: Optional["image_viewer.Blitter"] = None
 
         self._plot_ax_imgs = None
         self._ax_img_labels = None  # displayed labels image
@@ -1167,8 +1169,12 @@ class PlotEditor:
                         config.labels_ref.ref_lookup):
                     self._update_region_label(x, y, coord)
 
-            # need explicit draw call for figs embedded in TraitsUI
-            self.axes.figure.canvas.draw_idle()
+            if self.blitter:
+                # blit updates if available for more efficient rendering
+                self.blitter.update()
+            else:
+                # need explicit draw call for figs embedded in TraitsUI
+                self.axes.figure.canvas.draw_idle()
 
         if self.fn_status_bar:
             self.fn_status_bar(self.axes.format_coord.get_msg(event))

--- a/magmap/gui/plot_editor.py
+++ b/magmap/gui/plot_editor.py
@@ -993,10 +993,17 @@ class PlotEditor:
                     self.fn_show_label_3d(self.img3d_labels[tuple(coord)])
     
     def on_axes_exit(self, event):
+        """Remove any mouse circle and region label."""
         if event.inaxes != self.axes: return
+        
         if self.circle:
+            # remove circle
             self.circle.remove()
             self.circle = None
+        
+        if self.region_label:
+            # make region label empty
+            self.region_label.set_text("")
     
     def _update_region_label(self, x: int, y: int, coord: Sequence[int]):
         """Update region label at the given location.

--- a/magmap/gui/plot_editor.py
+++ b/magmap/gui/plot_editor.py
@@ -1013,17 +1013,21 @@ class PlotEditor:
                 _logger.debug("Found label: %s", name)
             
                 # minimize chance of text overflowing out of axes by
-                # word-wrapping and switching sides at midlines; shift in axes
-                # coords for consistent distance across zooming
+                # word-wrapping and switching sides at plot midlines; shift in
+                # axes coords for consistent distance across zooming
                 name = "\n".join(textwrap.wrap(name, 30))
                 ax_coords = self.axes.transLimits.transform((x, y))
-                if x > self.img3d_labels.shape[2] / 2:
+                
+                # shift horizontally
+                if ax_coords[0] > 0.5:
                     alignment_x = "right"
                     ax_coords[0] -= self._region_label_offset
                 else:
                     alignment_x = "left"
                     ax_coords[0] += self._region_label_offset
-                if y > self.img3d_labels.shape[1] / 2:
+                
+                # shift vertically
+                if ax_coords[1] > 0.5:
                     alignment_y = "top"
                     ax_coords[1] -= self._region_label_offset
                 else:

--- a/magmap/gui/plot_editor.py
+++ b/magmap/gui/plot_editor.py
@@ -433,6 +433,12 @@ class PlotEditor:
         self.hline = None
         self.vline = None
         
+        if self.blitter:
+            # remove existing artists in this editor from blitter
+            artists = self.blitter.artists
+            if self.region_label in artists:
+                artists.remove(self.region_label)
+        
         # prep 2D image from main image, assumed to be an intensity image,
         # with settings for each channel within this main image
         imgs2d = [self._get_img2d(0, self.img3d, self.max_intens_proj)]
@@ -581,9 +587,12 @@ class PlotEditor:
         if not self.connected:
             # connect once get AxesImage
             self.connect()
+        
         # text label with color for visibility on axes plus fig background
         self.region_label = self.axes.text(
             0, 0, "", color="k", bbox=dict(facecolor="xkcd:silver", alpha=0.5))
+        if self.blitter:
+            self.blitter.add_artist(self.region_label)
         self.circle = None
         
         if self.overlayer.labels_annots:

--- a/magmap/gui/roi_editor.py
+++ b/magmap/gui/roi_editor.py
@@ -24,7 +24,7 @@ from matplotlib import pyplot as plt
 from matplotlib.collections import PatchCollection
 
 from magmap.cv import detector
-from magmap.gui import pixel_display, plot_editor
+from magmap.gui import image_viewer, pixel_display, plot_editor
 from magmap.io import importer, libmag, naming
 from magmap.plot import colormaps, plot_support
 from magmap.settings import config
@@ -363,6 +363,8 @@ class ROIEditor(plot_support.ImageSyncMixin):
         self._blobs_coloc_text = None
         self._z_overview = None
         self._channel = None  # list of channel lists
+        #: Image blitter.
+        self._blitter: Optional["image_viewer.Blitter"] = None
         
         # store DraggableCircles objects to prevent premature garbage collection
         self._draggable_circles = []
@@ -465,6 +467,7 @@ class ROIEditor(plot_support.ImageSyncMixin):
         plot_ed.scale_bar = True
         plot_ed.enable_painting = False
         plot_ed.max_intens_proj = self._max_intens_proj
+        plot_ed.blitter = self._blitter
         update_coords((self._z_overview, *self.offset[1::-1]), self.plane)
         plot_ed.show_roi(self.offset[1::-1], self.roi_size[1::-1])
         if offsets and sizes:
@@ -595,6 +598,7 @@ class ROIEditor(plot_support.ImageSyncMixin):
             fig = figure.Figure()
         fig.clear()
         self.fig = fig
+        self._blitter = image_viewer.Blitter(fig)
 
         # black text with transluscent background the color of the figure
         # background in case the title is a 2D plot

--- a/magmap/plot/plot_support.py
+++ b/magmap/plot/plot_support.py
@@ -258,10 +258,13 @@ class ImageSyncMixin:
             btn.hovercolor = str(float(btn.hovercolor) + shift)
             if text: btn.label.set_text(text[0])
 
-    def on_close(self):
+    def on_close(self, *args):
         """Figure close handler.
         
         Disconnects all Plot Editors and listeners.
+        
+        Args:
+            args: Additional arguments, currently ignored.
 
         """
         for plot_ed in self.plot_eds.values():

--- a/magmap/plot/plot_support.py
+++ b/magmap/plot/plot_support.py
@@ -257,6 +257,16 @@ class ImageSyncMixin:
             btn.color = str(float(btn.color) + shift)
             btn.hovercolor = str(float(btn.hovercolor) + shift)
             if text: btn.label.set_text(text[0])
+    
+    def axes_exit(self, event: "backend_bases.LocationEvent"):
+        """Trigger axes exit for all plot editors.
+
+        Args:
+            event: Axes exit event.
+        
+        """
+        for key in self.plot_eds:
+            self.plot_eds[key].on_axes_exit(event)
 
     def on_close(self, *args):
         """Figure close handler.

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,16 @@ _EXTRAS_JUPYTER = ["jupyterlab", "bash_kernel"]
 # optional dependencies for classification
 _EXTRAS_CLASSIFER = ["tensorflow"]
 
+# optional dependencies for full GUI; note that this group is not necessary
+# for the Matplotlib-based viewers (eg ROI Editor, Atlas Editor)
+_EXTRAS_GUI = [
+    "PyQt5",
+    "vtk",
+    "mayavi",
+    "pyface",
+    "traitsui",
+]
+
 # installation configuration
 config = {
     "name": "magellanmapper",
@@ -56,12 +66,7 @@ config = {
         "scikit-image",
         # PlotEditor performance regression with 3.3.0-3.3.1
         "matplotlib != 3.3.0, != 3.3.1",
-        "vtk",
-        "mayavi",
         "pandas",
-        "PyQt5",
-        "pyface",
-        "traitsui",
         "simpleitk==2.0.2rc2.dev785+g8ac4f",  # pre-built SimpleElastix
         "PyYAML",
         "appdirs",
@@ -83,11 +88,13 @@ config = {
         "docs": _EXTRAS_DOCS,
         "jupyter": _EXTRAS_JUPYTER,
         "classifier": _EXTRAS_CLASSIFER,
+        "gui": _EXTRAS_GUI,
         
         # dependencies for most common tasks
         "most": [
             "matplotlib_scalebar",
             "pyamg",  # for Random-Walker segmentation "cg_mg" mode
+            *_EXTRAS_GUI,
             *_EXTRAS_IMPORT,
         ],
         
@@ -97,6 +104,7 @@ config = {
             "pyamg",  # for Random-Walker segmentation "cg_mg" mode
             "seaborn",  # for Seaborn-based plots
             "scikit-learn",
+            *_EXTRAS_GUI,
             *_EXTRAS_PANDAS,
             *_EXTRAS_IMPORT,
             *_EXTRAS_AWS,


### PR DESCRIPTION
The Plot Editor shows region labels on mouse hover when registered atlas labels are loaded with an image. This PR fixes several issues with label interactivity:
- Greatly speeds up label display by using [blitting](https://matplotlib.org/stable/tutorials/advanced/blitting.html) in Matplotlib
- The label's position relative to the mouse now fits within the plot across zoom. The label has changed its position relative to the mouse depending in turn on where the mouse is relative to the whole image, which tends to keep the label within the plot. This relative image position is no longer relevant to the label position when zooming into an image, however. Instead, the relative plot position is used so that the label tends to stay within the plot.