### PR TITLE
Pin BrainGlobe Atlas API to last version supporting Python <= 3.6

### DIFF
--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -164,7 +164,7 @@
 #### Python Dependency Changes
 
 - Python 3.8 is the default version now that Python 3.6 has reached End-of-Life
-- The BrainGlobe Atlas API package (`bg-atlasapi`) dependency has been added to access a suite of cloud-based atlases (#75)
+- The BrainGlobe Atlas API package (`bg-atlasapi`) dependency has been added to access a suite of cloud-based atlases (#75, #443)
 - The `dataclasses` backport is installed for Python < 3.7
 - `Tifffile` is now a direct dependency, previously already installed as a sub-dependency of other required packages
 - `Imagecodecs` is optional for `tifffile` but required for its uses here as of `tifffile v2022.7.28` and thus added as a dependency (#153)

--- a/envs/requirements.txt
+++ b/envs/requirements.txt
@@ -1,7 +1,7 @@
 --extra-index-url https://pypi.fury.io/dd8/
 appdirs==1.4.4
 apptools==5.2.0
-bg-atlasapi @ https://github.com/brainglobe/bg-atlasapi/archive/refs/heads/master.zip
+bg-atlasapi @ https://github.com/brainglobe/bg-atlasapi/archive/dbecd16b2f63a8e167543f3358452a756bad0e64.tar.gz
 bg-space==0.6.0
 certifi==2022.12.7
 charset-normalizer==2.1.1

--- a/envs/requirements_py36
+++ b/envs/requirements_py36
@@ -6,7 +6,7 @@ apptools==5.1.0
 async-timeout==4.0.2
 asynctest==0.13.0
 attrs==21.4.0
-bg-atlasapi @ git+https://github.com/brainglobe/bg-atlasapi.git@cc980143c88e71202d09cbbd0f1bcfa491ea759d
+bg-atlasapi @ https://github.com/brainglobe/bg-atlasapi/archive/dbecd16b2f63a8e167543f3358452a756bad0e64.tar.gz
 bg-space==0.6.0
 boto3==1.23.10
 botocore==1.26.10

--- a/envs/requirements_py37
+++ b/envs/requirements_py37
@@ -6,7 +6,7 @@ apptools==5.2.0
 async-timeout==4.0.2
 asynctest==0.13.0
 attrs==22.1.0
-bg-atlasapi @ https://github.com/brainglobe/bg-atlasapi/archive/refs/heads/master.zip
+bg-atlasapi @ https://github.com/brainglobe/bg-atlasapi/archive/dbecd16b2f63a8e167543f3358452a756bad0e64.tar.gz
 bg-space==0.6.0
 boto3==1.24.93
 botocore==1.27.93

--- a/setup.py
+++ b/setup.py
@@ -85,8 +85,9 @@ config = {
         "imagecodecs",
         # part of stdlib in Python >= 3.7
         "dataclasses ; python_version < '3.7'",
-        # BrainGlobe dependencies for access to cloud-hosted atlases
-        "bg-atlasapi @ https://github.com/brainglobe/bg-atlasapi/archive/refs/heads/master.zip",
+        # BrainGlobe dependencies for access to cloud-hosted atlases, pinned
+        # to last commit supporting Python >= 3.6
+        "bg-atlasapi @ https://github.com/brainglobe/bg-atlasapi/archive/dbecd16b2f63a8e167543f3358452a756bad0e64.tar.gz",
         "typing_extensions",
     ],
     "extras_require": {


### PR DESCRIPTION
Restore support for Python 3.6-3.7 by pinning to commit before the package requires Python >= 3.8. Also, fix the package requirements listing for Python 3.6 to not use Git, consistent with the other requirements listings.