### PR TITLE
Fix image opacity when scrolling through planes

### DIFF
--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -38,7 +38,7 @@
 - Atlas Editor planes can be reordered or turned off (#180)
 - EXPERIMENTAL: New viewer that displays each blob separately to verify blob classifications (#193)
 - Image adjustment
-  - "Blend" option in the image adjustment panel to visualize alignment in overlaid images (#89)
+  - "Blend" option in the image adjustment panel to visualize alignment in overlaid images (#89, #450)
   - Image adjustment channels are radio buttons for easier selection (#212)
   - Fixed synchronization between the ROI Editor and image adjustment controls after initialization (#142)
 - Smoother, faster interactions with main plots, including atlas label name display, label editing, and pan and zoom navigation (#317, #335, #359, #367)

--- a/magmap/gui/plot_editor.py
+++ b/magmap/gui/plot_editor.py
@@ -501,6 +501,7 @@ class PlotEditor:
         self._channels = [config.channel]
         cmaps = [config.cmaps]
         alphas = [config.alphas[0]]
+        alpha_is_default = True
         alpha_blends = [None]
         shapes = [self._img3d_shapes[0][1:3]]
         vmaxs = [None]
@@ -517,6 +518,7 @@ class PlotEditor:
             
             # use opacity, brightness, anc contrast from prior images
             alphas[0] = [p.alpha for p in self._plot_ax_imgs[0]]
+            alpha_is_default = False
             alpha_blends[0] = [p.alpha_blend for p in self._plot_ax_imgs[0]]
             brightnesses[0] = [p.brightness for p in self._plot_ax_imgs[0]]
             contrasts[0] = [p.contrast for p in self._plot_ax_imgs[0]]
@@ -630,8 +632,13 @@ class PlotEditor:
                         plot_ax_img, libmag.get_if_within(brightnesses[i], j),
                         libmag.get_if_within(contrasts[i], j))
                 
+                # get alpha from image if default since image overlayer scales
+                # the default alpha for each channel
+                plot_ax_img.alpha = (
+                    plot_ax_img.ax_img.get_alpha() if alpha_is_default
+                    else libmag.get_if_within(alphas[i], j))
+                
                 # store rest of settings
-                plot_ax_img.alpha = libmag.get_if_within(alphas[i], j)
                 plot_ax_img.alpha_blend = libmag.get_if_within(
                     alpha_blends[i], j)
                 plot_ax_img.rgb = self.overlayer.rgb


### PR DESCRIPTION
The image opacity is typically generated from the image overlayer for multichannel images. This opacity displays correctly when first loading an image but is lost when scrolling through planes in the image, instead making all images fully opaque. This PR fixes the opacity by getting the alpha value from the displayed image in these cases.