### PR TITLE
Round up for customizing exports

### DIFF
--- a/clrstats/R/clrstats.R
+++ b/clrstats/R/clrstats.R
@@ -129,12 +129,18 @@ fitModel <- function(model, vals, genos, sides, ids=NULL) {
       lm.formula <- as.formula(form)
       fit <- lm(lm.formula)
       result.summary <- summary.lm(fit)
-      result <- result.summary$coefficients
+      result <- as.data.frame(result.summary$coefficients)
+      result$r.squared <- result.summary$r.squared
       
+      # store intercept coefficient
+      intercept.coef <- 0
       if (intercept) {
-        # remove first ("non-intercept") row
+        # extract intercept coefficient and remove its row so result only
+        # has main effect and interactions
+        intercept.coef <- fit$coefficients[1]
         result <- result[-(1:1), ]
       }
+      result$intercept <- intercept.coef
       
     } else if (model == kModel[3]) {
       # generalized estimating equations
@@ -209,6 +215,15 @@ fitModel <- function(model, vals, genos, sides, ids=NULL) {
   }
   coef.tab$P <- result[rows, 4]
   coef.tab$N <- length(vals)
+  
+  # transfer any additional stats to output table
+  extra.cols <- c("intercept", "r.squared")
+  for (col in extra.cols) {
+    if (col %in% colnames(result)) {
+      coef.tab[[col]] <- result[rows, col]
+    }
+  }
+  
   print(coef.tab)
   return(coef.tab)
 }

--- a/clrstats/R/clrstats.R
+++ b/clrstats/R/clrstats.R
@@ -112,18 +112,29 @@ fitModel <- function(model, vals, genos, sides, ids=NULL) {
       # linear regression
       # TODO: see whether need to factorize genos
       if (length(unique(genos)) < 2) {
-        lm.formula <- as.formula(vals ~ sides)
+        form <- "vals ~ sides"
       } else if (length(unique(sides)) < 2) {
-        lm.formula <- as.formula(vals ~ genos)
+        form <- "vals ~ genos"
       } else {
-        lm.formula <- as.formula(vals ~ genos * sides)
+        form <- "vals ~ genos * sides"
       }
+      
+      intercept <- config.env$Intercept
+      if (!intercept) {
+        # remove the implied intercept term
+        form <- paste0(form, " + 0")
+      }
+      
+      # perform linear regression
+      lm.formula <- as.formula(form)
       fit <- lm(lm.formula)
       result.summary <- summary.lm(fit)
       result <- result.summary$coefficients
       
-      # remove first ("non-intercept") row
-      result <- result[-(1:1), ]
+      if (intercept) {
+        # remove first ("non-intercept") row
+        result <- result[-(1:1), ]
+      }
       
     } else if (model == kModel[3]) {
       # generalized estimating equations
@@ -891,6 +902,8 @@ setupConfig <- function(name=NULL) {
     # region-ID map from MagellanMapper, which should contain all regions
     # including hierarchical/ontological ones
     config.env$Labels.Path <- "../region_ids.csv"
+    # include linear regression intercept term
+    config.env$Intercept <- TRUE
 
   } else if (endsWith(name, ".R")) {
     # load a profile file

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -34,7 +34,7 @@ Argument | Sub-argument | Function | Ver Added | Last updated
 `--labels` | `[path_ref="""] [level=0] [ID=0] [orig_colors=1] [symmetric_colors=1] [binary=<backround>,<foreground>] [translate_labels=<path>"] [translate_children=0]` | Atlas label settings; see `config.AtlasLabels`. <ul><li>`path_ref`: Path to the labels reference file. Should have at least these columns: `Region` or `id` for region IDs, and `RegionName` or `name` for corresponding names. Atlases generated in >=v1.5.0 with this flag will copy this file into the atlas directory so that this argument is not needed when loading the atlas and images registered to it.</li> <li>`level`: Ontology level. Structures in sub-levels will be grouped at this level for volume stats. | v1.0.0 | v1.0.0
 `--transform` | `[rotate=0] [flip_vert=0] [flip_horiz=0] [flip=axis] [rescale=0] [interpolation=1]` | Image transformations; see `config.Transforms`. <ul><li>`interpolation`: Interpolation order `n` for the main (intensity) image, where `n` is passed to the `order` argument in Scikit-image's [`transform.resize`](https://scikit-image.org/docs/dev/api/skimage.transform.html#skimage.transform.resize) function</li> <li>*Since [v1.6.0](#changes-in-magellanmapper-v16):* `flip`: Flip the selected axis, where `axis` = 0 for the z-axis, 1 for the y-axis, and 2 for the x-axis</li></ul> | v1.0.0 | v1.6.0
 `--reg_suffixes` | `[atlas=atlasVolume.mhd,...] [annotation=annotation.mhd,...] [borders=<path>]` | Suffixes of registered images to load; see `config.RegSuffixes` for suffixes used throughout the package. Atlases and regenerated and registered with output paths based on the path given by `--img` or `--prefix`. For example:<ul><li>"Base" path (from `--img` or `--prefix`): `/home/me/my_image`</li><li>Intensity/histology/"atlas" image: `/home/me/my_image_atlasVolume.nii.gz`</li><li>Annotation/labels image: `/home/me/my_image_annotation.nii.gz`</li><li>Other registered images, eg atlas edges: `/home/me/my_image_atlasEdge.nii.gz`</li></ul>To load intensity and annotations image: `./run.py --img /home/me/my_image --reg_suffixes atlasVolume.nii.gz annotation.nii.gz`. <ul><li>*Since [v1.5.0](#changes-in-magellanmapper-v15):* Suffixes can be also given as an absolute path, such as a labels image not registered to the main image.</li> <li>*Since [v1.6.0](#changes-in-magellanmapper-v16):* Multiple labels suffixes can be given, separated by commas.</li></ul> | v1.0.0 | [v1.5.0](#changes-in-magellanmapper-v15)
-`--plot_labels` | `[title=<title>] ...` | Plot labels; see `config.PlotLabels` for available parameters. | v1.0.0 | v1.0.0
+`--plot_labels` | `[title=<title>] [err_col_abs=<col>] [background=<color>] [vspan_col=<col>] [vspan_format=<str>] [rotation=<deg>] ...` | Plot labels; see `config.PlotLabels` for available parameters.<ul><li>*Since [v1.6.0](#changes-in-magellanmapper-v16):* Added several new sub-arguments.</li></ul> | v1.0.0 | [v1.6.0](#changes-in-magellanmapper-v16)
 `--set_meta` | `[resolutions=<x,y,z>] [magnification=<n>] [zoom=<n>] [shape=<c,x,y,z,...>] [dtype=<data-type>]` | Metadata to set when importing an image; see `config.MetaKeys`. | v1.0.0 | [v1.3.0](#changes-in-magellanmapper-v13)
 `--plane` | `<xy\|xz\|yz>` | Transpose to the given planar orientation | v1.0.0 | v1.0.0
 `--show` | `<0\|1>` | Show images after generating them in atlas pipelines. `0` to not show, `1` to show. | v1.0.0 | [v1.3.0](#changes-in-magellanmapper-v13)
@@ -53,10 +53,14 @@ Argument | Sub-argument | Function | Ver Added | Last updated
 
 Old | New | Version | Purpose of Change |
 --- | --- | --- | ---
-None | `--rgb` | v1.6.0 | Open images in RGB(a) mode.
-`--ref_suffixes annotation=` | `--transform [flip=axis] ...` | v1.6.0 | Flip the specified axis.
-`--transform ...` | `--transform [interpolation=n] ...` | v1.6.0 | Interpolation order can be specified when exporting the main image.
-`--transform ...` | `--transform [flip=axis] ...` | v1.6.0 | Flip the specified axis.
+None | `--rgb` | v1.6a1 | Open images in RGB(a) mode.
+`--plot_labels ...` | `--plot_labels err_col_abs=<col> ...` | v1.6a1 | Plot error bars with a column of absolute rather than relative values, now that Clrstats gives absolute values for effect sizes.
+` ` |  `--plot_labels background=<color>` | v1.6a1 | Change plot background color with a Matplotlib color string.
+` ` |  `--plot_labels vspan_col=<col> vspan_format=<str>` | v1.6a1 | Column denoting vertical span groups and string format for them, respectively.
+` ` |  `--plot_labels rotation=<deg>` | v1.6a2 | Change rotation in degrees.
+`--ref_suffixes annotation=` | `--transform [flip=axis] ...` | v1.6a1 | Flip the specified axis.
+`--transform ...` | `--transform [interpolation=n] ...` | v1.6a1 | Interpolation order can be specified when exporting the main image.
+`--transform ...` | `--transform [flip=axis] ...` | v1.6a1 | Flip the specified axis.
 
 ## Changes in MagellanMapper v1.5
 

--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -110,8 +110,8 @@
 
 #### I/O
 
-- Images can be viewed as RGB(A) using the `RGB` button or the `--rgb` CLI argument (#142)
-- EXPERIMENTAL: Some TIF files can be loaded directly, without importing the file first (#90, #213, #242)
+- Images can be viewed and exported as RGB(A) using the `RGB` button or the `--rgb` CLI argument (#142, #445)
+- EXPERIMENTAL: Some TIF files can be loaded directly, without importing the file first (#90, #213, #242, #445)
 - The `--proc export_planes` task can export a subset of image planes specified by `--slice`, or an ROI specified by `--offset` and `--size`
 - Image metadata is stored in the `Image5d` image object (#115)
 - Better 2D image support
@@ -119,6 +119,7 @@
   - Unit factor conversions adapts to image dimensions (eg 2D vs 3D) (#132)
   - Fixed ROI padding during blob verification and match-based colocalization for 2D images (#380)
 - Multiple multiplane image files can be selected directly instead of relying on file auto-detection (#201)
+- `openpyxl` package is now optional during region export (#445)
 - Fixed re-importing an image after loading it (#117)
 - Fixed to store the image path when loading a registered image as the main image, which fixes saving the experiment name used when saving blobs (#139)
 
@@ -132,7 +133,9 @@
   - `--plot labels err_col_abs=<col>`: plot error bars with a column of absolute rather than relative values, now that Clrstats gives absolute values for effect sizes
   - `--plot_labels background=<color>`: change plot background color with a Matplotlib color string
   - `--plot_labels vspan_col=<col> vspan_format=<str>`: column denoting vertical span groups and string format for them, respectively (#135, 137)
+  - `--plot_labels rotation=<deg>`: change rotation in degrees (#445)
 - The figure save wrapper (`plot_support.save_fig`) is more flexible (#215)
+- 2D plots can be set not to save (#445)
 - Discrete colormaps can use [Matplotlib named colors](https://matplotlib.org/stable/gallery/color/named_colors.html) and use them for symmetric colors (#226)
 - Fixed errors when generating labels difference heat maps, and conditions can be set through `--plot_labels condition=cond1,cond2,...` (#132)
 - Fixed alignment of headers and columns in data frames printed to console (#109)
@@ -148,6 +151,7 @@
 - The labels reference path has been moved to an environment variable, which can be configured through `--labels <path>` (#147)
 - The Shapiro-Wilks test has been implemented in `meansModel` for consistent table output (#164)
 - A basic `NAMESPACE` file is provided to fix installation and exporting functions (#303)
+- Linear regression intercept term can be toggled using the `Intercept` environment field, and r<sup>2</sup> and intercept are exported (#445)
 - Fixed t-test, which also provides Cohen's d as a standardized effect size through the `effectsize` package (#135)
 - Fixed jitter plot box plots to avoid covering labels (#147)
 - Fixed model fitting (#240, #304)

--- a/magmap/io/export_regions.py
+++ b/magmap/io/export_regions.py
@@ -96,8 +96,12 @@ def export_region_ids(labels_ref_lookup, path, level=None,
     if rgbs is not None:
         df = df.style.apply(color_cells, subset="RGB")
     path_xlsx = "{}.xlsx".format(os.path.splitext(path)[0])
-    df.to_excel(path_xlsx)
-    print("exported regions to styled spreadsheet: \"{}\"".format(path_xlsx))
+    try:
+        df.to_excel(path_xlsx)
+        _logger.info("Exported regions to styled spreadsheet: %s", path_xlsx)
+    except ModuleNotFoundError:
+        raise ModuleNotFoundError(
+            config.format_import_err("openpyxl", task="formatting Excel files"))
     return df
 
 

--- a/magmap/io/export_stack.py
+++ b/magmap/io/export_stack.py
@@ -531,6 +531,7 @@ def stack_to_img(paths, roi_offset, roi_size, series=None, subimg_offset=None,
     collage = num_paths > 1
     figs = {}
     
+    path_base = paths[0]
     for i in range(nrows):
         for j in range(ncols):
             n = i * ncols + j
@@ -542,6 +543,10 @@ def stack_to_img(paths, roi_offset, roi_size, series=None, subimg_offset=None,
             # TODO: test directory of images
             # TODO: consider not reloading first image
             np_io.setup_images(path_sub, series, subimg_offset, subimg_size)
+            if config.img5d.img_io is config.LoadIO.TIFFFILE:
+                # remove extension from TIF files, which needed ext to load
+                path_base = libmag.get_filename_without_ext(path_base)
+            
             stacker = setup_stack(
                 config.image5d, path_sub, offset=roi_offset,
                 roi_size=roi_size, slice_vals=config.slice_vals, 
@@ -590,7 +595,6 @@ def stack_to_img(paths, roi_offset, roi_size, series=None, subimg_offset=None,
                 for fig_dict, img in zip(figs.values(), plotted_imgs):
                     fig_dict["imgs"].append(img)
     
-    path_base = paths[0]
     for planei, fig_dict in figs.items():
         if animated:
             # generate animated image (eg animated GIF or movie file)

--- a/magmap/plot/plot_2d.py
+++ b/magmap/plot/plot_2d.py
@@ -1047,7 +1047,8 @@ def plot_swarm(
     """
     
     if sns is None:
-        raise ImportError(config.format_import_err("seaborn", task="swarm plots"))
+        raise ImportError(
+            config.format_import_err("seaborn", task="swarm plots"))
     
     df_vspan = df
     if x_order is not None:
@@ -1143,7 +1144,8 @@ def plot_catplot(
     """
     
     if sns is None:
-        raise ImportError("Seaborn is required for swarm plots, please install")
+        raise ImportError(
+            config.format_import_err("seaborn", task="category plots"))
 
     if kwargs_plot is None:
         kwargs_plot = {}

--- a/magmap/plot/plot_2d.py
+++ b/magmap/plot/plot_2d.py
@@ -1394,7 +1394,8 @@ def post_plot(ax, out_path=None, save_ext=None, show=False):
 
 def main(
         ax: Optional["axes.Axes"] = None, df: Optional[pd.DataFrame] = None,
-        kwargs_plot: Optional[Dict[str, Any]] = None, **kwargs):
+        kwargs_plot: Optional[Dict[str, Any]] = None, save: bool = True,
+        **kwargs):
     """Perform 2D plot tasks.
     
     Args:
@@ -1402,6 +1403,7 @@ def main(
         df: Data frame; defaults to None.
         kwargs_plot: Dictionary of args to the underlying plot function;
             defaults to None.
+        save: True (default) to save plot.
         kwargs: Additional args to :meth:`decorate_plot`.
     
     Returns:
@@ -1553,9 +1555,8 @@ def main(
     if ax is not None:
         # perform plot post-processing tasks, including file save unless
         # savefig is None
-        post_plot(
-            ax, libmag.make_out_path(base_out_path), config.savefig,
-            config.show)
+        out_path = libmag.make_out_path(base_out_path) if save else None
+        post_plot(ax, out_path, config.savefig, config.show)
     
     return ax
 

--- a/magmap/plot/plot_2d.py
+++ b/magmap/plot/plot_2d.py
@@ -1009,7 +1009,8 @@ def plot_swarm(
         col_vspan: Optional[str] = None, vspan_fmt: Optional[str] = None,
         size: Optional[Sequence[float]] = None,
         ax: Optional["axes.Axes"] = None, rotation: Optional[float] = None,
-        **kwargs) -> "axes.Axes":
+        legend_title: Optional[str] = None,
+        kwargs_plot: Optional[Dict[str, Any]] = None, **kwargs) -> "axes.Axes":
     """Generate a swarm/jitter plot in Seaborn.
     
     Supports x-axis scaling and vertical spans.
@@ -1036,6 +1037,9 @@ def plot_swarm(
         ax: Matplotlib axes; defaults to None.
         rotation: x-axis ttext angle rotation in degrees. Defaults to None,
             which will rotate by 45 degrees.
+        legend_title: Legened title; defaults to None.
+        kwargs_plot: Dictionary of arguments to :meth:`sns.swarmplot`; defaults
+            to None.
         **kwargs: Additional arguments, passed to :meth:`decorate_plot`.
 
     Returns:
@@ -1049,6 +1053,9 @@ def plot_swarm(
     if sns is None:
         raise ImportError(
             config.format_import_err("seaborn", task="swarm plots"))
+    
+    if kwargs_plot is None:
+        kwargs_plot = {}
     
     df_vspan = df
     if x_order is not None:
@@ -1073,7 +1080,7 @@ def plot_swarm(
     # plot in seaborn
     ax = sns.swarmplot(
         x=x_cols, y=y_cols, hue=group_col, hue_order=legend_names,
-        order=x_order, data=df, ax=ax)
+        order=x_order, data=df, ax=ax, **kwargs_plot)
     
     # scale x-axis ticks and rotate labels
     if rotation is None:
@@ -1085,7 +1092,7 @@ def plot_swarm(
         # make legend translucent in case it overlaps points and remove
         # legend title
         legend.get_frame().set(alpha=0.5)
-        legend.set_title(None)
+        legend.set_title(legend_title if legend_title else None)
 
     if col_vspan is not None:
         # add vertical spans
@@ -1526,10 +1533,12 @@ def main(
 
     elif plot_2d_type is config.Plot2DTypes.SWARM_PLOT:
         # swarm/jitter plot
+        df_plot = pd.read_csv(config.filename) if df is None else df
         ax = plot_swarm(
-            pd.read_csv(config.filename), x_cols, data_cols, config.groups,
+            df_plot, x_cols, data_cols, config.groups,
             group_col, x_lbl, y_lbl, x_unit, y_unit, legend_names, col_vspan,
-            vspan_fmt, size, title=title, rotation=rotation)
+            vspan_fmt, size, ax=ax, title=title, rotation=rotation,
+            kwargs_plot=kwargs_plot, **kwargs)
         base_out_path = "swarm"
     
     elif plot_2d_type is config.Plot2DTypes.CAT_PLOT:

--- a/magmap/plot/plot_2d.py
+++ b/magmap/plot/plot_2d.py
@@ -1007,7 +1007,9 @@ def plot_swarm(
         x_unit: Optional[str] = None, y_unit: Optional[str] = None,
         legend_names: Optional[Sequence[str]] = None,
         col_vspan: Optional[str] = None, vspan_fmt: Optional[str] = None,
-        size=None, ax=None, **kwargs) -> "axes.Axes":
+        size: Optional[Sequence[float]] = None,
+        ax: Optional["axes.Axes"] = None, rotation: Optional[float] = None,
+        **kwargs) -> "axes.Axes":
     """Generate a swarm/jitter plot in Seaborn.
     
     Supports x-axis scaling and vertical spans.
@@ -1032,6 +1034,8 @@ def plot_swarm(
         vspan_fmt: Vertical span label string format; defaulst to None.
         size: Figure size in ``width, height`` as inches; defaults to None.
         ax: Matplotlib axes; defaults to None.
+        rotation: x-axis ttext angle rotation in degrees. Defaults to None,
+            which will rotate by 45 degrees.
         **kwargs: Additional arguments, passed to :meth:`decorate_plot`.
 
     Returns:
@@ -1071,7 +1075,9 @@ def plot_swarm(
         order=x_order, data=df, ax=ax)
     
     # scale x-axis ticks and rotate labels
-    plot_support.scale_xticks(ax, 45)
+    if rotation is None:
+        rotation = 45
+    plot_support.scale_xticks(ax, rotation)
     
     legend = ax.get_legend()
     if legend:
@@ -1417,6 +1423,7 @@ def main(
     hline = config.plot_labels[config.PlotLabels.HLINE]
     col_vspan = config.plot_labels[config.PlotLabels.VSPAN_COL]
     vspan_fmt = config.plot_labels[config.PlotLabels.VSPAN_FORMAT]
+    rotation = config.plot_labels[config.PlotLabels.ROTATION]
     
     # base output path for tasks that defer saving to post_plot
     base_out_path = None
@@ -1433,7 +1440,8 @@ def main(
             size=size, show=False, groups=config.groups,
             col_vspan=col_vspan, vspan_fmt=vspan_fmt,
             prefix=config.prefix, save=False,
-            col_wt=col_wt, x_tick_labels=x_tick_lbls, rotation=45,
+            col_wt=col_wt, x_tick_labels=x_tick_lbls,
+            rotation=45 if rotation is None else rotation,
             err_cols_abs=err_col_abs)
     
     elif plot_2d_type is config.Plot2DTypes.BAR_PLOT_VOLS_STATS_EFFECTS:
@@ -1519,7 +1527,7 @@ def main(
         ax = plot_swarm(
             pd.read_csv(config.filename), x_cols, data_cols, config.groups,
             group_col, x_lbl, y_lbl, x_unit, y_unit, legend_names, col_vspan,
-            vspan_fmt, size, title=title)
+            vspan_fmt, size, title=title, rotation=rotation)
         base_out_path = "swarm"
     
     elif plot_2d_type is config.Plot2DTypes.CAT_PLOT:

--- a/magmap/settings/config.py
+++ b/magmap/settings/config.py
@@ -369,6 +369,8 @@ class PlotLabels(Enum):
     VSPAN_FORMAT = auto()
     #: Background color as a Matplotlib or RGBA string.
     BACKGROUND = auto()
+    #: Rotation angle in degrees.
+    ROTATION = auto()
 
 
 #: dict[Any]: Plot labels set from command-line.


### PR DESCRIPTION
Various fixes and small enhancements for data export:
- The `openpyxl` package is now optional for region CSV file export
- `--plot_labels rotation=<deg>` sub-argument to specify label rotation for 2D plots, supported in swarm and bar plot x-labels
- Options not to save 2D plots and to further customize swarm plots
- Stack export supports RGB images and removes TIF file extensions
- Blob verification matches logging is more readable
- Clrstats linear regression intercept term can be toggled via the new `config.env$Intercept <- FALSE` setting
- Easier to extract more stats from R models, such as `r<sup>2</sup>` and intercepts in linear regressions