### PR TITLE
Fix ROI padding for blob verification and match-based colocalization in 2D images

### DIFF
--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -114,6 +114,7 @@
 - Better 2D image support
   - Extended zero-crossing detection to 2D cases (#142)
   - Unit factor conversions adapts to image dimensions (eg 2D vs 3D) (#132)
+  - Fixed ROI padding during blob verification and match-based colocalization for 2D images (#380)
 - Multiple multiplane image files can be selected directly instead of relying on file auto-detection (#201)
 - Fixed re-importing an image after loading it (#117)
 - Fixed to store the image path when loading a registered image as the main image, which fixes saving the experiment name used when saving blobs (#139)

--- a/magmap/cv/detector.py
+++ b/magmap/cv/detector.py
@@ -1081,27 +1081,31 @@ def remove_close_blobs_within_sorted_array(blobs, tol):
     return blobs_all
 
 
-def get_blobs_in_roi(blobs, offset, size, margin=(0, 0, 0), reverse=True):
+def get_blobs_in_roi(
+        blobs: np.ndarray, offset: Sequence[int], size: Sequence[int],
+        margin: Sequence[int] = (0, 0, 0), reverse: bool = True
+) -> Tuple[np.ndarray, np.ndarray]:
     """Get blobs within an ROI based on offset and size.
     
-    Note that dimensions are in x,y,z for natural ordering but may 
-    change for consistency with z,y,x ordering used throughout MagellanMapper.
+    Note that dimensions are in x,y,z for natural ordering but may change for
+    consistency with z,y,x ordering used throughout MagellanMapper.
     
     Args:
-        blobs (:obj:`np.ndarray`): The blobs to retrieve, given as 2D array of
+        blobs: The blobs to retrieve, given as 2D array of
             ``[n, [z, row, column, radius, ...]]``.
-        offset (List[int]): Offset coordinates in .
-        size (List[int]): Size of ROI in x,y,z.
-        margin (List[int]): Additional space outside the ROI to include
-            in x,y,z.
-        reverse (bool): True to reverse the order of ``offset`` and ``size``,
-            assuming that they are in x,y,z rather than z,y,x order.
+        offset: Offset coordinates in ``x,y,z``.
+        size: Size of ROI in ``x,y,z``.
+        margin: Additional space outside the ROI to include in ``x,y,z``.
+        reverse: True to reverse the order of ``offset`` and ``size``,
+            assuming that they are in ``x,y,z`` rather than ``z,y,x`` order.
             Defaults to True for backward compatibility with the ROI
             convention used here.
     
     Returns:
-        :obj:`np.ndarray`, :obj:`np.ndarray`: Blobs within the ROI and the
-        mask used to retrieve these blobs.
+        Tuple of:
+        - ``segs_all`: Blobs within the ROI
+        - ``mask``: the mask used to retrieve these blobs
+    
     """
     if reverse:
         offset = offset[::-1]

--- a/magmap/io/export_regions.py
+++ b/magmap/io/export_regions.py
@@ -312,7 +312,7 @@ def make_density_image(
     # annotate blobs based on position
     heat_map = make_heat_map()
     if is_2d:
-        # convert back to 3D
+        # convert back to 2D
         heat_map = heat_map[0]
     imgs_write = {
         config.RegNames.IMG_HEAT_MAP.value:
@@ -356,9 +356,11 @@ def make_density_image(
     if heat_colocs is not None:
         # combine heat maps into single image
         heat_colocs = np.stack(heat_colocs, axis=3)
+        if is_2d:
+            # convert back to 2D
+            heat_colocs = heat_colocs[0]
         imgs_write[config.RegNames.IMG_HEAT_COLOC.value] = \
-            sitk_io.replace_sitk_with_numpy(
-                labels_img_sitk, heat_colocs)
+            sitk_io.replace_sitk_with_numpy(labels_img_sitk, heat_colocs, True)
     
     # write images to file
     sitk_io.write_reg_images(imgs_write, mod_path)

--- a/magmap/io/np_io.py
+++ b/magmap/io/np_io.py
@@ -651,7 +651,7 @@ def read_tif(
         # apply 90 deg rotations; appears to need flipping; both return views
         # TODO: check scenarios requiring flipping
         tif_memmap = cv_nd.rotate90(tif_memmap, nrot, (2, 3), ndim >= 5)
-        tif_memmap = np.fliplr(tif_memmap)
+        tif_memmap = tif_memmap[:, :, :, ::-1]
     
     if config.verbose:
         _logger.debug("Parsed TIF metadata:\n%s", pprint.pformat(md))

--- a/magmap/io/sitk_io.py
+++ b/magmap/io/sitk_io.py
@@ -65,13 +65,16 @@ def reg_out_path(file_path, reg_name, match_ext=False):
 
 
 def replace_sitk_with_numpy(
-        img_sitk: sitk.Image, img_np: np.ndarray) -> sitk.Image:
+        img_sitk: sitk.Image, img_np: np.ndarray, multichannel: bool = None
+) -> sitk.Image:
     """Generate a :class:``sitk.Image`` object based on another Image object,
     but replace its array with a new Numpy array.
     
     Args:
         img_sitk: Image object to use as template.
         img_np: Numpy array to swap in.
+        multichannel: True for multichannel images. Defaults to None, where
+            the multichannel setting from ``img_sitk`` will be used.
     
     Returns:
         New :class:``sitk.Image`` object with same spacing, origin, and 
@@ -84,8 +87,10 @@ def replace_sitk_with_numpy(
     direction = img_sitk.GetDirection()
     
     # treat as vector (multichannel) image if source is multichannel
-    img_sitk_back = sitk.GetImageFromArray(
-        img_np, True if img_sitk.GetNumberOfComponentsPerPixel() > 1 else None)
+    if multichannel is None:
+        multichannel = (
+            True if img_sitk.GetNumberOfComponentsPerPixel() > 1 else None)
+    img_sitk_back = sitk.GetImageFromArray(img_np, multichannel)
     
     # transfer original settings to new sitk Image
     img_sitk_back.SetSpacing(spacing)


### PR DESCRIPTION
The inner padding may exceed the space of the ROI, particularly for 2D images since the z-plane only has one plane, leading to zero or negative sizes. Fixed here by clipping the inner padding dimensions so that the remaining size will be greater than 0 if possible.