### PR TITLE
Fix blobs column setup for archives without columns metadata

### DIFF
--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -81,12 +81,12 @@
 
 ##### Detection
 
-- Detection channels can be selected, including those not in the currently displayed image or loaded from a saved blobs file (#121)
+- Detection channels can be selected, including those not in the currently displayed image or loaded from a saved blobs file (#121, #449)
 - Auto-scrolls the detections table to the selected annotation (#109)
 - `ctrl+[n]+click` to add a channel now sets the channel directly to `n` rather than to the `n`th seleted channel (#109)
 - Added a slider to choose the fraction of 3D blobs to display (#121)
 - Improved blob size slider range and readability (#121)
-- Blob columns can be customized, including excluding or reordering columns (#133, #216)
+- Blob columns can be customized, including excluding or reordering columns (#133, #216, #449)
 - Existing blob archives are backed up before saving (#216) 
 - Fixed to scale blobs' radii when viewing blobs detections on a downsampled image (#121)
 - Fixed getting atlas colors for blobs for ROIs inside the main image (#121)

--- a/magmap/cv/detector.py
+++ b/magmap/cv/detector.py
@@ -215,6 +215,10 @@ class Blobs:
         """
         if to_add is None:
             # save current attributes
+            
+            # filter out column indices that are None
+            col_inds = {k: v for k, v in self.col_inds.items() if v is not None}
+            
             blobs_arc = {
                 Blobs.Keys.VER.value: self.ver,
                 Blobs.Keys.BLOBS.value: self.blobs,
@@ -227,7 +231,7 @@ class Blobs:
                 # save columns ordered by the col indices
                 Blobs.Keys.COLS.value: [
                     k.value for k, v in sorted(
-                        self.col_inds.items(), key=lambda e: e[1])],
+                        col_inds.items(), key=lambda e: e[1])],
             }
         else:
             blobs_arc = to_add

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -2505,10 +2505,14 @@ class Visualization(HasTraits):
         self.blobs.blob_matches = blob_matches
         cli.update_profiles()
         
-        # get selected channels for blob detection; must have at least 1
+        # get selected channels for blob detection
         chls = sorted([int(n) for n in self._segs_chls])
         if len(chls) == 0:
-            self.segs_feedback = "Please select a channel for blob detection"
+            # provide feedback if no channels are selected and return
+            self.segs_feedback = "Please select channels for blob detection"
+            msg = "Please select channels in the Detect tab to show blobs"
+            self.update_status_bar_msg(msg)
+            self._update_roi_feedback(msg)
             return
         
         # process ROI in prep for showing filtered 2D view and segmenting


### PR DESCRIPTION
Blobs archives added a metadata field for columns to indicate which columns are included in the archive (blobs format v4). Older archives without this metadata have been loaded as if they contained all columns, even though they often do not. This PR couples blob and blob column name attributes to ensure that blobs and column names are set together. Column names default to the fit the number of columns in the blobs array.