### PR TITLE
Fix errors on deprecated NumPy data type aliases

### DIFF
--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -172,6 +172,7 @@
 - The `jupyter` install group installs packages for running the Jupyter sample commands notebook in a Bash kernel (#122)
 - Missing dependencies are starting to use more consistent error messages and instructions (#226)
 - Python 3.6 and 3.7 have separate pinned dependencies (`envs/requirements_py3<n>`) (#232)
+- Fixed error on deprecated NumPy data type aliases (#364)
 
 #### R Dependency Changes
 

--- a/magmap/atlas/atlas_refiner.py
+++ b/magmap/atlas/atlas_refiner.py
@@ -65,7 +65,7 @@ def truncate_labels(img_np, x_frac=None, y_frac=None, z_frac=None):
         if bound is not None:
             # convert boundary fractions to absolute coordinates for the 
             # given axis, filling the other axes with full slices
-            bound_abs = np.multiply(bound, shape[axis]).astype(np.int)
+            bound_abs = np.multiply(bound, shape[axis]).astype(int)
             slices = [slice(None)] * bounds_len
             slices[axis] = slice(0, bound_abs[0])
             img_np[tuple(slices)] = 0
@@ -971,7 +971,7 @@ def label_smoothing_metric(orig_img_np, smoothed_img_np, filter_size=None,
         # smoothed image to improve efficiency over filtering whole image
         label_mask = np.logical_or(
             orig_img_np == label_id, smoothed_img_np == label_id)
-        props = measure.regionprops(label_mask.astype(np.int))
+        props = measure.regionprops(label_mask.astype(int))
         if len(props) < 1 or props[0].bbox is None: continue
         _, slices = cv_nd.get_bbox_region(
             props[0].bbox, 2, orig_img_np.shape)

--- a/magmap/atlas/ontology.py
+++ b/magmap/atlas/ontology.py
@@ -693,12 +693,12 @@ def scale_coords(
         # round when extra precision is necessary, such as during reverse 
         # scaling, which requires clipping so coordinates don't exceed labels 
         # image shape
-        coords_only = np.around(coords_only).astype(np.int)
+        coords_only = np.around(coords_only).astype(int)
         coords_only = np.clip(
             coords_only, None, np.subtract(clip_shape, 1))
     else:
         # typically don't round to stay within bounds
-        coords_only = coords_only.astype(np.int)
+        coords_only = coords_only.astype(int)
     if coord_scaled.shape[-1] <= 3:
         # assume coords are spatial dimensions
         coord_scaled = coords_only
@@ -901,7 +901,7 @@ def get_region_middle(
         # print("coord_labels (unscaled): {}".format(coord))
         # print("ID at middle coord: {} (in region? {})"
         #       .format(labels_img[coord], img_region[coord]))
-        coord = tuple(np.around(np.divide(coord, scaling)).astype(np.int))
+        coord = tuple(np.around(np.divide(coord, scaling)).astype(int))
     # print("coord at middle: {}".format(coord))
     return coord, img_region, region_ids
 

--- a/magmap/atlas/register.py
+++ b/magmap/atlas/register.py
@@ -1349,8 +1349,8 @@ def get_scaled_regionprops(img_region, scaling):
         bbox_scaled[:3] = bbox_scaled[:3] * scaling_inv
         bbox_scaled[3:] = bbox_scaled[3:] * scaling_inv
         centroid_scaled = np.array(props[0].centroid) * scaling_inv
-        bbox_scaled = np.around(bbox_scaled).astype(np.int)
-        centroid_scaled = np.around(centroid_scaled).astype(np.int)
+        bbox_scaled = np.around(bbox_scaled).astype(int)
+        centroid_scaled = np.around(centroid_scaled).astype(int)
         print(props[0].bbox, props[0].centroid)
         print(bbox_scaled, centroid_scaled)
         return props, bbox_scaled, centroid_scaled

--- a/magmap/atlas/transformer.py
+++ b/magmap/atlas/transformer.py
@@ -235,9 +235,9 @@ def transpose_img(
             shape = rescaled.shape[:3]
             num_chunks = np.ceil(np.divide(shape, max_pixels))
             max_pixels = np.ceil(
-                np.divide(shape, num_chunks)).astype(np.int)
+                np.divide(shape, num_chunks)).astype(int)
             sub_roi_size = np.floor(
-                np.divide(target_size, num_chunks)).astype(np.int)
+                np.divide(target_size, num_chunks)).astype(int)
             print("Resizing image of shape {} to target_size: {}, using "
                   "num_chunks: {}, max_pixels: {}, sub_roi_size: {}"
                   .format(rescaled.shape, target_size, num_chunks, max_pixels,

--- a/magmap/cv/chunking.py
+++ b/magmap/cv/chunking.py
@@ -182,7 +182,7 @@ def _num_units(
     """
     num = np.floor_divide(size, max_pixels)
     num[np.remainder(size, max_pixels) > 0] += 1
-    return num.astype(np.int)
+    return num.astype(int)
 
 
 def _bounds_side(
@@ -275,8 +275,8 @@ def merge_split_stack(
     """
     size = sub_rois.shape
     merged = None
-    if overlap.dtype != np.int:
-        overlap = overlap.astype(np.int)
+    if overlap.dtype != int:
+        overlap = overlap.astype(int)
     for z in range(size[0]):
         merged_y = None
         for y in range(size[1]):
@@ -332,8 +332,8 @@ def get_split_stack_total_shape(sub_rois, overlap=None):
     """
     size = sub_rois.shape
     shape_sub_roi = sub_rois[0, 0, 0].shape # for number of dimensions
-    merged_shape = np.zeros(len(shape_sub_roi)).astype(np.int)
-    final_shape = np.zeros(len(shape_sub_roi)).astype(np.int)
+    merged_shape = np.zeros(len(shape_sub_roi)).astype(int)
+    final_shape = np.zeros(len(shape_sub_roi)).astype(int)
     edges = None
     for z in range(size[0]):
         for y in range(size[1]):
@@ -377,7 +377,7 @@ def merge_split_stack2(sub_rois, overlap, offset, output):
         The merged stack.
     """
     size = sub_rois.shape
-    merged_coord = np.zeros(3, dtype=np.int)
+    merged_coord = np.zeros(3, dtype=int)
     sub_roi_shape = sub_rois[0, 0, 0].shape
     if offset > 0:
         # axis offset, such as skipping the time axis

--- a/magmap/cv/cv_nd.py
+++ b/magmap/cv/cv_nd.py
@@ -631,7 +631,7 @@ def get_label_props(labels_img_np, label_id):
     else:
         # single ID
         label_mask = labels_img_np == label_id
-    props = measure.regionprops(label_mask.astype(np.int))
+    props = measure.regionprops(label_mask.astype(int))
     return props
 
 
@@ -694,7 +694,7 @@ def meas_region(mask, res):
         of ``mask`` as given by :meth:`measure.regionprops`.
 
     """
-    props = measure.regionprops(mask.astype(np.int))
+    props = measure.regionprops(mask.astype(int))
     shape = get_bbox_region(props[0].bbox)[0]
     meas = np.multiply(shape, res)
     vol = np.prod(res) * np.sum(mask)
@@ -762,7 +762,7 @@ def crop_to_labels(img_labels, img_ref, mask=None, dil_size=2, padding=5):
     if mask is None:
         # default to get bounding box of all labels, assuming 0 is background
         mask = img_labels != 0
-    props = measure.regionprops(mask.astype(np.int))
+    props = measure.regionprops(mask.astype(int))
     if not props or len(props) < 1: return
     shape, slices = get_bbox_region(
         props[0].bbox, padding=padding, img_shape=img_labels.shape)
@@ -1088,7 +1088,7 @@ def make_isotropic(
     """
     resize_factor = calc_isotropic_factor(scale, res)
     isotropic_shape = np.array(roi.shape)
-    isotropic_shape[:3] = (isotropic_shape[:3] * resize_factor).astype(np.int)
+    isotropic_shape[:3] = (isotropic_shape[:3] * resize_factor).astype(int)
     libmag.printv("original ROI shape: {}, isotropic: {}"
                   .format(roi.shape, isotropic_shape))
     

--- a/magmap/cv/detector.py
+++ b/magmap/cv/detector.py
@@ -527,7 +527,7 @@ class Blobs:
             
             if to_int:
                 # convert shifted values to ints
-                sub = sub.astype(np.int)
+                sub = sub.astype(int)
             
             # replace values
             if is_1d:

--- a/magmap/cv/segmenter.py
+++ b/magmap/cv/segmenter.py
@@ -673,7 +673,7 @@ class SubSegmenter(object):
         labels_seg = None
         slices = None
         if label_size > 0:
-            props = measure.regionprops(label_mask.astype(np.int))
+            props = measure.regionprops(label_mask.astype(int))
             _, slices = cv_nd.get_bbox_region(props[0].bbox)
             
             # work on a view of the region for efficiency

--- a/magmap/cv/stack_detect.py
+++ b/magmap/cv/stack_detect.py
@@ -707,7 +707,7 @@ class StackPruner(object):
                 for j in range(num_sections):
                     # build overlapping region dimensions based on size of 
                     # sub-region in the given axis
-                    coord = np.zeros(3, dtype=np.int)
+                    coord = np.zeros(3, dtype=int)
                     coord[axis] = j
                     print("** setting up blob pruning in axis {}, section {} "
                           "of {}".format(axis, j, num_sections - 1))

--- a/magmap/gui/plot_editor.py
+++ b/magmap/gui/plot_editor.py
@@ -358,7 +358,7 @@ class PlotEditor:
         else:
             coord_tr[coord_slice] = np.divide(
                 coord_tr[coord_slice], self._downsample[0])
-        coord_tr = list(coord_tr.astype(np.int))
+        coord_tr = list(coord_tr.astype(int))
         # print("translated from {} to {}".format(coord, coord_tr))
         return coord_tr
 

--- a/magmap/gui/roi_editor.py
+++ b/magmap/gui/roi_editor.py
@@ -181,7 +181,7 @@ class DraggableCircle:
         print("segment moving from {}...".format(self.segment))
         seg_old = np.copy(self.segment)
         self.segment[1:3] += np.subtract(
-            self.circle.center, self._press[0:2]).astype(np.int)[::-1]
+            self.circle.center, self._press[0:2]).astype(int)[::-1]
         rad_sign = -1 if self.segment[3] < config.POS_THRESH else 1
         self.segment[3] = rad_sign * self.circle.radius
         print("...to {}".format(self.segment))
@@ -445,8 +445,8 @@ class ROIEditor(plot_support.ImageSyncMixin):
                     # zoom images based on scaling to main image
                     scale = np.divide(
                         img.shape[1:3], arrs_3d[0].shape[1:3])[::-1]
-                    origin_scaled = np.multiply(ori, scale).astype(np.int)
-                    end_scaled = np.multiply(end, scale).astype(np.int)
+                    origin_scaled = np.multiply(ori, scale).astype(int)
+                    end_scaled = np.multiply(end, scale).astype(int)
                     offsets.append(origin_scaled[::-1])
                     sizes.append(np.subtract(end_scaled, origin_scaled)[::-1])
 
@@ -490,7 +490,7 @@ class ROIEditor(plot_support.ImageSyncMixin):
         if config.zoom and config.magnification:
             # calculate total mag from objective zoom and mag
             zoom_components = np.array(
-                [config.zoom, config.magnification, zoom]).astype(np.float)
+                [config.zoom, config.magnification, zoom]).astype(float)
             # use abs since the default mag and zoom were previously -1.0
             tot_zoom = "{}x".format(
                 libmag.compact_float(abs(np.prod(zoom_components)), 1))

--- a/magmap/gui/vis_3d.py
+++ b/magmap/gui/vis_3d.py
@@ -387,7 +387,7 @@ class Vis3D:
         if segments.shape[0] <= 0:
             return 0, 0
         if roi_offset is None:
-            roi_offset = np.zeros(3, dtype=np.int)
+            roi_offset = np.zeros(3, dtype=int)
         if self.blobs3d:
             for blob in self.blobs3d:
                 # remove existing blob glyphs from the pipeline
@@ -521,7 +521,7 @@ class Vis3D:
                 if self.fn_update_coords:
                     # callback to update coordinates using blob's orig coords
                     self.fn_update_coords(np.add(
-                        segs_in[blobi, 4:7], roi_offset).astype(np.int))
+                        segs_in[blobi, 4:7], roi_offset).astype(int))
         
         # show ROI outline and make blobs pickable, falling back to closest
         # blobs within 20% of the longest ROI edge to be picked if present
@@ -577,7 +577,7 @@ class Vis3D:
             roi = roi[:, :, :, 0]
         isotropic = plot_3d.get_isotropic_vis(config.roi_profile)
         shape = roi.shape
-        shape_iso = np.multiply(roi.shape, isotropic).astype(np.int)
+        shape_iso = np.multiply(roi.shape, isotropic).astype(int)
         shape_iso_mid = shape_iso // 2
         
         # TODO: shift z by +10?
@@ -585,7 +585,7 @@ class Vis3D:
         # xy-plane, positioned just below the 3D ROI
         img2d = roi[shape[0] // 2, :, :]
         img2d = transform.resize(
-            img2d, np.multiply(img2d.shape, isotropic[1:]).astype(np.int),
+            img2d, np.multiply(img2d.shape, isotropic[1:]).astype(int),
             preserve_range=True)
         img2d_mlab = self._shadow_img2d(img2d, shape_iso, 0)
         # Mayavi positions are in x,y,z
@@ -595,7 +595,7 @@ class Vis3D:
         # xz-plane
         img2d = roi[:, shape[1] // 2, :]
         img2d = transform.resize(
-            img2d, np.multiply(img2d.shape, isotropic[[0, 2]]).astype(np.int),
+            img2d, np.multiply(img2d.shape, isotropic[[0, 2]]).astype(int),
             preserve_range=True)
         img2d_mlab = self._shadow_img2d(img2d, shape_iso, 2)
         img2d_mlab.actor.position = [
@@ -605,7 +605,7 @@ class Vis3D:
         # yz-plane
         img2d = roi[:, :, shape[2] // 2]
         img2d = transform.resize(
-            img2d, np.multiply(img2d.shape, isotropic[:2]).astype(np.int),
+            img2d, np.multiply(img2d.shape, isotropic[:2]).astype(int),
             preserve_range=True)
         img2d_mlab = self._shadow_img2d(img2d, shape_iso, 1)
         img2d_mlab.actor.position = [

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -455,10 +455,10 @@ class Visualization(HasTraits):
     _import_btn = Button("Import files")
     _import_btn_enabled = Bool
     _import_clear_btn = Button("Clear import")
-    _import_res = Array(np.float, shape=(1, 3))
+    _import_res = Array(float, shape=(1, 3))
     _import_mag = Float(1.0)
     _import_zoom = Float(1.0)
-    _import_shape = Array(np.int, shape=(1, 5), editor=ArrayEditor(
+    _import_shape = Array(int, shape=(1, 5), editor=ArrayEditor(
         width=-40, format_str="%0d"))
     # map bits to bytes for constructing Numpy data type
     _IMPORT_BITS = OrderedDict((
@@ -1691,7 +1691,7 @@ class Visualization(HasTraits):
             # get atlas label at ROI center
             center = np.add(
                 curr_offset, 
-                np.around(np.divide(curr_roi_size, 2)).astype(np.int))
+                np.around(np.divide(curr_roi_size, 2)).astype(int))
             self._atlas_label = ontology.get_label(
                 center[::-1], config.labels_img, config.labels_ref.ref_lookup, 
                 config.labels_scaling, level, rounding=True)
@@ -2641,7 +2641,7 @@ class Visualization(HasTraits):
                     # get colors of corresponding atlas labels
                     if coords is None: return None
                     blob_ids = ontology.get_label_ids_from_position(
-                        coords.astype(np.int), config.labels_img)
+                        coords.astype(int), config.labels_img)
                     atlas_cmap = config.cmap_labels(
                         config.cmap_labels.convert_img_labels(blob_ids))
                     atlas_cmap[:, :3] *= 255
@@ -2660,7 +2660,7 @@ class Visualization(HasTraits):
             else:
                 # default to color by channel
                 blob_chls = detector.Blobs.get_blobs_channel(
-                    segs_all[self.segs_in_mask]).astype(np.int)
+                    segs_all[self.segs_in_mask]).astype(int)
                 cmap = colormaps.discrete_colormap(
                     max(blob_chls) + 1, alpha, True, config.seed)
                 self.segs_cmap = cmap[blob_chls]
@@ -3421,7 +3421,7 @@ class Visualization(HasTraits):
             curr_roi_size = self.roi_array[0].astype(int)
             corner = np.subtract(
                 centroid, 
-                np.around(np.divide(curr_roi_size[::-1], 2)).astype(np.int))
+                np.around(np.divide(curr_roi_size[::-1], 2)).astype(int))
             self.z_offset, self.y_offset, self.x_offset = corner
             self._check_roi_position()
             self.show_3d()
@@ -3998,7 +3998,7 @@ class Visualization(HasTraits):
         self._import_paths = []
         self._import_mode = None
         self._import_res = np.ones((1, 3))
-        self._import_shape = np.zeros((1, 5), dtype=np.int)
+        self._import_shape = np.zeros((1, 5), dtype=int)
         self._import_bit = [tuple(self._IMPORT_BITS.keys())[0]]
         self._import_data_type = [tuple(self._IMPORT_DATA_TYPES.keys())[0]]
         self._import_byte_order = [tuple(self._IMPORT_BYTE_ORDERS.keys())[0]]

--- a/magmap/plot/plot_2d.py
+++ b/magmap/plot/plot_2d.py
@@ -170,7 +170,7 @@ def plot_overlays_reg(exp, atlas, atlas_reg, labels_reg, cmap_exp,
     '''
     labels_reg = labels_reg.astype(np.float)
     lib_clrbrain.normalize(labels_reg, 1, 100, background=15000)
-    labels_reg = labels_reg.astype(np.int)
+    labels_reg = labels_reg.astype(int)
     print(labels_reg[290:300, 20, 190:200])
     '''
     

--- a/magmap/plot/plot_support.py
+++ b/magmap/plot/plot_support.py
@@ -595,7 +595,7 @@ class ImageOverlayer:
                 shape[:2] = imgs2d[0].shape[:2]
                 img = transform.resize(
                     img, shape, order=0, anti_aliasing=False,
-                    preserve_range=True, mode="reflect").astype(np.int)
+                    preserve_range=True, mode="reflect").astype(int)
             
             if check_single and discrete and len(np.unique(img)) < 2:
                 # WORKAROUND: increment the last val of single unique val images


### PR DESCRIPTION
NumPy aliases for generic data types have been deprecated and now give an error as of NumPy v1.24 (see https://numpy.org/doc/stable/release/1.24.0-notes.html#expired-deprecations). This PR changes these references to the standard Python types (see https://numpy.org/doc/stable/release/1.20.0-notes.html#deprecations).