### PR TITLE
Bump version to v1.6a3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ config = {
     "url": "https://github.com/sanderslab/magellanmapper",
     "author_email": "david@textflex.com",
     "license": "BSD-3",
-    "version": "1.6a2",
+    "version": "1.6a3",
     "packages": setuptools.find_packages(),
     "scripts": [],
     "python_requires": ">=3.6",


### PR DESCRIPTION
Increment version to include workaround for critical runtime error (#428).