### PR TITLE
Support ITK-Elastix for image registration

### DIFF
--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -81,6 +81,9 @@
 - Landmark distance measurements save the raw distances and no longer require spacing (#147)
 - Masks with angle planes can be constructed (#252)
 - `register.RegImgs` is a data class to track registered images (#335)
+- Supports image I/O and registration through ITK (#495)
+  - `ITK-Elastix` support has been added as an alternative to `SimpleITK`
+  - Both libraries are now optional rather than required dependencies
 - Fixed changes to large label IDs during registration (#303)
 
 #### Cell detection

--- a/magmap/atlas/register.py
+++ b/magmap/atlas/register.py
@@ -959,13 +959,6 @@ def register(
             lbls_meta.prefix = name_prefix
             lbls_meta.save()
 
-    # save transform parameters and attempt to find the original position 
-    # that corresponds to the final position that will be displayed
-    if transformix_filter is not None:
-        _, translation = _handle_transform_file(
-            name_prefix, transformix_filter.GetTransformParameterMap())
-        _translation_adjust(moving_img, img_moved, translation, flip=True)
-    
     # compare original atlas with registered labels taken as a whole
     dsc_labels = atlas_refiner.measure_overlap_combined_labels(
         fixed_img_orig, labels_moved)
@@ -994,6 +987,13 @@ def register(
     df_io.dict_to_data_frame(metrics, df_path, show="\t")
 
     '''
+    # save transform parameters and attempt to find the original position
+    # that corresponds to the final position that will be displayed
+    if transformix_filter is not None:
+        _, translation = _handle_transform_file(
+            name_prefix, transformix_filter.GetTransformParameterMap())
+        _translation_adjust(moving_img, img_moved, translation, flip=True)
+    
     # show 2D overlays or registered image and atlas last since blocks until 
     # fig is closed
     imgs = [

--- a/magmap/atlas/register.py
+++ b/magmap/atlas/register.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # Image registration
-# Author: David Young, 2017, 2019
+# Author: David Young, 2017, 2023
 """Register images to one another.
 
 The registration type can be given on the command-line (see :mod:``cli``) as 
@@ -253,7 +253,7 @@ def curate_img(
 
 
 def register_repeat(
-        transformix_img_filter: sitk.TransformixImageFilter,
+        transformix_img_filter: "sitk.TransformixImageFilter",
         img: sitk.Image, preserve_idents: bool = False) -> sitk.Image:
     """Transform labels to match a prior registration.
     
@@ -336,7 +336,7 @@ def register_duo(
         moving_mask: Optional[sitk.Image] = None,
         regs: Optional[Union[
             Sequence[str], Sequence["atlas_prof.RegParamMap"]]] = None
-) -> Tuple[sitk.Image, sitk.TransformixImageFilter]:
+) -> Tuple[sitk.Image, "sitk.TransformixImageFilter"]:
     """Register two images to one another using ``SimpleElastix``.
     
     Args:

--- a/magmap/io/sitk_io.py
+++ b/magmap/io/sitk_io.py
@@ -100,7 +100,7 @@ def convert_img(
     if sitk and isinstance(img, sitk.Image):
         # convert an sitk Image to an np array
         conv = sitk.GetArrayFromImage(img)
-    elif itk and isinstance(img, itk.Image):
+    elif itk and isinstance(img, (itk.Image, itk.VectorImage)):
         # convert an ITK image to an np array
         conv = itk.GetArrayFromImage(img)
     elif sitk and to_sitk:
@@ -108,6 +108,9 @@ def convert_img(
         conv = sitk.GetImageFromArray(img, multichannel)
     elif itk:
         # convert an np array to ITK Image
+        if multichannel is None:
+            # default to treat 4D+ images as multichannel
+            multichannel = img.ndim > 3
         conv = itk.GetImageFromArray(img, multichannel)
     return conv
 

--- a/magmap/io/sitk_io.py
+++ b/magmap/io/sitk_io.py
@@ -746,12 +746,14 @@ def sitk_to_itk_img(sitk_img: "sitk.Image") -> "itk.Image":
     """Convert a SimpleITK image to an ITK Image.
     
     Args:
-        sitk_img: SimpleITK Image.
+        sitk_img: SimpleITK Image. If None, will simply be returned.
 
     Returns:
         ITK Image.
 
     """
+    if sitk_img is None: return sitk_img
+    
     # construct an ITK Image through the ndarray extracted from the sitk Image
     itk_img = itk.GetImageFromArray(
         sitk.GetArrayFromImage(sitk_img),
@@ -773,12 +775,14 @@ def itk_to_sitk_img(itk_img: "itk.Image") -> "sitk.Image":
     """Convert an ITK image to a SimpleITK Image.
     
     Args:
-        itk_img: ITK Image.
+        itk_img: ITK Image. If None, will simply be returned.
 
     Returns:
         SimpleITK Image.
 
     """
+    if itk_img is None: return itk_img
+    
     # construct a sitk Image through the ndarray extracted from the ITK Image
     sitk_img = sitk.GetImageFromArray(
         itk.GetArrayFromImage(itk_img),

--- a/magmap/io/sitk_io.py
+++ b/magmap/io/sitk_io.py
@@ -73,7 +73,7 @@ def reg_out_path(file_path, reg_name, match_ext=False):
 
 def convert_img(
         img: Union["sitk.Image", "itk.Image", np.ndarray],
-        multichannel: bool = None, to_sitk: bool = False
+        multichannel: Optional[bool] = None, to_sitk: Optional[bool] = None
 ) -> Union["sitk.Image", "itk.Image", np.ndarray]:
     """Convert SimpleITK, ITK, and NumPy images.
     
@@ -84,13 +84,18 @@ def convert_img(
             multichannel. Defaults to None, which will attempt to auto-detect
             multichannel images. Only used if ``img`` is a NumPy array.
         to_sitk: True to convert a NumPy ``img`` to a SimpleITK Image. If
-            False (default), an ITK Image is output instead. Ignored if
-            ``img`` is not a NumPy array.
+            False, an ITK Image is output instead. If None, the parameter will
+            be True if the SimpleITK library is found. Ignored if ``img`` is
+            not a NumPy array.
 
     Returns:
         The converted image.
 
     """
+    if to_sitk is None:
+        # default to convert to SimpleITK if the library is present
+        to_sitk = sitk is not None
+    
     conv = img
     if sitk and isinstance(img, sitk.Image):
         # convert an sitk Image to an np array

--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,8 @@ config = {
         # pre-built SimpleITK with Elastix
         "simpleitk==2.0.2rc2.dev785+g8ac4f ; python_version < '3.8'",
         "simpleitk==2.3.0.dev117+g0640d ; python_version >= '3.8'",
+        "itk",
+        "itk-elastix",
         
         "PyYAML",
         "appdirs",

--- a/setup.py
+++ b/setup.py
@@ -74,9 +74,8 @@ config = {
         "matplotlib != 3.3.0, != 3.3.1",
         "pandas",
         
-        # pre-built SimpleITK with Elastix
-        "simpleitk==2.0.2rc2.dev785+g8ac4f ; python_version < '3.8'",
-        "simpleitk==2.3.0.dev117+g0640d ; python_version >= '3.8'",
+        # image registration toolkits
+        "simpleitk",
         "itk",
         "itk-elastix",
         


### PR DESCRIPTION
Addresses #496. This PR is the first of a series of PRs to add support for the ITK-Elastix image registration library as an alternative to SimpleITK with Elastix.

Images can now be registered using ITK-Elastix instead of requiring a custom build of SimpleITK with Elastix enabled. Continues to require SimpleITK to load images, but can use the standard SimpleITK package available on PyPi instead of the custom build.