### PR TITLE
Workaround for Qt backend error with PyQt5 v5.15.8

### DIFF
--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -175,6 +175,7 @@
 - Missing dependencies are starting to use more consistent error messages and instructions (#226)
 - Python 3.6 and 3.7 have separate pinned dependencies (`envs/requirements_py3<n>`) (#232)
 - Fixed error on deprecated NumPy data type aliases (#364)
+- Fixed `qt4 backend` error by installing PyQt <= 5.15.7 (#431)
 
 #### R Dependency Changes
 

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,8 @@ _EXTRAS_CLASSIFER = ["tensorflow"]
 # optional dependencies for full GUI; note that this group is not necessary
 # for the Matplotlib-based viewers (eg ROI Editor, Atlas Editor)
 _EXTRAS_GUI = [
-    "PyQt5",
+    # backend error with 5.15.8
+    "PyQt5 <= 5.15.7",
     "vtk",
     "mayavi",
     "pyface",


### PR DESCRIPTION
Fixes #428 . PyQt5 v.5.15.8 appears to give a startup error, fixed by installing the prior version.