### PR TITLE
Fix blank image when double-clicking ROI Editor

### DIFF
--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -39,7 +39,7 @@
   - "Blend" option in the image adjustment panel to visualize alignment in overlaid images (#89)
   - Image adjustment channels are radio buttons for easier selection (#212)
   - Fixed synchronization between the ROI Editor and image adjustment controls after initialization (#142)
-- Smoother, faster interactions with main plots, including atlas label name display, label editing, and pan and zoom navigation (#317, #335, #359)
+- Smoother, faster interactions with main plots, including atlas label name display, label editing, and pan and zoom navigation (#317, #335, #359, #367)
 - Atlas labels adapt better in zoomed images to stay within each plot (#317)
 - Fixed to reset the ROI selector when redrawing (#115)
 - Fixed to reorient the camera after clearing the 3D space (#121)

--- a/magmap/gui/plot_editor.py
+++ b/magmap/gui/plot_editor.py
@@ -1006,14 +1006,14 @@ class PlotEditor:
     @staticmethod
     def _is_pan(event: "backend_bases.MouseEvent") -> bool:
         """Check if a mouse event is for panning navigation."""
-        return event.button == 2 or (
-                event.button == 1 and event.key == "shift")
+        return not event.dblclick and (event.button == 2 or (
+                event.button == 1 and event.key == "shift"))
 
     @staticmethod
     def _is_zoom(event: "backend_bases.MouseEvent") -> bool:
         """Check if a mouse event is for zooming navigation."""
-        return event.button == 3 or (
-                event.button == 1 and event.key == "control")
+        return not event.dblclick and (event.button == 3 or (
+                event.button == 1 and event.key == "control"))
 
     def on_press(self, event):
         """Respond to mouse press events."""


### PR DESCRIPTION
Double (right) clicking the ROI Editor redraws it, but the click also set the images for blitting as for panning or zooming and prevented the images from appearing in the redrawn image or to be drawn very faintly. Fixed here by filtering out double-click events for pan/zoom.