### PR TITLE
Run CI for Python 3.6 on Ubuntu 20.04 only

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install libsm6 libgl1-mesa-glx
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Cache pip

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,8 +22,17 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-20.04, ubuntu-latest, macos-latest, windows-latest]
         python-version: [3.6, 3.7, 3.8, 3.9]
+        exclude:
+          - os: ubuntu-20.04
+            python-version: 3.7
+          - os: ubuntu-20.04
+            python-version: 3.8
+          - os: ubuntu-20.04
+            python-version: 3.9
+          - os: ubuntu-latest
+            python-version: 3.6
     
     env:
       # set requirements path based on Python version

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,7 +51,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Cache pip
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           # python environment path from setup-python
           path: ${{ env.pythonLocation }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: Check out repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install VTK dependencies
         if: ${{ runner.os == 'Linux' }}
         run: |


### PR DESCRIPTION
The `ubuntu-latest` platform for GitHub Actions CI recently updated to Ubuntu 22.04 (see https://github.com/actions/runner-images/issues/6399) and dropped support for Python 3.6 (https://github.com/actions/setup-python/issues/544#issuecomment-1332535877)

As inspired by this workaround (https://github.com/microsoft/responsible-ai-toolbox/pull/1838), use Ubuntu 20.04 only for Python 3.6 testing.