### PR TITLE
Position vertical span labels in axes coordinates

### DIFF
--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -144,6 +144,7 @@
 - The figure save wrapper (`plot_support.save_fig`) is more flexible (#215)
 - 2D plots can be set not to save (#445)
 - Discrete colormaps can use [Matplotlib named colors](https://matplotlib.org/stable/gallery/color/named_colors.html) and use them for symmetric colors (#226)
+- Vertical span labels adapt to the axes rather than data limits (#472)
 - Fixed errors when generating labels difference heat maps, and conditions can be set through `--plot_labels condition=cond1,cond2,...` (#132)
 - Fixed alignment of headers and columns in data frames printed to console (#109)
 

--- a/magmap/plot/plot_support.py
+++ b/magmap/plot/plot_support.py
@@ -1251,11 +1251,12 @@ def add_vspans(
     """
     # set up span x-val indices
     num_groups = len(ax.get_xticklabels())
-    xs = vspans - padding / 2
+    x_offset = padding / 2
+    xs = vspans - x_offset
     num_xs = len(xs)
     
     if vspans is not None:
-        # show vertical spans alternating in white and black; assume 
+        # show vertical spans alternating in white and black; assume
         # background is already white, so simply skip white shading
         for i, x in enumerate(xs):
             if i % 2 == 0: continue
@@ -1264,20 +1265,23 @@ def add_vspans(
 
     if vspan_lbls is not None:
         # show labels for vertical spans
-        ylims = ax.get_ylim()
-        y_span = abs(ylims[1] - ylims[0])
-        y_top = max(ylims)
+        x_max = num_groups
         for i, x in enumerate(xs):
+            # set x to middle of span
             end = xs[i + 1] if i < num_xs - 1 else num_groups
-            x = (x + end) / 2
+            x = (x + end + x_offset) / 2 / x_max
+            
             # position 4% down from top in data coordinates
             y_frac = 0.04
             if vspan_alt_y and i % 2 != 0:
                 # shift alternating labels further down to avoid overlap
                 y_frac += 0.03
-            y = y_top - y_span * y_frac
+            y = 1 - y_frac
+            
+            # add text
             ax.text(
-                x, y, vspan_lbls[i], color="k", horizontalalignment="center")
+                x, y, vspan_lbls[i], color="k", horizontalalignment="center",
+                transform=ax.transAxes)
     
     legend = ax.get_legend()
     if legend:


### PR DESCRIPTION
Vertical span labels have been set in data limits, but the axes limits may differ from data limits, such as plots with error bars or violin plots. Changed this positioning to use axes-relative coordinates instead.