### PR TITLE
Support selecting specific channels for match-based colocalization

### DIFF
--- a/bin/sample_cmds_bash.ipynb
+++ b/bin/sample_cmds_bash.ipynb
@@ -28,9 +28,15 @@
    ]
   },
   {
-   "cell_type": "raw",
+   "cell_type": "code",
+   "execution_count": null,
    "id": "5ff91655-82d3-4007-8854-fda802a298b9",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
+   "outputs": [],
    "source": [
     "pip install jupyterlab\n",
     "pip install bash_kernel\n",
@@ -46,9 +52,15 @@
    ]
   },
   {
-   "cell_type": "raw",
+   "cell_type": "code",
+   "execution_count": null,
    "id": "f28f8b69-fd31-4922-b371-a8e4edfa782d",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
+   "outputs": [],
    "source": [
     "jupyter-lab"
    ]
@@ -519,6 +531,63 @@
     "### Build and test ground truth sets\n",
     "\n",
     "TODO"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "ce3ca4c9",
+   "metadata": {},
+   "source": [
+    "### Channel colocalization\n",
+    "\n",
+    "Blobs detected in several channels may represent the same cells. To find which blobs are colocalized across channels, MagellanMapper offers several colocalization detection methods:\n",
+    "* Intensity-based colocalization\n",
+    "* Match-based colocalization\n",
+    "\n",
+    "#### Intensity-based colocalization\n",
+    "\n",
+    "For each blob detected in one channel, the corresponding positions are checked in all remaining channels. Channels above threshold at that position are considered to be colocalized with the blob. This process is performed during blob detection since it uses the same preprocessed versions of the image."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f4cba0b3",
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "mm \"$img\" --proc detect_coloc --roi_profile lightsheet"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "8a935d2b",
+   "metadata": {},
+   "source": [
+    "#### Match-based colocalization\n",
+    "\n",
+    "After detecting blobs in each channel, blobs in one channel are paired with blobs in another channel. Matches are optimized by distance to maximize the number of pairs. This approach does not rely on thresholding and be performed after the detection step.\n",
+    "\n",
+    "The ROI profile specifies the block sizes used for colocalization. Only the first ROI parameter will be used (ie for channel 0). Relevant parameters are:\n",
+    "* `segment_size`: adjusts block size, where larger blocks reduce the number of blocks to process but require more memory\n",
+    "* `prune_tol_factor`: adjusts the overlap between blocks\n",
+    "* `verify_tol_factor`: tolerance for a match, where larger values allow blobs farther apart to be considered matches\n",
+    "* `resize_blobs`: rescales blob coordinates, which may be important for anisotropic images"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "ed0c16b6",
+   "metadata": {},
+   "source": [
+    "mm \"$img\" --proc coloc_match --roi_profile lightsheet"
    ]
   },
   {

--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -98,6 +98,7 @@
 
 - Match-based colocalization can run without the main image, using just its metadata instead (#117)
 - These colocalizations are now displayed in the 3D viewer (#121)
+- Specific match-based colocalizations channels can be set, eg `--channels 0 2` (#451)
 - Fixed match-based colocalizations when no matches are found (#117, #120)
 - Fixed slow loading of match-based colocalizations (#119, #123)
 

--- a/magmap/cv/colocalizer.py
+++ b/magmap/cv/colocalizer.py
@@ -451,6 +451,8 @@ def colocalize_blobs_match(
         tol: Tolerances for matching given as x,y,z
         inner_padding: ROI padding given as x,y,z; defaults
             to None to use the padding based on ``tol``.
+        channels: Indices of channels to colocalize. Defaults to None, which
+            will use all channels in ``blobs``.
 
     Returns:
         Dictionary where keys are tuples of the two channels compared and
@@ -464,9 +466,13 @@ def colocalize_blobs_match(
     if inner_padding is None:
         inner_padding = inner_pad
     matches_chls = {}
+    
+    # get channels in blobs
     blob_chls = np.unique(blobs.get_blobs_channel(blobs_roi)).astype(int)
     if channels is not None:
+        # filter blob channels to only include specified channels
         blob_chls = [c for c in blob_chls if c in channels]
+    
     for chl in blob_chls:
         # pair channels
         blobs_chl = blobs.blobs_in_channel(blobs_roi, chl)
@@ -486,6 +492,7 @@ def colocalize_blobs_match(
             matches.update_blobs(blobs.set_blob_truth, -1)
             matches.update_blobs(blobs.set_blob_confirmed, -1)
             matches_chls[chl_combo] = matches
+    
     return matches_chls
 
 

--- a/magmap/cv/verifier.py
+++ b/magmap/cv/verifier.py
@@ -91,14 +91,16 @@ def find_closest_blobs_cdist(
         
         if config.verbose:
             # show matches using original blob coordinates
+            i = -1
             for i, (blob, blob_base, dist_in) in enumerate(zip(
                     blobs[rowis], blobs_master[colis], dists_in)):
                 _logger.debug(
                     "%s: Detected blob: %s, truth blob: %s, in? %s",
                     i, blob[:3], blob_base[:3], dist_in)
-            _logger.debug("")
+            if i >= 0: _logger.debug("")
             
             # show corresponding scaled coordinates and distances
+            i = -1
             for i, (blob_sc, blob_base_sc, dist, dist_in) in enumerate(zip(
                     blobs_scaled[rowis], blobs_master_scaled[colis],
                     dists_closest, dists_in)):
@@ -108,7 +110,7 @@ def find_closest_blobs_cdist(
                     "  %s (detected)", blob_sc[:3])
                 _logger.debug(
                     "  %s (truth)", blob_base_sc[:3])
-            _logger.debug("")
+            if i >= 0: _logger.debug("")
         
         rowis = rowis[dists_in]
         colis = colis[dists_in]

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -2542,8 +2542,8 @@ class Visualization(HasTraits):
                     detector.calc_overlap(),
                     config.roi_profile["verify_tol_factor"])
                 matches = colocalizer.colocalize_blobs_match(
-                    segs_all, np.zeros(3, dtype=int), roi_size, verify_tol,
-                    np.zeros(3, dtype=int))
+                    detector.Blobs(segs_all), np.zeros(3, dtype=int), roi_size,
+                    verify_tol, np.zeros(3, dtype=int))
                 if matches and len(matches) > 0:
                     # TODO: include all channel combos
                     self.blobs.blob_matches = matches[tuple(matches.keys())[0]]

--- a/magmap/io/cli.py
+++ b/magmap/io/cli.py
@@ -1256,7 +1256,7 @@ def process_file(
                 else:
                     shape = config.img5d.meta[config.MetaKeys.SHAPE][1:]
             matches = colocalizer.StackColocalizer.colocalize_stack(
-                shape, config.blobs)
+                shape, config.blobs, config.channel)
             # insert matches into database
             colocalizer.insert_matches(config.db, matches)
         else:

--- a/magmap/io/cli.py
+++ b/magmap/io/cli.py
@@ -1256,7 +1256,7 @@ def process_file(
                 else:
                     shape = config.img5d.meta[config.MetaKeys.SHAPE][1:]
             matches = colocalizer.StackColocalizer.colocalize_stack(
-                shape, config.blobs.blobs)
+                shape, config.blobs)
             # insert matches into database
             colocalizer.insert_matches(config.db, matches)
         else:


### PR DESCRIPTION
Match-based blob colocalization has run separate colocalizations for each pair of channels in the blobs archive, but one may wish to colocalize only select channels. This PR:
- Supports the `--channel <n> <n1> ...` CLI argument to specify the channels to colocalize. Note that all pairs within the given channels will be run.
- Refactored these colocalization functions to use the `Blobs` class as part of our ongoing effort to use pass these objects instead of just blobs array so as to include additional metadata
- Added Notebook docs on running colocalizations