### PR TITLE
Clean up Plot Editor blitting implementation

### DIFF
--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -39,7 +39,7 @@
   - "Blend" option in the image adjustment panel to visualize alignment in overlaid images (#89)
   - Image adjustment channels are radio buttons for easier selection (#212)
   - Fixed synchronization between the ROI Editor and image adjustment controls after initialization (#142)
-- Smoother, faster interactions with main plots, including atlas label name display, label editing, and pan and zoom navigation (#317, #335)
+- Smoother, faster interactions with main plots, including atlas label name display, label editing, and pan and zoom navigation (#317, #335, #359)
 - Atlas labels adapt better in zoomed images to stay within each plot (#317)
 - Fixed to reset the ROI selector when redrawing (#115)
 - Fixed to reorient the camera after clearing the 3D space (#121)
@@ -49,6 +49,7 @@
 - Fixed browsing for files or directories in some environments (#201)
 - Fixed clearing the import path (#201)
 - Fixed saving additional, old figures when using the save shortcut (#256)
+- Fixed lag in zoom direction change (#359)
 
 #### CLI
 

--- a/magmap/gui/plot_editor.py
+++ b/magmap/gui/plot_editor.py
@@ -1067,7 +1067,7 @@ class PlotEditor:
                     # trigger provided handler
                     self.fn_update_coords(self.coord, self.plane)
                 
-                elif self.label_motion_thresh is np.inf:
+                if self.label_motion_thresh is np.inf:
                     # update region label on click if set to ignore motion
                     self._update_region_label(x, y, coord)
                     self._redraw_animated()

--- a/magmap/gui/plot_editor.py
+++ b/magmap/gui/plot_editor.py
@@ -1080,8 +1080,8 @@ class PlotEditor:
         """Remove any mouse circle and region label."""
         if event.inaxes != self.axes: return
         
-        if self.circle:
-            # remove circle
+        if self.circle and not self.blitter:
+            # remove circle unless managed by blitter
             self.circle.remove()
             self.circle = None
         

--- a/magmap/gui/plot_editor.py
+++ b/magmap/gui/plot_editor.py
@@ -1025,7 +1025,7 @@ class PlotEditor:
         # re-translate downsampled coordinates back up
         coord = self.translate_coord([self.coord[0], y, x], up=True)
 
-        if self._is_pan(event) or self._is_zoom(event) and self.blitter:
+        if (self._is_pan(event) or self._is_zoom(event)) and self.blitter:
             # add axes images to blitter for navigation
             for ax_img in self._get_ax_imgs():
                 artists = self.blitter.artists
@@ -1320,7 +1320,7 @@ class PlotEditor:
                     self.plane, self.coord[0], self.intensity)
             self._editing = False
 
-        if self._is_pan(event) or self._is_zoom(event) and self.blitter:
+        if (self._is_pan(event) or self._is_zoom(event)) and self.blitter:
             # remove axes images except labels image in editing mode
             for ax_img in self._get_ax_imgs():
                 artists = self.blitter.artists


### PR DESCRIPTION
PRs #317 and #335 introduced blitting operations in the Plot Editor. This PR follows up with several fixes:
- Fixed mouse press/release events when a blitter has not been set
- Fixed stale paint circle when moving the mouse outside of a plot or changing planes
- Mouse presses can trigger both coordinate and region label updates

Additionally, the mouse motion handler has had a long-standing issue where state is not updated until the end of the handler, which can cause rapidly successive events to use a stale state. Now motion events that are not filtered will update state immediately, which improves the event filter check and fixes a slight lag experienced during zoom direction change.