### PR TITLE
Add additive blending to merge channels

### DIFF
--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -40,6 +40,7 @@
 - Atlas Editor planes can be reordered or turned off (#180)
 - EXPERIMENTAL: New viewer that displays each blob separately to verify blob classifications (#193)
 - Image adjustment
+  - "Merge" option in the ROI panel to merge channels using additive blending (#492)
   - "Blend" option in the image adjustment panel to visualize alignment in overlaid images (#89, #450)
   - Image adjustment channels are radio buttons for easier selection (#212)
   - Fixed synchronization between the ROI Editor and image adjustment controls after initialization (#142)

--- a/magmap/gui/atlas_editor.py
+++ b/magmap/gui/atlas_editor.py
@@ -194,7 +194,8 @@ class AtlasEditor(plot_support.ImageSyncMixin):
             # plot editor
             max_size = max_sizes[plane] if max_sizes else None
             overlayer = plot_support.ImageOverlayer(
-                ax, aspect, origin, rgb=self.img5d.rgb)
+                ax, aspect, origin, rgb=self.img5d.rgb,
+                additive_blend=self.additive_blend)
             plot_ed = plot_editor.PlotEditor(
                 overlayer, img3d_tr, labels_img_tr, config.cmap_labels,
                 plane, self.update_coords, self.refresh_images,

--- a/magmap/gui/plot_editor.py
+++ b/magmap/gui/plot_editor.py
@@ -511,10 +511,8 @@ class PlotEditor:
         if self._plot_ax_imgs:
             # use vmin/vmax from norm values in previously displayed images
             # if available; None specifies auto-scaling
-            vmaxs[0] = [p.vmax if p.vmax is None else p.ax_img.norm.vmax
-                        for p in self._plot_ax_imgs[0]]
-            vmins[0] = [p.vmin if p.vmin is None else p.ax_img.norm.vmin
-                        for p in self._plot_ax_imgs[0]]
+            vmaxs[0] = [p.vmax for p in self._plot_ax_imgs[0]]
+            vmins[0] = [p.vmin for p in self._plot_ax_imgs[0]]
             
             # use opacity, brightness, anc contrast from prior images
             alphas[0] = [p.alpha for p in self._plot_ax_imgs[0]]

--- a/magmap/gui/plot_editor.py
+++ b/magmap/gui/plot_editor.py
@@ -63,11 +63,14 @@ class PlotAxImg:
         #: True if the image is displayed as RGB(A); defaults to False.
         self.rgb: bool = False
         
-        #: Original underlying image data, copied to allow adjusting the array
-        #: in ``ax_img`` while retaining the original data unless given by
-        #: directly by ``img``.
+        #: Original array of the displayed Matplotlib image. If None (default),
+        #: the displayed image's array will be copied to allow adjusting the
+        #: array in ``ax_img`` while retaining the original data.
         self.img: np.ndarray = np.copy(
             self.ax_img.get_array()) if img is None else img
+        
+        #: Original input image data; defaults to None.
+        self.input_img: Optional[np.ndarray] = None
 
 
 class PlotEditor:
@@ -615,9 +618,16 @@ class PlotEditor:
         for i, imgs in enumerate(ax_imgs):
             plot_ax_imgs = []
             for j, img in enumerate(imgs):
-                # use original 2D labels, without cmap index conversion
+                # for 2D label images, use the original 2D labels, without
+                # cmap index conversion
                 img_orig = img2d_lbl if i == 1 else None
+                
+                # initialized the plotted image storage instance
                 plot_ax_img = PlotAxImg(img, img=img_orig)
+                if i == 0 and imgs2d:
+                    # store the original intensity image plane, which may
+                    # differ from the displayed axes image array
+                    plot_ax_img.input_img = libmag.get_if_within(imgs2d[0], j)
                 
                 if i == 0:
                     # specified vmin/vmax, in contrast to the AxesImages's

--- a/magmap/gui/plot_editor.py
+++ b/magmap/gui/plot_editor.py
@@ -162,6 +162,11 @@ class PlotEditor:
         self.fn_status_bar = fn_status_bar
         self.img3d_extras = img3d_extras
         
+        #: Main image opacity as a sequence of values from 0-1 for each
+        #: channel. Defaults to a list of the first element in
+        #: :attr:`config.alphas`.
+        self.alpha_img3d: Sequence[float] = [config.alphas[0]]
+        #: Labels opacity from 0-1; defaults to :const:`ALPHA_DEFAULT`.
         self.alpha: float = self.ALPHA_DEFAULT
         self.intensity = None  # picked intensity of underlying img3d_label
         self.intensity_spec = None  # specified intensity
@@ -508,7 +513,7 @@ class PlotEditor:
         imgs2d = [self._get_img2d(0, self.img3d, self.max_intens_proj)]
         self._channels = [config.channel]
         cmaps = [config.cmaps]
-        alphas = [config.alphas[0]]
+        alphas = self.alpha_img3d
         alpha_is_default = True
         alpha_blends = [None]
         shapes = [self._img3d_shapes[0][1:3]]

--- a/magmap/gui/roi_editor.py
+++ b/magmap/gui/roi_editor.py
@@ -457,7 +457,8 @@ class ROIEditor(plot_support.ImageSyncMixin):
         if img3d_extras is not None:
             img3d_extras = [np.array(img) for img in img3d_extras]
         overlayer = plot_support.ImageOverlayer(
-            ax_ov, aspect, origin, rgb=self.img5d.rgb)
+            ax_ov, aspect, origin, rgb=self.img5d.rgb,
+            additive_blend=self.additive_blend)
         plot_ed = plot_editor.PlotEditor(
             overlayer, arrs_3d[0], labels_img, cmap_labels,
             self.plane, update_coords,
@@ -1235,7 +1236,8 @@ class ROIEditor(plot_support.ImageSyncMixin):
 
             # show the ROI, which is now a 2D zoomed image
             overlaid = plot_support.ImageOverlayer(
-                ax, aspect, rgb=self.img5d.rgb)
+                ax, aspect, rgb=self.img5d.rgb,
+                additive_blend=self.additive_blend)
             ax_imgs = [overlaid.imshow_multichannel(
                 roi, channel, config.cmaps, alpha, rgb=self.img5d.rgb)]
             #print("roi shape: {} for z_relative: {}".format(roi.shape, z_relative))

--- a/magmap/gui/verifier_editor.py
+++ b/magmap/gui/verifier_editor.py
@@ -155,7 +155,8 @@ class VerifierEditor(plot_support.ImageSyncMixin):
 
                 # display plot editor centered on blob
                 overlayer = plot_support.ImageOverlayer(
-                    ax, aspect, origin, rgb=config.rgb)
+                    ax, aspect, origin, rgb=config.rgb,
+                    additive_blend=self.additive_blend)
                 plot_ed = plot_editor.PlotEditor(
                     overlayer, self.img5d.img[0], None, None)
                 

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -15,11 +15,12 @@ Examples:
 import glob
 import pprint
 from collections import OrderedDict
-from enum import auto, Enum 
+from enum import auto, Enum
 import os
 import subprocess
 import sys
-from typing import Dict, Optional, Sequence, TYPE_CHECKING, Tuple, Type, Union
+from typing import Dict, List as TypeList, Optional, Sequence, TYPE_CHECKING, \
+    Tuple, Type, Union
 
 import matplotlib
 matplotlib.use("Qt5Agg")  # explicitly use PyQt5 for custom GUI events
@@ -1306,8 +1307,8 @@ class Visualization(HasTraits):
         # update control values
         self.update_imgadj_for_img()
 
-    def _get_selected_viewers(self) -> List:
-        """Get selected viewers."""
+    def _get_mpl_viewers(self) -> TypeList["plot_support.ImageSyncMixin"]:
+        """Get Matplotlib-based viewers."""
         viewers = []
         if self.selected_viewer_tab is vis_handler.ViewerTabs.ROI_ED:
             if self.roi_ed:
@@ -1320,7 +1321,7 @@ class Visualization(HasTraits):
     
     def _get_curr_plot_ax_img(self) -> Optional["plot_editor.PlotAxImg"]:
         """Get the first displayed image in the current viewer."""
-        viewers = self._get_selected_viewers()
+        viewers = self._get_mpl_viewers()
         plot_ax_img = None
         if viewers:
             # get the first displayed image from the viewer
@@ -1539,8 +1540,8 @@ class Visualization(HasTraits):
             # update 3D visualization Mayavi/VTK settings
             self._vis3d.update_img_display(**kwargs)
         else:
-            # update any selected Matplotlib-based viewer settings
-            viewers = self._get_selected_viewers()
+            # update all Matplotlib-based viewers
+            viewers = self._get_mpl_viewers()
             plot_ax_img = None
             for viewer in viewers:
                 if not viewer: continue

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -1370,21 +1370,21 @@ class Visualization(HasTraits):
         # respond to triggers
         self._imgadj_ignore_update = False
     
-    def _adapt_imgadj_limits(self, plot_ax_img):
+    def _adapt_imgadj_limits(self, plot_ax_img: "plot_editor.PlotAxImg"):
         """Adapt image adjustment slider limits based on values in the
         given plotted image.
         
         Args:
-            plot_ax_img (:obj:`magmap.gui.plot_editor.PlotAxImg`): Plotted
-                image.
+            plot_ax_img: Plotted image.
 
         """
         if plot_ax_img is None: return
         norm = plot_ax_img.ax_img.norm
-        inten_lim = (np.amin(plot_ax_img.img), np.amax(plot_ax_img.img))
+        input_img = plot_ax_img.input_img
+        inten_lim = (np.amin(input_img), np.amax(input_img))
 
         if inten_lim[0] < self._imgadj_max_low:
-            # ensure that lower limit is beyond current plane's limits;
+            # ensure that lower limit is beyond current plane's lower limit;
             # bottom out at 0 unless current low is < 0
             low_thresh = inten_lim[0] if norm.vmin is None else min(
                 inten_lim[0], norm.vmin)

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -435,6 +435,9 @@ class Visualization(HasTraits):
     _imgadj_brightness_high = Float
     _imgadj_contrast = Float
     _imgadj_alpha = Float
+    _imgadj_merge_chls = Bool(
+        tooltip="Merge channels using additive blending"
+    )
     _imgadj_alpha_blend = Float(0.5)
     _imgadj_alpha_blend_check = Bool(
         tooltip="Blend the overlapping parts of imags to shown alignment.\n"
@@ -871,6 +874,9 @@ class Visualization(HasTraits):
         HGroup(
             Item("_imgadj_alpha", label="Opacity", editor=RangeEditor(
                  low=0.0, high=1.0, mode="slider", format="%.3g")),
+        ),
+        HGroup(
+            Item("_imgadj_merge_chls", label="Merge channels"),
         ),
         
         HGroup(
@@ -2992,6 +2998,7 @@ class Visualization(HasTraits):
         roi_ed.fn_update_coords = self.set_offset
         roi_ed.fn_redraw = self.redraw_selected_viewer
         roi_ed.blobs = self.blobs
+        roi_ed.additive_blend = self._imgadj_merge_chls
         roi_cols = libmag.get_if_within(
             config.plot_labels[config.PlotLabels.LAYOUT], 0)
         stack_args_named = {
@@ -3069,6 +3076,7 @@ class Visualization(HasTraits):
             config.borders_img, self.show_label_3d, title,
             self._refresh_atlas_eds, self._atlas_ed_fig,
             self.update_status_bar_msg)
+        atlas_ed.additive_blend = self._imgadj_merge_chls
         self.atlas_eds.append(atlas_ed)
         
         if self._DEFAULTS_2D[4] in self._check_list_2d:
@@ -3251,6 +3259,7 @@ class Visualization(HasTraits):
             config.img5d, self.blobs, "Verifier", self._roi_ed_fig,
             # necessary for immediate table refresh rather than after scroll
             self.update_segment)
+        verifier_ed.additive_blend = self._imgadj_merge_chls
         verifier_ed.show_fig()
         self.verifier_ed = verifier_ed
     

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -1544,11 +1544,17 @@ class Visualization(HasTraits):
             plot_ax_img = None
             for viewer in viewers:
                 if not viewer: continue
+                
                 # update settings for the viewer
-                print("adjusting channel", int(self.imgadj_chls), kwargs)
                 plot_ax_img = viewer.update_imgs_display(
                     self._imgadj_names.selections.index(self._imgadj_name),
                     chl=int(self.imgadj_chls), **kwargs)
+                
+                if self._imgadj_merge_chls:
+                    # fully re-blend the image using the updated settings
+                    for plot_ed in viewer.plot_eds.values():
+                        plot_ed.show_overview()
+        
         return plot_ax_img
 
     @staticmethod

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -1522,17 +1522,19 @@ class Visualization(HasTraits):
             # turn off alpha blending and reset alpha values
             self._adjust_displayed_imgs(alpha_blend=False)
 
-    def _adjust_displayed_imgs(self, **kwargs):
+    def _adjust_displayed_imgs(
+            self, refresh: bool = False, **kwargs) -> "plot_editor.PlotAxImg":
         """Adjust image display settings for the currently selected viewer.
 
         Args:
+            refresh: True to refresh all Plot Editors; defaults to False.
             **kwargs: Arguments to update the currently selected viewer.
         
         Returns:
-            :obj:`magmap.plot_editor.PlotAxImg`: The last updated axes image
-            plot, assumed to have the same values as all the other
-            updated plots, or None if the selected tab does not have an
-            axes image, such as an unloaded tab or 3D visualization tab.
+            The last updated axes image plot, assumed to have the same values
+            as all the other updated plots, or None if the selected tab does
+            not have an axes image, such as an unloaded tab or 3D visualization
+            tab.
 
         """
         plot_ax_img = None
@@ -1551,8 +1553,8 @@ class Visualization(HasTraits):
                     self._imgadj_names.selections.index(self._imgadj_name),
                     chl=int(self.imgadj_chls), **kwargs)
                 
-                if self._imgadj_merge_chls:
-                    # fully re-blend the image using the updated settings
+                if self._imgadj_merge_chls or refresh:
+                    # fully refresh the image using the updated settings
                     for plot_ed in viewer.plot_eds.values():
                         plot_ed.show_overview()
         
@@ -2373,6 +2375,21 @@ class Visualization(HasTraits):
             ed.update_max_intens_proj(shape, True)
         if self.roi_ed is not None:
             self.roi_ed.update_max_intens_proj(shape, True)
+
+    @observe("_imgadj_merge_chls")
+    def _update_merge_channels(self, evt):
+        """Handle changes to merge channels control.
+        
+        Args:
+            evt: Event, ignored.
+
+        """
+        viewers = self._get_mpl_viewers()
+        for viewer in viewers:
+            # update additive blending
+            viewer.additive_blend = self._imgadj_merge_chls
+        # refresh display images
+        self._adjust_displayed_imgs(refresh=True)
 
     def update_status_bar_msg(self, msg):
         """Update the message displayed in the status bar.

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -1528,6 +1528,7 @@ class Visualization(HasTraits):
 
         Args:
             refresh: True to refresh all Plot Editors; defaults to False.
+                Overridden to True if merge channels is on.
             **kwargs: Arguments to update the currently selected viewer.
         
         Returns:
@@ -1545,18 +1546,17 @@ class Visualization(HasTraits):
             # update all Matplotlib-based viewers
             viewers = self._get_mpl_viewers()
             plot_ax_img = None
+            
+            # always fully refresh when channels are merged
+            refresh = refresh or self._imgadj_merge_chls
+            
             for viewer in viewers:
                 if not viewer: continue
                 
                 # update settings for the viewer
                 plot_ax_img = viewer.update_imgs_display(
                     self._imgadj_names.selections.index(self._imgadj_name),
-                    chl=int(self.imgadj_chls), **kwargs)
-                
-                if self._imgadj_merge_chls or refresh:
-                    # fully refresh the image using the updated settings
-                    for plot_ed in viewer.plot_eds.values():
-                        plot_ed.show_overview()
+                    chl=int(self.imgadj_chls), refresh=refresh, **kwargs)
         
         return plot_ax_img
 

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -851,6 +851,9 @@ class Visualization(HasTraits):
                      name="object._imgadj_chls_names.selections", cols=8)),
         ),
         HGroup(
+            Item("_imgadj_merge_chls", label="Merge channels"),
+        ),
+        HGroup(
             Item("_imgadj_min", label="Minimum", editor=RangeEditor(
                      low_name="_imgadj_min_low", high_name="_imgadj_min_high",
                      mode="slider", format="%.4g")),
@@ -876,13 +879,11 @@ class Visualization(HasTraits):
             Item("_imgadj_alpha", label="Opacity", editor=RangeEditor(
                  low=0.0, high=1.0, mode="slider", format="%.3g")),
         ),
-        HGroup(
-            Item("_imgadj_merge_chls", label="Merge channels"),
-        ),
         
         HGroup(
             # alpha blending controls
-            Item("_imgadj_alpha_blend_check", label="Blend"),
+            Item("_imgadj_alpha_blend_check", label="Blend",
+                 enabled_when="not _imgadj_merge_chls"),
             Item("_imgadj_alpha_blend", show_label=False, editor=RangeEditor(
                  low=0.0, high=1.0, mode="slider", format="%.3g"),
                  enabled_when="_imgadj_alpha_blend_check"),
@@ -2384,10 +2385,15 @@ class Visualization(HasTraits):
             evt: Event, ignored.
 
         """
+        if self._imgadj_merge_chls and self._imgadj_alpha_blend_check:
+            # turn off alpha blending when merging channels
+            self._imgadj_alpha_blend_check = False
+        
         viewers = self._get_mpl_viewers()
         for viewer in viewers:
             # update additive blending
             viewer.additive_blend = self._imgadj_merge_chls
+        
         # refresh display images
         self._adjust_displayed_imgs(refresh=True)
 

--- a/magmap/plot/colormaps.py
+++ b/magmap/plot/colormaps.py
@@ -46,6 +46,14 @@ def setup_cmaps():
         config.Cmaps.CMAP_GRBK_NAME.value, "green")
     CMAPS[config.Cmaps.CMAP_RDBK_NAME] = make_dark_linear_cmap(
         config.Cmaps.CMAP_RDBK_NAME.value, "red")
+    CMAPS[config.Cmaps.CMAP_BUBK_NAME] = make_dark_linear_cmap(
+        config.Cmaps.CMAP_BUBK_NAME.value, "blue")
+    CMAPS[config.Cmaps.CMAP_CYBK_NAME] = make_dark_linear_cmap(
+        config.Cmaps.CMAP_CYBK_NAME.value, "cyan")
+    CMAPS[config.Cmaps.CMAP_MGBK_NAME] = make_dark_linear_cmap(
+        config.Cmaps.CMAP_MGBK_NAME.value, "magenta")
+    CMAPS[config.Cmaps.CMAP_YLBK_NAME] = make_dark_linear_cmap(
+        config.Cmaps.CMAP_YLBK_NAME.value, "yellow")
 
 
 class DiscreteColormap(colors.ListedColormap):

--- a/magmap/plot/plot_support.py
+++ b/magmap/plot/plot_support.py
@@ -66,6 +66,18 @@ class ImageSyncMixin:
         #: Listeners attached to the editor.
         self._listeners: List["backend_bases.Event"] = []
 
+    @property
+    def additive_blend(self) -> bool:
+        """Get additive blend setting."""
+        return self._additive_blend
+    
+    @additive_blend.setter
+    def additive_blend(self, val: bool):
+        """Set additive blend setting and propagate to Plot Editors."""
+        self._additive_blend = val
+        for ed in self.plot_eds.values():
+            ed.overlayer.additive_blend = val
+
     def get_img_display_settings(self, imgi, chl=None):
         """Get display settings for the given image.
         

--- a/magmap/plot/plot_support.py
+++ b/magmap/plot/plot_support.py
@@ -98,14 +98,13 @@ class ImageSyncMixin:
         return None
 
     def update_imgs_display(
-            self, imgi: int,
-            chl: Optional[int] = None,
+            self, imgi: int, chl: Optional[int] = None,
             minimum: Optional[float] = np.nan,
             maximum: Optional[float] = np.nan,
             brightness: Optional[float] = None,
-            contrast: Optional[float] = None,
-            alpha: Optional[float] = None,
-            alpha_blend: Optional[float] = None) -> "plot_editor.PlotAxImg":
+            contrast: Optional[float] = None, alpha: Optional[float] = None,
+            alpha_blend: Optional[float] = None, refresh: bool = False, **kwargs
+    ) -> "plot_editor.PlotAxImg":
         """Update dislayed image settings in all Plot Editors.
 
         Args:
@@ -119,6 +118,8 @@ class ImageSyncMixin:
             contrast: Contrast multiplier; defaults to None.
             alpha: Opacity value; defalts to None.
             alpha_blend: Opacity blending value; defaults to None.
+            refresh: True to refresh all zoomed Plot Editors; defaults to False.
+            kwargs: Additional arguments, which are ignored.
         
         Returns:
             The updated axes image plot.
@@ -126,9 +127,15 @@ class ImageSyncMixin:
         """
         plot_ax_img = None
         for ed in self.plot_eds.values():
+            # update the displayed image
             plot_ax_img = ed.update_img_display(
                 imgi, chl, minimum, maximum, brightness, contrast, alpha,
                 alpha_blend)
+            
+            if refresh:
+                # fully refresh editor
+                ed.show_overview()
+        
         return plot_ax_img
     
     def save_fig(self, path: str, **kwargs):

--- a/magmap/plot/plot_support.py
+++ b/magmap/plot/plot_support.py
@@ -56,6 +56,9 @@ class ImageSyncMixin:
         self.plot_eds: Dict[Any, "plot_editor.PlotEditor"] = OrderedDict()
         #: Edited flag.
         self.edited: bool = False
+        
+        #: Display images with additive blending; default to False.
+        self.additive_blend: bool = False
 
         #: Plane(s) for max intensity projections.
         self._max_intens_proj: Optional[Union[int, Sequence[int]]] = None

--- a/magmap/settings/config.py
+++ b/magmap/settings/config.py
@@ -303,10 +303,14 @@ proc_type: Dict[ProcessTypes, Any] = dict.fromkeys(ProcessTypes, None)
 # 2D PLOTTING
 
 
-# custom colormaps in plot_2d
 class Cmaps(Enum):
+    """Custom colormap names."""
     CMAP_GRBK_NAME = "Green_black"
     CMAP_RDBK_NAME = "Red_black"
+    CMAP_BUBK_NAME = "Blue_black"
+    CMAP_CYBK_NAME = "Cyan_black"
+    CMAP_MGBK_NAME = "Magenta_black"
+    CMAP_YLBK_NAME = "Yellow_black"
 
 
 class Plot2DTypes(Enum):

--- a/magmap/settings/roi_prof.py
+++ b/magmap/settings/roi_prof.py
@@ -56,7 +56,13 @@ class ROIProfile(profiles.SettingsDict):
         self["vis_3d"] = "points"  # "points" or "surface" 3D visualization
         self["points_3d_thresh"] = 0.85  # frac of thresh (changed in v.0.6.6)
         self["channel_colors"] = (
-            config.Cmaps.CMAP_GRBK_NAME, config.Cmaps.CMAP_RDBK_NAME)
+            config.Cmaps.CMAP_GRBK_NAME,
+            config.Cmaps.CMAP_RDBK_NAME,
+            config.Cmaps.CMAP_BUBK_NAME,
+            config.Cmaps.CMAP_YLBK_NAME,
+            config.Cmaps.CMAP_MGBK_NAME,
+            config.Cmaps.CMAP_CYBK_NAME,
+        )
         self["scale_bar_color"] = "w"
         #: Colorbar args passed to :meth:`matplotlib.figure.Figure.colorbar`.
         self["colorbar"] = None


### PR DESCRIPTION
Multi-channel images have been shown with each channel overlaid on the next with progressively increasing levels of translucency. While this overlay is straightforward and can work well for a small number of colors, the colors become increasingly muted. As an alternative, colors can be blended in an additive manner to retain more signal from underlying layers of channels.

To implement this blending, we convert channels to a black-to-single-color colormap and take the maximum value across channels at each pixel, as inspired by the [microfilm](https://github.com/guiwitz/microfilm) package. Users can toggle this channel merging through a new check box, which dynamically updates the ROI and Atlas editor plots. The ROI Editors's zoom plots now use `PlotEditor` instances to store and update their state for these dynamic updates.