### PR TITLE
Generate auto-docs with default function arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ mm
 Or install using Pip (virtual environment [recommended](https://realpython.com/python-virtual-environments-a-primer/)):
 
 ```shell
-pip install magellanmapper[most] --extra-index-url https://pypi.fury.io/dd8/
+pip install "magellanmapper[most]" --extra-index-url https://pypi.fury.io/dd8/
 ```
 
 The extra index accesses a few [customized dependencies](docs/install.md#custom-packages) for MagellanMapper.
@@ -82,4 +82,4 @@ To try out functions with sample images, download any of these files:
 
 Licensed under the open-source [BSD-3 license](LICENSE.txt)
 
-Author: David Young, 2017, 2022, Stephan Sanders Lab
+Author: David Young, 2017, 2023, Stephan Sanders Lab

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -218,6 +218,12 @@ napoleon_use_rtype = True
 myst_heading_anchors = 4
 
 
+# -- Options for Sphinx-autodoc-typehints ---------------------------------
+
+# add default values within type hints parentheses
+typehints_defaults = "comma"
+
+
 # automate building API .rst files, necessary for ReadTheDocs, as inspired by:
 # https://github.com/readthedocs/readthedocs.org/issues/1139#issuecomment-398083449
 def run_apidoc(_):

--- a/docs/install.md
+++ b/docs/install.md
@@ -38,7 +38,7 @@ The `mm` entry points was added in v1.6.0 to facilitate launching from installed
 Install using Pip with Python >= 3.6 (see [Python versions](#python-version-support); [virtual environment](https://realpython.com/python-virtual-environments-a-primer/) recommended):
 
 ```shell
-pip install magellanmapper[most] --extra-index-url https://pypi.fury.io/dd8/
+pip install "magellanmapper[most]" --extra-index-url https://pypi.fury.io/dd8/
 ```
 
 The `most` group installs the GUI and file import tools (see [optional dependencies below](#optional-installation-groups)). The extra index accesses a few [customized dependencies](#custom-packages) for MagellanMapper.
@@ -65,7 +65,7 @@ conda env create -n mag -f environment.yml
 - Or Pip:
 
 ```shell
-pip install -e .[most] --extra-index-url https://pypi.fury.io/dd8/
+pip install -e ".[most]" --extra-index-url https://pypi.fury.io/dd8/
 ```
 
 MagellanMapper can be run using `mm` and `mm-cli` as above, or through the run script:

--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -24,6 +24,7 @@
 - Conda install simplified to use Pip primarily, which reduces disk space usage (#166)
 - Removed Conda `environment_light.yml` (no GUI) and OS-specific specs (#187)
 - No-GUI (headless) install is now by default, with a new `gui` install group to include the GUI (#317)
+- Fixed instructions for installing by Pip in ZSH terminals (#485)
 
 #### GUI
 
@@ -177,6 +178,7 @@
 - Settings profiles are being migrated from dictionaries to data classes to document and configure settings more easily (#138)
 - Jupyter Notebook as a tutorial for running various tasks in the CLI (#122)
 - Documentation is now [hosted on ReadTheDocs](https://magellanmapper.readthedocs.io/en/latest/index.html), using the Furo theme (#225)
+- Default arguments are documented in API auto-docs (#485)
 
 ### Dependency Updates
 

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ config = {
     "url": "https://github.com/sanderslab/magellanmapper",
     "author_email": "david@textflex.com",
     "license": "BSD-3",
-    "version": "1.6a3",
+    "version": "1.6b1",
     "packages": setuptools.find_packages(),
     "scripts": [],
     "python_requires": ">=3.6",


### PR DESCRIPTION
Add the `Sphinx-autodoc-typehints` setting to output default arguments for function parameters next to type hints. This PR also serves as the release branch for v1.6b1.