### PR TITLE
Roundup to make 2D plot tasks and registration post-processing more accessible

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -23,7 +23,7 @@ Argument | Sub-argument | Function | Ver Added | Last updated
 `--proc` | `<task1>=[sub-task1,...] <task2>` | Image processing tasks; see `config.ProcessTypes` | v1.0.0 | [v1.5.0](#changes-in-magellanmapper-v15)
 `--register` | `<task>` | Registration and other atlas-related tasks; see `config.RegisterTypes` | v1.0.0 | [v1.4.0](#changes-in-magellanmapper-v14)
 `--df` | `<task>` | Pandas data frame tasks; see `config.DFTasks` | v1.0.0 | [v1.3.0](#changes-in-magellanmapper-v13)
-`--plot_2d` | `<task>` | 2D plot tasks; see `config.Plot2DTypes` | v1.0.0 | v1.0.0
+`--plot_2d` | `<task>` | 2D plot tasks; see `config.Plot2DTypes` | v1.0.0 | [v1.6.0](#changes-in-magellanmapper-v16)
 `--ec2_start` | `<tag_name> <ami_id> <instance_type> <subnet_id> <sec_group> <key_name> <ebs> <max_count> <snapshot_ids>` | Start an EC2 instance. | v1.0.0 | v1.0.0
 `--ec2_list` | `<state> <image_id>` | List EC2 instances. | v1.0.0 | v1.0.0
 `--ec2_terminate` | `<instance1> [instance2] ...` | Terminate EC2 instances by instance ID. | v1.0.0 | v1.0.0
@@ -54,6 +54,7 @@ Argument | Sub-argument | Function | Ver Added | Last updated
 Old | New | Version | Purpose of Change |
 --- | --- | --- | ---
 None | `--rgb` | v1.6a1 | Open images in RGB(a) mode.
+`--plot_2d ...` | `--plot_2d decorate_plot ...` | v1.6b1 | Task to add plot decorations such as title and axis labels.
 `--plot_labels ...` | `--plot_labels err_col_abs=<col> ...` | v1.6a1 | Plot error bars with a column of absolute rather than relative values, now that Clrstats gives absolute values for effect sizes.
 ` ` |  `--plot_labels background=<color>` | v1.6a1 | Change plot background color with a Matplotlib color string.
 ` ` |  `--plot_labels vspan_col=<col> vspan_format=<str>` | v1.6a1 | Column denoting vertical span groups and string format for them, respectively.

--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -136,6 +136,9 @@
   - `--plot_labels background=<color>`: change plot background color with a Matplotlib color string
   - `--plot_labels vspan_col=<col> vspan_format=<str>`: column denoting vertical span groups and string format for them, respectively (#135, 137)
   - `--plot_labels rotation=<deg>`: change rotation in degrees (#445)
+- 2D plot tasks
+  - `--plot_2d decorate_plot` to add plot decorations such as title and axis labels (#457)
+  - Tasks can be run programmatically as: `plot_2d.main(plot_2d_type=<config.Plot2DTypes>)` (#457)
 - The figure save wrapper (`plot_support.save_fig`) is more flexible (#215)
 - 2D plots can be set not to save (#445)
 - Discrete colormaps can use [Matplotlib named colors](https://matplotlib.org/stable/gallery/color/named_colors.html) and use them for symmetric colors (#226)

--- a/magmap/plot/plot_2d.py
+++ b/magmap/plot/plot_2d.py
@@ -1551,6 +1551,10 @@ def main(
             y_unit, legend_names, size, title, kwargs_plot=kwargs_plot,
             **kwargs)
         base_out_path = "catplot"
+        
+    elif plot_2d_type is config.Plot2DTypes.DECORATE_PLOT:
+        # decorate plot labels
+        ax = decorate_plot(ax, title, x_lbl, y_lbl, x_unit, y_unit, **kwargs)
 
     if ax is not None:
         # perform plot post-processing tasks, including file save unless

--- a/magmap/plot/plot_2d.py
+++ b/magmap/plot/plot_2d.py
@@ -1395,6 +1395,7 @@ def post_plot(ax, out_path=None, save_ext=None, show=False):
 def main(
         ax: Optional["axes.Axes"] = None, df: Optional[pd.DataFrame] = None,
         kwargs_plot: Optional[Dict[str, Any]] = None, save: bool = True,
+        plot_2d_type: Optional["config.Plot2DTypes"] = None,
         **kwargs):
     """Perform 2D plot tasks.
     
@@ -1404,16 +1405,21 @@ def main(
         kwargs_plot: Dictionary of args to the underlying plot function;
             defaults to None.
         save: True (default) to save plot.
+        plot_2d_type: Enum of plot type. If None (default),
+            :attr:`config.plot_2d_type` will be used.
         kwargs: Additional args to :meth:`decorate_plot`.
     
     Returns:
         The generated axes, or ``ax`` if given.
     
     """
+    if plot_2d_type is None:
+        # default to set task from config
+        plot_2d_type = libmag.get_enum(
+            config.plot_2d_type, config.Plot2DTypes)
+
     # collect config settings
     size = config.plot_labels[config.PlotLabels.SIZE]
-    plot_2d_type = libmag.get_enum(
-        config.plot_2d_type, config.Plot2DTypes)
     x_cols = config.plot_labels[config.PlotLabels.X_COL]
     data_cols = config.plot_labels[config.PlotLabels.Y_COL]
     annot_col = config.plot_labels[config.PlotLabels.ANNOT_COL]

--- a/magmap/settings/config.py
+++ b/magmap/settings/config.py
@@ -320,6 +320,8 @@ class Plot2DTypes(Enum):
     SWARM_PLOT = auto()
     #: Generate a category plot through Seaborn.
     CAT_PLOT = auto()
+    #: Decorate plot labels.
+    DECORATE_PLOT = auto()
     
 
 plot_2d_type = None


### PR DESCRIPTION
This PR is another round-up of changes, focused on programmatic access.

Plot decorations have been applied in most 2D plot tasks, but these labels may be lost when adding additional plots such as those from Seaborn. Add a task specifically to (re)decorate these labels.

Also, the 2D plot task has been set through `config`, typically as a CLI argument. Add a parameter in the main 2D plotting entry point to set this task through the API.

Image registration `register.curate_img` is now public to make this post-processing more accessible.