### PR TITLE
Adapt axes bounding box to rotated image

### DIFF
--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -42,6 +42,7 @@
   - "Blend" option in the image adjustment panel to visualize alignment in overlaid images (#89, #450)
   - Image adjustment channels are radio buttons for easier selection (#212)
   - Fixed synchronization between the ROI Editor and image adjustment controls after initialization (#142)
+- Images are rotated by dynamic transformation (#214, #471)
 - Smoother, faster interactions with main plots, including atlas label name display, label editing, and pan and zoom navigation (#317, #335, #359, #367)
 - Atlas labels adapt better in zoomed images to stay within each plot (#317)
 - Fixed to reset the ROI selector when redrawing (#115)

--- a/magmap/io/export_stack.py
+++ b/magmap/io/export_stack.py
@@ -267,6 +267,7 @@ class StackPlaneIO(chunking.SharedArrsContainer):
                 if libmag.is_seq(ax_img):
                     ax_img = ax_img[0]
                 if isinstance(ax_img, AxesImage):
+                    ax_img.axes.set_frame_on(False)
                     plot_support.fit_frame_to_image(
                         ax_img.figure, ax_img.get_array().shape, self.aspect)
         
@@ -650,6 +651,7 @@ def reg_planes_to_img(imgs, path=None, ax=None):
     plotted_imgs = stacker.build_stack(ax, scale_bar=False)
     ax_img = plotted_imgs[0][0]
     aspect, origin = plot_support.get_aspect_ratio(config.plane)
+    ax_img.axes.set_frame_on(False)
     plot_support.fit_frame_to_image(
         ax_img.figure, ax_img.get_array().shape, aspect)
     if path:

--- a/magmap/io/export_stack.py
+++ b/magmap/io/export_stack.py
@@ -269,7 +269,7 @@ class StackPlaneIO(chunking.SharedArrsContainer):
                 if isinstance(ax_img, AxesImage):
                     ax_img.axes.set_frame_on(False)
                     plot_support.fit_frame_to_image(
-                        ax_img.figure, ax_img.get_array().shape, self.aspect)
+                        ax_img.figure, None, self.aspect)
         
         return plotted_imgs
 

--- a/magmap/plot/plot_2d.py
+++ b/magmap/plot/plot_2d.py
@@ -1252,7 +1252,7 @@ def plot_image(img, path=None, show=False):
     # plot figure without frame, axes, or border space
     fig, gs = plot_support.setup_fig(1, 1)
     ax = fig.add_subplot(gs[0, 0])
-    plot_support.hide_axes(ax)
+    plot_support.hide_axes(ax, True)
     ax.imshow(img)
     plot_support.fit_frame_to_image(fig, img.shape, None)
     

--- a/magmap/plot/plot_support.py
+++ b/magmap/plot/plot_support.py
@@ -1035,7 +1035,8 @@ def scale_axes(ax, scale_x=None, scale_y=None):
 
 
 def fit_frame_to_image(
-        fig: "figure.Figure", shape: Sequence[int], aspect: Optional[float]):
+        fig: "figure.Figure", shape: Optional[Sequence[int]] = None,
+        aspect: Optional[float] = None):
     """Compress figure to fit image only.
 
     Use :attr:`config.plot_labels[config.PlotLabels.PADDING]` to configure
@@ -1043,10 +1044,18 @@ def fit_frame_to_image(
     
     Args:
         fig: Figure to compress.
-        shape: Shape of image to which the figure will be fit.
-        aspect: Aspect ratio of image.
+        shape: Shape of image to which the figure will be fit. Default of None
+            uses the first axes bounding box.
+        aspect: Aspect ratio of image. Default of None gives 1.
     
     """
+    axs = fig.axes
+    if shape is None and axs:
+        # default shape is bounding box of axes
+        shape = np.abs([
+            np.diff(axs[0].get_ylim())[0],
+            np.diff(axs[0].get_xlim())[0]])
+    
     pad = config.plot_labels[config.PlotLabels.PADDING]
     if aspect is None:
         aspect = 1

--- a/magmap/plot/plot_support.py
+++ b/magmap/plot/plot_support.py
@@ -11,7 +11,7 @@ from typing import Any, Callable, Dict, List, Optional, Sequence, \
     TYPE_CHECKING, Tuple, Union
 
 import numpy as np
-from matplotlib import backend_bases, gridspec, pyplot as plt
+from matplotlib import backend_bases, gridspec, layout_engine, pyplot as plt
 import matplotlib.transforms as transforms
 from skimage import filters, img_as_float32, transform
 
@@ -1034,36 +1034,42 @@ def scale_axes(ax, scale_x=None, scale_y=None):
         ax.set_yscale(scale_y)
 
 
-def fit_frame_to_image(fig, shape, aspect):
+def fit_frame_to_image(
+        fig: "figure.Figure", shape: Sequence[int], aspect: float):
     """Compress figure to fit image only.
 
     Use :attr:`config.plot_labels[config.PlotLabels.PADDING]` to configure
-    figure padding, which will turn off the constrained layout.
+    figure padding. Negative padding may be required to remove a thin left
+    border that sometimes appears.
     
     Args:
         fig: Figure to compress.
         shape: Shape of image to which the figure will be fit.
         aspect: Aspect ratio of image.
+    
     """
     pad = config.plot_labels[config.PlotLabels.PADDING]
     if aspect is None:
         aspect = 1
     img_size_inches = np.divide(shape, fig.dpi)  # convert to inches
-    print("image shape: {}, img_size_inches: {}, aspect: {}"
-          .format(shape, img_size_inches, aspect))
+    
     if aspect > 1:
         fig.set_size_inches(img_size_inches[1], img_size_inches[0] * aspect)
     else:
         # multiply both sides by 1 / aspect => number > 1 to enlarge
         fig.set_size_inches(img_size_inches[1] / aspect, img_size_inches[0])
+    
     if pad:
-        # use neg padding to remove thin left border that sometimes appears;
-        # NOTE: this setting will turn off constrained layout
-        fig.tight_layout(pad=libmag.get_if_within(pad, 0, 0))
-    print("fig size: {}".format(fig.get_size_inches()))
+        # set padding in layout engine
+        engine = fig.get_layout_engine()
+        padding = libmag.get_if_within(pad, 0, 0)
+        if isinstance(engine, layout_engine.ConstrainedLayoutEngine):
+            engine.set(h_pad=padding, w_pad=padding)
+        else:
+            fig.tight_layout(pad=padding)
 
 
-def set_overview_title(ax, plane, z_overview, zoom="", level=0, 
+def set_overview_title(ax, plane, z_overview, zoom="", level=0,
                        max_intens_proj=False):
     """Set the overview image title.
     
@@ -1437,7 +1443,7 @@ def setup_fig(
         The figure and grid spec used for its layout.
 
     """
-    fig = plt.figure(frameon=False, constrained_layout=True, figsize=size)
+    fig = plt.figure(frameon=False, layout="constrained", figsize=size)
     fig.set_constrained_layout_pads(w_pad=0, h_pad=0)
     gs = gridspec.GridSpec(nrows, ncols, figure=fig)
     return fig, gs

--- a/magmap/plot/plot_support.py
+++ b/magmap/plot/plot_support.py
@@ -12,7 +12,12 @@ from typing import Any, Callable, Dict, List, Optional, Sequence, \
     TYPE_CHECKING, Tuple, Union
 
 import numpy as np
-from matplotlib import backend_bases, gridspec, layout_engine, pyplot as plt
+from matplotlib import backend_bases, gridspec, pyplot as plt
+try:
+    from matplotlib import layout_engine
+except ImportError as e:
+    # not available in Matplotlib on Python 3.6
+    layout_engine = None
 import matplotlib.transforms as transforms
 from skimage import filters, img_as_float32, transform
 
@@ -1123,7 +1128,8 @@ def fit_frame_to_image(
         # set padding in layout engine
         engine = fig.get_layout_engine()
         padding = libmag.get_if_within(pad, 0, 0)
-        if isinstance(engine, layout_engine.ConstrainedLayoutEngine):
+        if layout_engine is not None and isinstance(
+                engine, layout_engine.ConstrainedLayoutEngine):
             engine.set(h_pad=padding, w_pad=padding)
         else:
             fig.tight_layout(pad=padding)

--- a/magmap/plot/plot_support.py
+++ b/magmap/plot/plot_support.py
@@ -1035,12 +1035,11 @@ def scale_axes(ax, scale_x=None, scale_y=None):
 
 
 def fit_frame_to_image(
-        fig: "figure.Figure", shape: Sequence[int], aspect: float):
+        fig: "figure.Figure", shape: Sequence[int], aspect: Optional[float]):
     """Compress figure to fit image only.
 
     Use :attr:`config.plot_labels[config.PlotLabels.PADDING]` to configure
-    figure padding. Negative padding may be required to remove a thin left
-    border that sometimes appears.
+    figure padding.
     
     Args:
         fig: Figure to compress.


### PR DESCRIPTION
Fixes #452. 

Image rotation by affine transformations do not change the axes limits, which can crop images in some areas while leaving large gaps in others. Fixed here by adjusting the axes limits to fit a rotated image. For simplicity, the image is now rotated around the origin rather than the image center. The transformation is also no longer applied when no rotation is set.

This PR also includes additional fixes for fitting a figure frame to an image. Setting a tight layout in a figure that has been set to use a constrained layout leads to an error, for example when exporting a stack with a colorbar and setting a padding for the image. Fix here by setting the padding through the constrained layout engine if the figure has this engine.nn

Constrained layout also does not appear to allow negative padding to hide a border. As a fix and simplification, the axes frame is now removed when exporting an image plane, which also avoids the need to set the padding. Providing the image shape is also now optional when fitting a figure frame to its image, defaulting to use the bounding box of the first axes.