### PR TITLE
Extend blitting to speed up atlas label editing and image pan/zoom

### DIFF
--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -11,6 +11,7 @@
 - Detection channels can be selected independently of the loaded image to overlay prior detections or compare channels (see "Detect > Chl")
 - Images can be viewed as RGB (see "ROI > Channels")
 - [Jupyter Notebook tutorial](https://github.com/sanderslab/magellanmapper/blob/master/bin/sample_cmds_bash.ipynb) for running common tasks
+- Smoother, faster interactions with main plots, including atlas label name display, label editing, and pan and zoom navigation
 
 ### Changes
 
@@ -38,7 +39,7 @@
   - "Blend" option in the image adjustment panel to visualize alignment in overlaid images (#89)
   - Image adjustment channels are radio buttons for easier selection (#212)
   - Fixed synchronization between the ROI Editor and image adjustment controls after initialization (#142)
-- Faster atlas label display when hovering over regions (#317)
+- Smoother, faster interactions with main plots, including atlas label name display, label editing, and pan and zoom navigation (#317, #335)
 - Atlas labels adapt better in zoomed images to stay within each plot (#317)
 - Fixed to reset the ROI selector when redrawing (#115)
 - Fixed to reorient the camera after clearing the 3D space (#121)
@@ -56,6 +57,7 @@
 - Any axis can be flipped through `--transform flip=<axis>`, where `axis = 0` for the z-axis, 1 for the y-axis, and 2 for the x-axis (#147)
 - Density/heat maps can be specified through `--reg_suffixes density=<suffix>` (#129)
 - Write point files for corresponding-point-based registration (#195)
+- Quieter console output by default (#335)
 - Fixed to only remove the final extension from image paths, and paths given by the `--prefix <path>` CLI argument do not undergo any stripping (#115)
 
 #### Atlas refinement
@@ -68,6 +70,7 @@
 - Image registration now supports multiple labels images given as `--reg_suffixes annotation=<suffix1>,<suffix2>,...`, which will apply the same transformation to each of these images (#147)
 - Landmark distance measurements save the raw distances and no longer require spacing (#147)
 - Masks with angle planes can be constructed (#252)
+- `register.RegImgs` is a data class to track registered images (#335)
 - Fixed changes to large label IDs during registration (#303)
 
 #### Cell detection

--- a/magmap/atlas/register.py
+++ b/magmap/atlas/register.py
@@ -39,6 +39,7 @@ outlined here. Each type can be coupled with additional arguments in ``cli``.
 """
 
 from collections import OrderedDict
+import dataclasses
 import os
 import shutil
 from time import time
@@ -73,6 +74,30 @@ _SORT_VOL_COLS = [
 ]
 
 _logger = config.logger.getChild(__name__)
+
+
+@dataclasses.dataclass
+class RegImgs:
+    """Data class for tracking registered images."""
+    exp_orig: Optional[Union[np.ndarray, sitk.Image]] = None
+    exp: Optional[Union[np.ndarray, sitk.Image]] = None
+    atlas: Optional[Union[np.ndarray, sitk.Image]] = None
+    labels: Optional[Union[np.ndarray, sitk.Image]] = None
+    labels_markers: Optional[Union[np.ndarray, sitk.Image]] = None
+    borders: Optional[Union[np.ndarray, sitk.Image]] = None
+    
+    @staticmethod
+    def get_order(name: str) -> Optional[int]:
+        """Get interpolation order for the given image type.
+        
+        Args:
+            name: Image field name.
+
+        Returns:
+            0 if the image is a labels-related image, otherwise None.
+
+        """
+        return 0 if name in ("labels", "labels_markers", "borders") else None
 
 
 def _translation_adjust(orig, transformed, translation, flip=False):

--- a/magmap/gui/image_viewer.py
+++ b/magmap/gui/image_viewer.py
@@ -55,13 +55,13 @@ class Blitter:
             # add artist
             self.add_artist(val)
     
-    def add_artist(self, arist: "artist.Artist"):
+    def add_artist(self, arist: "artist.Artist", i: Optional[int] = None):
         """Add tracked artist.
         
         Args:
             arist: Artist to track. Only artists in :attr:`fig` will be added.
-
-        Returns:
+            i: Index at which to add the artist. Defaults to None, which will
+                append the artist.
 
         """
         if arist.figure != self.fig:
@@ -73,7 +73,13 @@ class Blitter:
         # flag as animated for update, which appears to prevent updating
         # non-animated artists as well
         arist.set_animated(True)
-        self._artists.append(arist)
+        
+        if i is None:
+            # append artist
+            self._artists.append(arist)
+        else:
+            # use lower index to position behind other animated artists
+            self._artists.insert(i, arist)
     
     def on_draw(self, evt: Optional["backend_bases.DrawEvent"]):
         """Recapture backgrouna and draw the figure canvas."""

--- a/magmap/gui/plot_editor.py
+++ b/magmap/gui/plot_editor.py
@@ -236,8 +236,9 @@ class PlotEditor:
                 if downsample > 1:
                     # only downsample if factor is over 1
                     self._downsample[i] = downsample
-        print("plane {} downsampling factors by image: {}"
-              .format(self.plane, self._downsample))
+        _logger.debug(
+            "plane %s downsampling factors by image: %s", self.plane,
+            self._downsample)
 
     def connect(self):
         """Connect events to functions.

--- a/magmap/gui/plot_editor.py
+++ b/magmap/gui/plot_editor.py
@@ -445,8 +445,9 @@ class PlotEditor:
         if self.blitter:
             # remove existing artists in this editor from blitter
             artists = self.blitter.artists
-            if self.region_label in artists:
-                artists.remove(self.region_label)
+            for artist in (self.region_label, self.circle, self._ax_img_labels):
+                if artist in artists:
+                    artists.remove(artist)
         
         # prep 2D image from main image, assumed to be an intensity image,
         # with settings for each channel within this main image
@@ -558,9 +559,13 @@ class PlotEditor:
         if self.scale_bar:
             plot_support.add_scale_bar(self.axes, self._downsample[0])
 
+        if len(ax_imgs) > 1:
+            # store labels axes image separately for frequent access
+            self._ax_img_labels = ax_imgs[1][0]
+            self.blitter.add_artist(self._ax_img_labels)
+        
         # store displayed images in the PlotAxImg container class and update
         # displayed brightness/contrast
-        if len(ax_imgs) > 1: self._ax_img_labels = ax_imgs[1][0]
         self._plot_ax_imgs = []
         for i, imgs in enumerate(ax_imgs):
             plot_ax_imgs = []
@@ -1182,6 +1187,8 @@ class PlotEditor:
                             (x, y), radius=self.radius, linestyle=":",
                             fill=False, edgecolor="w")
                         self.axes.add_patch(self.circle)
+                        if self.blitter:
+                            self.blitter.add_artist(self.circle)
 
                 # re-translate downsampled coordinates to original space
                 coord = self.translate_coord([self.coord[0], y, x], up=True)

--- a/magmap/gui/plot_editor.py
+++ b/magmap/gui/plot_editor.py
@@ -475,8 +475,7 @@ class PlotEditor:
     
     def _get_ax_imgs(self) -> List["image.AxesImage"]:
         """Flatten ax image data stores and extract axes images."""
-        plot_axs = sum(self._plot_ax_imgs, [])
-        ax_imgs = [p.ax_img for p in plot_axs]
+        ax_imgs = [p.ax_img for p in libmag.flatten(self._plot_ax_imgs)]
         return ax_imgs
     
     def show_overview(self):

--- a/magmap/gui/plot_editor.py
+++ b/magmap/gui/plot_editor.py
@@ -1086,16 +1086,25 @@ class PlotEditor:
         loc_data = (x, y)
         curr_time = time.perf_counter()
         
+        # get action type
+        is_pan = event.button == 2 or (
+                event.button == 1 and event.key == "shift")
+        is_zoom = event.button == 3 or (
+                event.button == 1 and event.key == "control")
+        
+        # pan/zoom only filter out movement in same px to remain more responsive
+        motion_thresh = 0 if is_pan or is_zoom else self.motion_thresh
+        
         if self.last_loc is not None:
             # skip movements that are fast and short; all movements within the
             # same px will be skipped if threshold is non-neg
             time_diff = curr_time - self._last_time
             dist = np.hypot(*np.subtract(self.last_loc, loc))
             movt = dist * time_diff
-            if movt <= self.motion_thresh:
+            if movt <= motion_thresh:
                 return
         
-        if event.button == 2 or (event.button == 1 and event.key == "shift"):
+        if is_pan:
             # pan by middle-click or shift+left-click during mouseover
             
             # use data coordinates so same part of image stays under mouse
@@ -1111,8 +1120,7 @@ class PlotEditor:
             # data itself moved, so update location along with movement
             loc_data = (x - dx, y - dy)
             
-        elif event.button == 3 or (
-                event.button == 1 and event.key == "control"):
+        elif is_zoom:
             
             # zooming by right-click or ctrl+click (which coverts button event
             # to 3 on Mac at least) while moving mouse up/down in y

--- a/magmap/io/export_regions.py
+++ b/magmap/io/export_regions.py
@@ -476,7 +476,8 @@ def make_labels_level_img(
     Args:
         img_path: Path to the base image from which the corresponding
             registered image will be found. Can be None, where the globally
-            set up image stored in ``config`` will be used instead.
+            set up image stored in :attr:`magmap.settings.config` will be used
+            instead. If so, `prefix` must be given to specify the output path.
         level: Ontological level at which to group child labels.
         prefix: Start of path for output image; defaults to None to
             use ``img_path`` instead.
@@ -485,8 +486,13 @@ def make_labels_level_img(
     Returns:
         Dictionary of registered image suffix to SimpleITK image.
     
+    Raises:
+        `ValueError` if `img_path` and `prefix` are both None.
+    
     """
     if img_path is None:
+        if not prefix:
+            raise ValueError("Must set 'prefix' if 'img_path' is None")
         # use the globally set up image stored in config
         labels_sitk = config.labels_img_sitk
         ref = config.labels_ref

--- a/magmap/io/libmag.py
+++ b/magmap/io/libmag.py
@@ -8,7 +8,7 @@ import os
 import pathlib
 import shutil
 import sys
-from typing import Callable, List, Optional, Sequence, Union
+from typing import Any, Callable, Generator, List, Optional, Sequence, Union
 import warnings
 
 if sys.version_info >= (3, 8):
@@ -185,6 +185,23 @@ def combine_arrs(arrs, filter_none=True, fn=None, **kwargs):
     else:
         # combine with given function
         return fn(arrs, **kwargs)
+
+
+def flatten(vals: Sequence[Any]) -> Generator[Any, None, None]:
+    """Flatten an arbitrarily nested sequence.
+    
+    Args:
+        vals: Sequence of values with arbitrary levels of nesting.
+
+    Yields:
+        ``vals`` flattened to a single sequence.
+
+    """
+    for val in vals:
+        if is_seq(val):
+            yield from flatten(val)
+        else:
+            yield val
 
 
 def insert_before_ext(

--- a/magmap/io/sitk_io.py
+++ b/magmap/io/sitk_io.py
@@ -169,13 +169,14 @@ def read_sitk(path, dryrun=False):
         img_path = path_split[0] + ext
         if os.path.exists(img_path):
             if not dryrun:
-                print("Loading image with SimpleITK:", img_path)
+                _logger.debug("Loading image with SimpleITK: %s", img_path)
                 img_sitk = sitk.ReadImage(img_path)
             path_loaded = img_path
             break
     if not dryrun and img_sitk is None:
-        print("could not find image from {} and extensions {}"
-              .format(path_split[0], exts))
+        _logger.warn(
+            "could not find image from %s and extensions %s", path_split[0],
+            exts)
     return img_sitk, path_loaded
 
 
@@ -303,11 +304,11 @@ def read_sitk_files(
     
     if config.resolutions is None:
         # fallback to determining metadata directly from sitk file
-        libmag.warn(
+        _logger.warn(
             "MagellanMapper image metadata file not loaded; will fallback to "
-            "{} for metadata".format(loaded_path))
+            "%s for metadata", loaded_path)
         config.resolutions = np.array([img_sitk.GetSpacing()[::-1]])
-        print("set resolutions to {}".format(config.resolutions))
+        _logger.debug("set resolutions to %s", config.resolutions)
     
     # add time axis and insert into Image5d with original name
     img5d = np_io.Image5d(

--- a/magmap/io/sqlite.py
+++ b/magmap/io/sqlite.py
@@ -658,12 +658,12 @@ class ClrDB:
             path = config.db_path
         if new_db or not os.path.exists(path):
             conn, cur = _create_db(path)
-            print("Created a new database at {}".format(path))
+            _logger.debug("Created a new database at %s", path)
         else:
             conn = sqlite3.connect(path)
             conn.row_factory = sqlite3.Row
             cur = conn.cursor()
-            print("Loaded database from {}".format(path))
+            _logger.debug("Loaded database from %s", path)
         # add foreign key constraint support
         conn.execute("PRAGMA foreign_keys=ON")
         upgrade_db(conn, cur)

--- a/magmap/plot/colormaps.py
+++ b/magmap/plot/colormaps.py
@@ -17,6 +17,8 @@ from magmap.io import libmag
 # Default colormaps.
 CMAPS = {}
 
+_logger = config.logger.getChild(__name__)
+
 
 class DiscreteModes(Enum):
     """Discrete colormap generation modes."""
@@ -545,6 +547,6 @@ def setup_colormaps(num_channels):
         cmaps = discrete_colormap(
             chls_diff, alpha=255, prioritize_default=False, seed=config.seed,
             min_val=150) / 255.0
-        print("generating colormaps from RGBA colors:\n", cmaps)
+        _logger.debug("Generating colormaps from RGBA colors:\n%s", cmaps)
         for cmap in cmaps:
             config.cmaps.append(make_dark_linear_cmap("", cmap))

--- a/magmap/plot/plot_2d.py
+++ b/magmap/plot/plot_2d.py
@@ -1339,13 +1339,13 @@ def setup_style(style=None, rc_params=None):
         style = config.matplotlib_style
     if rc_params is None:
         rc_params = config.rc_params
-    print("setting up Matplotlib style", style)
+    _logger.debug("Setting up Matplotlib style: %s", style)
     plt.style.use(style)
     for rc in rc_params:
         if rc is config.Themes.DARK:
             # dark theme requires darker widgets for white text
             config.widget_color = 0.6
-        print("applying theme", rc.name)
+        _logger.debug("Applying theme: %s", rc.name)
         pylab.rcParams.update(rc.value)
 
 

--- a/magmap/plot/plot_support.py
+++ b/magmap/plot/plot_support.py
@@ -110,19 +110,20 @@ class ImageSyncMixin:
                 alpha_blend)
         return plot_ax_img
     
-    def save_fig(self, path):
+    def save_fig(self, path: str, **kwargs):
         """Save the figure to file, with path based on filename, ROI,
         and overview plane shown.
         
         Args:
-            path (str): Save path.
+            path: Save path.
+            kwargs: Additional arguments passed to :meth:`save_fig`.
         
         """
         if not self.fig:
             print("Figure not yet initialized, skipping save")
             return
         # use module save fig function
-        save_fig(path, fig=self.fig)
+        save_fig(path, fig=self.fig, **kwargs)
     
     def set_show_labels(self, val):
         """Set whether to show labels for all Plot Editors.

--- a/magmap/tests/test_libmag.py
+++ b/magmap/tests/test_libmag.py
@@ -10,6 +10,18 @@ from magmap.io import libmag
 
 class TestLibmag(unittest.TestCase):
     
+    def test_flatten(self):
+        self.assertSequenceEqual(
+            list(libmag.flatten(["a", "b"])), ["a", "b"])
+        self.assertSequenceEqual(
+            list(libmag.flatten([["a", "b"]])), ["a", "b"])
+        self.assertSequenceEqual(
+            list(libmag.flatten([["a", "b"], ["c", "d"]])),
+            ["a", "b", "c", "d"])
+        self.assertSequenceEqual(
+            list(libmag.flatten([["a", "b"], ["c", "d"], [["e", 1], "g", 3]])),
+            ["a", "b", "c", "d", "e", 1, "g", 3])
+    
     def test_insert_before_ext(self):
         self.assertEqual(libmag.insert_before_ext(
             "foo/bar/item.py", "totest", "_"), "foo/bar/item_totest.py")


### PR DESCRIPTION
PR #317 applied blitting to improve performance of displaying region labels so that hovering over labels is more responsive. This update broke atlas label editing, however, as the plot does not update. This PR fixes this label editing while also extending blitting to the paint controls and pan/zoom controls to improve their interactivity.

One side-effect is that the edited colors appear somewhat muted when first drawn but subsequently brighten to full intensity when initiating another edit or figure redraw.

This RP also bundles a few other changes:
- The motion threshold setting no longer applies to pan and zoom to maintain their interactivity
- Added a `register.RegImgs` data class to manage related images during image registration tasks
- Many print statements on startup and loading an image are now debug logging statements to reduce output