### PR TITLE
Reduce image adjustment triggers

### DIFF
--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -42,6 +42,7 @@
   - "Blend" option in the image adjustment panel to visualize alignment in overlaid images (#89, #450)
   - Image adjustment channels are radio buttons for easier selection (#212)
   - Fixed synchronization between the ROI Editor and image adjustment controls after initialization (#142)
+  - Fixed redundant triggers when adjusting the displayed image (#474)
 - Images are rotated by dynamic transformation (#214, #471)
 - Smoother, faster interactions with main plots, including atlas label name display, label editing, and pan and zoom navigation (#317, #335, #359, #367)
 - Atlas labels adapt better in zoomed images to stay within each plot (#317)

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -1405,7 +1405,7 @@ class Visualization(HasTraits):
             self._imgadj_brightness_high = high
     
     def _set_inten_min_to_curr(self, plot_ax_img):
-        # set min intensity to current image value
+        """Set min intensity to current image value."""
         if plot_ax_img is not None:
             vmin = plot_ax_img.ax_img.norm.vmin
             self._adapt_imgadj_limits(plot_ax_img)
@@ -1414,7 +1414,7 @@ class Visualization(HasTraits):
                 self._imgadj_min = vmin
 
     def _set_inten_max_to_curr(self, plot_ax_img):
-        # set max intensity to current image value
+        """Set max intensity to current image value."""
         if plot_ax_img is not None:
             vmax = plot_ax_img.ax_img.norm.vmax
             self._adapt_imgadj_limits(plot_ax_img)
@@ -1431,8 +1431,9 @@ class Visualization(HasTraits):
         self._imgadj_min_auto = False
         self._imgadj_ignore_update = False
         plot_ax_img = self._adjust_displayed_imgs(minimum=self._imgadj_min)
-        # intensity max may have been adjusted to remain >= min
-        self._set_inten_max_to_curr(plot_ax_img)
+        
+        # # intensity max may have been adjusted to remain >= min
+        # self._set_inten_max_to_curr(plot_ax_img)
     
     def _adjust_img_auto(self, mode: str = "min"):
         """Handle changes to the image range auto control.
@@ -1476,8 +1477,9 @@ class Visualization(HasTraits):
         self._imgadj_max_auto = False
         self._imgadj_ignore_update = False
         plot_ax_img = self._adjust_displayed_imgs(maximum=self._imgadj_max)
-        # intensity min may have been adjusted to remain <= max
-        self._set_inten_min_to_curr(plot_ax_img)
+        
+        # # intensity min may have been adjusted to remain <= max
+        # self._set_inten_min_to_curr(plot_ax_img)
 
     @on_trait_change("_imgadj_brightness")
     def _adjust_img_brightness(self):

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -1334,7 +1334,7 @@ class Visualization(HasTraits):
             # empty array
             return
 
-        # get currently dispalyed image
+        # get currently displayed image
         plot_ax_img = self._get_curr_plot_ax_img()
         if plot_ax_img is None: return
         
@@ -1348,11 +1348,13 @@ class Visualization(HasTraits):
 
         # populate intensity limits, auto-scaling, and current val (if not auto)
         self._adapt_imgadj_limits(plot_ax_img)
+        
         if plot_ax_img.vmin is None:
             self._imgadj_min_auto = True
         else:
             self._imgadj_min = plot_ax_img.ax_img.norm.vmin
             self._imgadj_min_auto = False
+        
         if plot_ax_img.vmax is None:
             self._imgadj_max_auto = True
         else:
@@ -1425,7 +1427,9 @@ class Visualization(HasTraits):
         if self._imgadj_min_ignore_update or self._imgadj_ignore_update:
             self._imgadj_min_ignore_update = False
             return
+        self._imgadj_ignore_update = True
         self._imgadj_min_auto = False
+        self._imgadj_ignore_update = False
         plot_ax_img = self._adjust_displayed_imgs(minimum=self._imgadj_min)
         # intensity max may have been adjusted to remain >= min
         self._set_inten_max_to_curr(plot_ax_img)
@@ -1468,7 +1472,9 @@ class Visualization(HasTraits):
         if self._imgadj_max_ignore_update or self._imgadj_ignore_update:
             self._imgadj_max_ignore_update = False
             return
+        self._imgadj_ignore_update = True
         self._imgadj_max_auto = False
+        self._imgadj_ignore_update = False
         plot_ax_img = self._adjust_displayed_imgs(maximum=self._imgadj_max)
         # intensity min may have been adjusted to remain <= max
         self._set_inten_min_to_curr(plot_ax_img)


### PR DESCRIPTION
Toggling channels in the "Adjust Image" panel has retrieved a currently displayed image and using its values to populate the panel's controls. Changing each of these controls in turn triggered additional image updates, though typically without changing the image since it already had these settings. Toggling the auto-intensity has similarly triggered an "update" to the current value. While this design has simplified the callbacks, it also leads to many unnecessary triggers. This PR reduces many of those triggers by ignoring many of these redundant events.

This PR also provides a workaround for #473, where one intensity sliders may shift unexpectedly and trigger a change in the other intensity slider. The workaround is simply to turn off this synchronization during intensity slider adjustments so that the user only needs to counter the unexpected shift in one slider.