### PR TITLE
Change shortcut for jumping to plane in ROI

### DIFF
--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -53,6 +53,7 @@
 - Fixed clearing the import path (#201)
 - Fixed saving additional, old figures when using the save shortcut (#256)
 - Fixed lag in zoom direction change (#359)
+- Fixed conflict between shortcut to add blob and jumping to ROI plane (`ctrl+click`) by changing the jump shortcut to `j+click` (#456)
 
 #### CLI
 

--- a/docs/viewers.md
+++ b/docs/viewers.md
@@ -11,7 +11,7 @@ The multi-level 2D plotter is geared toward simplifying annotation for nuclei or
 | To Do...        | Shortcut            |
 | ---------------- | :------------------: |
 | Increase/decrease the overview plots' z-plane | Arrow `up/right` to increase and `down/left` to decrease |
-| Jump to a z-plane in the overview plots corresponding to an ROI plane | `Right-click` on the the corresponding ROI plane |
+| Jump to a z-plane in the overview plots corresponding to an ROI plane | `"j"+click` on the the corresponding ROI plane |
 | Preview the ROI at a certain position | `Left-click` in the overview plot |
 | Redraw the editor at the chosen ROI settings | Double `right-click` in any overview plot |
 


### PR DESCRIPTION
The shortcut has been to right-click on the ROI plane, but control-left-click can emulate a right-click, which conflicts with the same shortcut used to add a blob.

This PR changes the shortcut to "j"-left-click for "jump." Although this shortcut may not be as memorable, it is also less likely used since mouse scrolling and the arrow keys also control ROI plane scrolling. By preventing accidental jumping, the ROI is less likely to shift unexpectedly when viewing the next ROI.