### PR TITLE
Make SimpleITK dependency optional

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -200,6 +200,7 @@ These package versions are used for automated testing (continuous integration).
 | `docs` | Tools for building docs | |
 | `gui` | Main graphical interface | |
 | `import` | Imports proprietary image formats | |
+| `itk` | ITK-Elastix | |
 | `jupyter` | Running Notebooks | |
 | `pandas_plus` | Exports styled and Excel formats | |
 | `simpleitk` | Custom SimpleITK with Elastix | |

--- a/docs/install.md
+++ b/docs/install.md
@@ -194,14 +194,15 @@ These package versions are used for automated testing (continuous integration).
 |-----|-----|-----|
 | `most` | Import and GUI tools | Has `import`, `gui` |
 | `all` | All groups plus `seaborn`, `scikit-learn` | Has all below |
-| `import` | Imports proprietary image formats | |
-| `gui` | Main graphical interface | |
-| `pandas_plus` | Exports styled and Excel formats | |
-| `aws` | Tools for accessing AWS | |
-| `docs` | Tools for building docs | |
-| `jupyter` | Running Notebooks | |
-| `classifer` | Tensorflow | |
 | `3D` | 3D rendering | |
+| `aws` | Tools for accessing AWS | |
+| `classifer` | Tensorflow | |
+| `docs` | Tools for building docs | |
+| `gui` | Main graphical interface | |
+| `import` | Imports proprietary image formats | |
+| `jupyter` | Running Notebooks | |
+| `pandas_plus` | Exports styled and Excel formats | |
+| `simpleitk` | Custom SimpleITK with Elastix | |
 
 ### Optional Dependency Build and Runtime Requirements
 

--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -81,9 +81,10 @@
 - Landmark distance measurements save the raw distances and no longer require spacing (#147)
 - Masks with angle planes can be constructed (#252)
 - `register.RegImgs` is a data class to track registered images (#335)
-- Supports image I/O and registration through ITK (#495)
-  - `ITK-Elastix` support has been added as an alternative to `SimpleITK`
-  - Both libraries are now optional rather than required dependencies
+- Supports image I/O and registration through ITK
+  - `ITK-Elastix` support has been added as an alternative to `SimpleITK` (#495)
+  - Both libraries are now optional rather than required dependencies (#497)
+  - Better support for image direction metadata (#497)
 - Fixed changes to large label IDs during registration (#303)
 
 #### Cell detection

--- a/magmap/atlas/atlas_refiner.py
+++ b/magmap/atlas/atlas_refiner.py
@@ -1,5 +1,5 @@
 # Atlas refinement
-# Author: David Young, 2019
+# Author: David Young, 2019, 2023
 """Refine atlases in 3D.
 """
 from collections import OrderedDict
@@ -1081,14 +1081,14 @@ def aggr_smoothing_metrics(df_pxs):
 
 
 def transpose_img(
-        img_sitk: sitk.Image, plane: Optional[str] = None,
+        img_sitk: "sitk.Image", plane: Optional[str] = None,
         rotate: Optional[int] = None,
         rotate_deg: Optional[Sequence[Dict[str, Any]]] = None,
         target_size: Optional[Union[float, Sequence[int]]] = None,
         target_size_res: Optional[Union[float, Sequence[int]]] = None,
         flip: Optional[Union[int, Sequence[int]]] = None,
         order: Optional[int] = None
-) -> sitk.Image:
+) -> "sitk.Image":
     """Transpose an image to a different plane or rotation.
     
     Supports the `ROTATE` and `FLIP` settings in
@@ -1574,8 +1574,8 @@ def import_atlas(atlas_dir, show=True, prefix=None):
 
 
 def measure_atlas_refinement(
-        metrics: Dict[Enum, List], img_atlas: sitk.Image,
-        img_labels: sitk.Image, atlas_profile: atlas_prof.AtlasProfile,
+        metrics: Dict[Enum, List], img_atlas: "sitk.Image",
+        img_labels: "sitk.Image", atlas_profile: atlas_prof.AtlasProfile,
         path: str = None) -> pd.DataFrame:
     """
     
@@ -1615,13 +1615,15 @@ def measure_atlas_refinement(
 
 
 def measure_overlap(
-        img1: sitk.Image, img2: sitk.Image, thresh_img1: Optional[float] = None,
+        img1: "sitk.Image", img2: "sitk.Image",
+        thresh_img1: Optional[float] = None,
         thresh_img2: Optional[float] = None,
         add_to_img1_mask: Optional[np.ndarray] = None,
         return_masks: bool = False
-) -> Union[float, Tuple[float, sitk.Image, np.ndarray]]:
-    """Measure the Dice Similarity Coefficient (DSC) between two foreground 
-    of two images.
+) -> Union[float, Tuple[float, "sitk.Image", np.ndarray]]:
+    """Measure the Dice Similarity Coefficient (DSC) two images.
+     
+    Calculdate the DSC between the foreground of two images.
     
     Args:
         img1: First image.
@@ -1642,7 +1644,7 @@ def measure_overlap(
         the DSC cannot be computed. If`return_masks`` is True, also returns
         the masked images as NumPy arrays.
     """
-    # upper threshold does not seem be set with max despite docs for 
+    # upper threshold does not seem be set with max despite docs for
     # sitk.BinaryThreshold, so need to set with max explicitly
     img1_np = sitk.GetArrayFromImage(img1)
     thresh_img1_up = float(np.amax(img1_np))

--- a/magmap/atlas/edge_seg.py
+++ b/magmap/atlas/edge_seg.py
@@ -6,9 +6,12 @@ import os
 from time import time
 from typing import List, Optional
 
-import SimpleITK as sitk
 import numpy as np
 import pandas as pd
+try:
+    import SimpleITK as sitk
+except ImportError:
+    sitk = None
 from skimage import color
 
 from magmap.atlas import atlas_refiner
@@ -111,7 +114,7 @@ def make_edge_images(path_img, show=True, atlas=True, suffix=None,
         path_atlas = path_img
         path_labels = os.path.join(path_atlas_dir, labels_suffix)
         print("loading labels from", path_labels)
-        labels_sitk = sitk.ReadImage(path_labels)
+        labels_sitk = sitk_io.read_img(path_labels)
     elif labels_suffix:
         # load labels registered to sample image
         labels_sitk = sitk_io.load_registered_img(
@@ -182,7 +185,7 @@ def make_edge_images(path_img, show=True, atlas=True, suffix=None,
         config.RegNames.IMG_LABELS_INTERIOR.value: labels_sitk_interior, 
         config.RegNames.IMG_LABELS_DIST.value: dist_sitk, 
     }
-    if show:
+    if show and sitk:
         for img in imgs_write.values():
             if img: sitk.Show(img)
     
@@ -393,7 +396,7 @@ def edge_aware_segmentation(
     # show and write image to same directory as atlas with appropriate suffix
     sitk_io.write_reg_images(
         {config.RegNames.IMG_LABELS.value: labels_sitk_seg}, mod_path)
-    if show: sitk.Show(labels_sitk_seg)
+    if show and sitk: sitk.Show(labels_sitk_seg)
     return path_atlas
 
 
@@ -501,7 +504,7 @@ def merge_atlas_segmentations(img_paths, show=True, atlas=True, suffix=None):
             config.RegNames.IMG_LABELS_INTERIOR.value: labels_sitk_interior, 
         }
         sitk_io.write_reg_images(imgs_write, mod_path)
-        if show:
+        if show and sitk:
             for img in imgs_write.values():
                 if img: sitk.Show(img)
         print("finished {}".format(path))

--- a/magmap/atlas/edge_seg.py
+++ b/magmap/atlas/edge_seg.py
@@ -1,5 +1,5 @@
 # Segmentation based on edge detection
-# Author: David Young, 2019
+# Author: David Young, 2019, 2023
 """Re-segment atlases based on edge detections.
 """
 import os
@@ -116,13 +116,13 @@ def make_edge_images(path_img, show=True, atlas=True, suffix=None,
         # load labels registered to sample image
         labels_sitk = sitk_io.load_registered_img(
             mod_path, labels_suffix, get_sitk=True)
-    labels_img_np = None if labels_sitk is None else sitk.GetArrayFromImage(
+    labels_img_np = None if labels_sitk is None else sitk_io.convert_img(
         labels_sitk)
     # load atlas image, set resolution from it
     atlas_sitk = sitk_io.load_registered_img(
         path_atlas, atlas_suffix, get_sitk=True)
     config.resolutions = np.array([atlas_sitk.GetSpacing()[::-1]])
-    atlas_np = sitk.GetArrayFromImage(atlas_sitk)
+    atlas_np = sitk_io.convert_img(atlas_sitk)
     
     if config.rgb:
         # convert RGB atlas image to grayscale for single channel
@@ -296,10 +296,10 @@ def edge_aware_segmentation(
         load_path, config.RegNames.IMG_LABELS_MARKERS.value, get_sitk=True)
     
     # get Numpy arrays of images
-    atlas_img_np = sitk.GetArrayFromImage(atlas_sitk)
-    atlas_edge = sitk.GetArrayFromImage(atlas_sitk_edge)
-    labels_img_np = sitk.GetArrayFromImage(labels_sitk)
-    markers = sitk.GetArrayFromImage(labels_sitk_markers)
+    atlas_img_np = sitk_io.convert_img(atlas_sitk)
+    atlas_edge = sitk_io.convert_img(atlas_sitk_edge)
+    labels_img_np = sitk_io.convert_img(labels_sitk)
+    markers = sitk_io.convert_img(labels_sitk_markers)
     
     # segment image from markers
     sym_axis = atlas_refiner.find_symmetric_axis(atlas_img_np)
@@ -433,7 +433,7 @@ def merge_atlas_segmentations(img_paths, show=True, atlas=True, suffix=None):
         if erode["markers"]:
             # use default minimal post-erosion size (not setting erosion frac)
             markers, df = erode_labels(
-                sitk.GetArrayFromImage(labels_sitk), erosion,
+                sitk_io.convert_img(labels_sitk), erosion,
                 mirrored=mirrored, mirror_mult=mirror_mult)
             labels_sitk_markers = sitk_io.replace_sitk_with_numpy(
                 labels_sitk, markers)
@@ -474,7 +474,7 @@ def merge_atlas_segmentations(img_paths, show=True, atlas=True, suffix=None):
         if meas_edge_dist or erode_interior:
             labels_sitk = sitk_io.load_registered_img(
                 mod_path, config.RegNames.IMG_LABELS.value, get_sitk=True)
-            labels_np = sitk.GetArrayFromImage(labels_sitk)
+            labels_np = sitk_io.convert_img(labels_sitk)
             if meas_edge_dist:
                 # make edge distance images and stats
                 dist_to_orig, labels_edge = edge_distances(
@@ -570,7 +570,7 @@ def make_sub_segmented_labels(img_path, suffix=None):
         img_path, config.RegNames.IMG_ATLAS_EDGE.value)
     
     # sub-divide the labels and save to file
-    labels_img_np = sitk.GetArrayFromImage(labels_sitk)
+    labels_img_np = sitk_io.convert_img(labels_sitk)
     labels_subseg = segmenter.sub_segment_labels(labels_img_np, atlas_edge)
     labels_subseg_sitk = sitk_io.replace_sitk_with_numpy(
         labels_sitk, labels_subseg)

--- a/magmap/atlas/register.py
+++ b/magmap/atlas/register.py
@@ -1056,14 +1056,14 @@ def register_rev(fixed_path, moving_path, reg_base=None, reg_names=None,
             defaults to None.
         show: True to show images after registration; defaults to True.
     """
-    fixed_img = sitk.ReadImage(fixed_path)
+    fixed_img = sitk_io.read_img(fixed_path)
     mod_path = moving_path
     if suffix is not None:
         # adjust image path to load with suffix
         mod_path = libmag.insert_before_ext(mod_path, suffix)
     if reg_base is None:
         # load the image directly from given path
-        moving_img = sitk.ReadImage(mod_path)
+        moving_img = sitk_io.read_img(mod_path)
     else:
         # treat the path as a base path to which a reg suffix will be combined
         moving_img = sitk_io.load_registered_img(
@@ -1477,11 +1477,10 @@ def overlay_registered_imgs(fixed_file, moving_file_dir, plane=None,
     image5d = img5d.img
     roi = image5d[0, ...]  # not using time dimension
     
-    # get the atlas file and transpose it to match the orientation of the 
+    # get the atlas file and transpose it to match the orientation of the
     # experiment image
     out_path = os.path.join(moving_file_dir, config.RegNames.IMG_ATLAS.value)
-    print("Reading in {}".format(out_path))
-    moving_sitk = sitk.ReadImage(out_path)
+    moving_sitk = sitk_io.read_img(out_path)
     moving_sitk = atlas_refiner.transpose_img(
         moving_sitk, plane, rotate)
     moving_img = sitk_io.convert_img(moving_sitk)
@@ -2101,7 +2100,7 @@ def _test_region_from_id():
         # been given similarly to register fn
         path = os.path.join(
             config.filenames[1], config.RegNames.IMG_LABELS.value)
-        labels_img = sitk.ReadImage(path)
+        labels_img = sitk_io.read_img(path)
         labels_img = sitk_io.convert_img(labels_img)
         scaling = np.ones(3)
         print("loaded labels image from {}".format(path))
@@ -2110,7 +2109,7 @@ def _test_region_from_id():
         labels_img = sitk_io.load_registered_img(
             config.filename, config.RegNames.IMG_LABELS.value)
         if config.filename.endswith(".mhd"):
-            img = sitk.ReadImage(config.filename)
+            img = sitk_io.read_img(config.filename)
             img = sitk_io.convert_img(img)
             image5d = img[None]
         else:

--- a/magmap/atlas/register.py
+++ b/magmap/atlas/register.py
@@ -942,7 +942,7 @@ def register(
             imgs_write[suffix] = make_labels(moving_imgs[suffix])[0]
             print("transforming label", suffix, imgs_write[suffix])
 
-    if show_imgs:
+    if show_imgs and sitk:
         # show individual SimpleITK images in default viewer
         for img in imgs_write.values():
             if img is not None:
@@ -1111,7 +1111,7 @@ def register_rev(fixed_path, moving_path, reg_base=None, reg_names=None,
         # distinct name to avoid overwriting previously registered images
         imgs_write[name] = img
     sitk_io.write_reg_images(imgs_write, output_base)
-    if show:
+    if show and sitk:
         for img in imgs_write.values(): sitk.Show(img)
 
 
@@ -1320,7 +1320,7 @@ def register_group(
         # of subject within first image
         img_large_np = np.zeros(size_orig[::-1])
         img_large_np[:, start_y:start_y+img_np.shape[1]] = img_np
-        if show_imgs:
+        if show_imgs and sitk:
             sitk.Show(sitk_io.replace_sitk_with_numpy(img, img_large_np))
         imgs.append(img_large_np)
     
@@ -1357,7 +1357,7 @@ def register_group(
         imgs_to_show.append(img_unfilled)
         imgs_to_show.append(transformed_img)
     
-    if show_imgs:
+    if show_imgs and sitk:
         for img in imgs_to_show: sitk.Show(img)
     
     #transformed_img = img_raw
@@ -1424,7 +1424,8 @@ def register_labels_to_atlas(path_fixed):
     # perform the registration
     transform = elastix_img_filter.Execute()
     transformed_img = elastix_img_filter.GetResultImage()
-    sitk.Show(transformed_img)
+    if sitk:
+        sitk.Show(transformed_img)
     
     # set up filter to apply the same transformation to label file, 
     # ensuring that no new labels are interpolated
@@ -2137,10 +2138,11 @@ def _test_curate_img(path, prefix):
     result_imgs = curate_img(
         fixed_img, labels_img, [atlas_img], inpaint=False, 
         holes_area=holes_area)
-    sitk.Show(fixed_img)
-    sitk.Show(labels_img)
-    sitk.Show(result_imgs[0])
-    sitk.Show(result_imgs[1])
+    if sitk:
+        sitk.Show(fixed_img)
+        sitk.Show(labels_img)
+        sitk.Show(result_imgs[0])
+        sitk.Show(result_imgs[1])
 
 
 def _test_smoothing_metric():

--- a/magmap/atlas/register.py
+++ b/magmap/atlas/register.py
@@ -216,10 +216,10 @@ def _handle_transform_file(fixed_file, transform_param_map=None):
 
 
 def curate_img(
-        fixed_img: sitk.Image, labels_img: sitk.Image,
-        imgs: Optional[List[sitk.Image]] = None, inpaint: bool = True,
+        fixed_img: "sitk.Image", labels_img: "sitk.Image",
+        imgs: Optional[List["sitk.Image"]] = None, inpaint: bool = True,
         carve: bool = True, thresh: Optional[float] = None,
-        holes_area: Optional[int] = None) -> List[sitk.Image]:
+        holes_area: Optional[int] = None) -> List["sitk.Image"]:
     """Curate an image by the foreground of another.
     
     In-painting where corresponding pixels are present in fixed image but

--- a/magmap/atlas/register.py
+++ b/magmap/atlas/register.py
@@ -1367,8 +1367,7 @@ def register_group(
         out_path = os.path.join(name_prefix, config.RegNames.IMG_GROUPED.value)
         if not os.path.exists(name_prefix):
             os.makedirs(name_prefix)
-        print("writing {}".format(out_path))
-        sitk.WriteImage(transformed_img, out_path, False)
+        sitk_io.write_img(transformed_img, out_path)
         img_np = sitk_io.convert_img(transformed_img)
         config.resolutions = [transformed_img.GetSpacing()[::-1]]
         importer.save_np_image(img_np[None], out_path, config.series)

--- a/magmap/io/export_regions.py
+++ b/magmap/io/export_regions.py
@@ -257,7 +257,7 @@ def make_density_image(
         scaling = np.divide(shape, blobs.roi_size)
         labels_spacing = np.divide(blobs.resolutions[0], scaling)
         labels_img = np.zeros(shape, dtype=np.uint8)
-        labels_img_sitk = sitk.GetImageFromArray(labels_img)
+        labels_img_sitk = sitk_io.convert_img(labels_img)
         labels_img_sitk.SetSpacing(labels_spacing[::-1])
     
     else:
@@ -265,7 +265,7 @@ def make_density_image(
         if labels_img_sitk is None:
             labels_img_sitk = sitk_io.load_registered_img(
                 mod_path, config.RegNames.IMG_LABELS.value, get_sitk=True)
-        labels_img = sitk.GetArrayFromImage(labels_img_sitk)
+        labels_img = sitk_io.convert_img(labels_img_sitk)
         
         is_2d = labels_img.ndim == 2
         labels_res = list(labels_img_sitk.GetSpacing()[::-1])
@@ -447,7 +447,7 @@ def make_labels_diff_img(img_path, df_path, meas, fn_avg, prefix=None,
     reg_name = (config.RegNames.IMG_LABELS.value if level is None 
                 else config.RegNames.IMG_LABELS_LEVEL.value.format(level))
     labels_sitk = sitk_io.load_registered_img(img_path, reg_name, get_sitk=True)
-    labels_np = sitk.GetArrayFromImage(labels_sitk)
+    labels_np = sitk_io.convert_img(labels_sitk)
     df = pd.read_csv(df_path)
     labels_diff = vols.map_meas_to_labels(
         labels_np, df, meas, fn_avg, col_wt=col_wt)
@@ -507,7 +507,7 @@ def make_labels_level_img(
         labels_sitk = sitk_io.load_registered_img(
             img_path, config.RegNames.IMG_LABELS.value, get_sitk=True)
         ref = ontology.LabelsRef(config.load_labels).load()
-    labels_np = sitk.GetArrayFromImage(labels_sitk)
+    labels_np = sitk_io.convert_img(labels_sitk)
     
     # remap labels to given level
     labels_np = ontology.make_labels_level(labels_np, ref, level)

--- a/magmap/io/export_regions.py
+++ b/magmap/io/export_regions.py
@@ -11,7 +11,10 @@ from collections import OrderedDict
 from time import time
 from typing import Dict, Optional, Sequence, Tuple
 
-import SimpleITK as sitk
+try:
+    import SimpleITK as sitk
+except ImportError:
+    sitk = None
 import numpy as np
 import pandas as pd
 
@@ -466,7 +469,7 @@ def make_labels_diff_img(img_path, df_path, meas, fn_avg, prefix=None,
     imgs_write = {reg_diff: labels_diff_sitk}
     out_path = prefix if prefix else img_path
     sitk_io.write_reg_images(imgs_write, out_path)
-    if show:
+    if show and sitk:
         for img in imgs_write.values():
             if img: sitk.Show(img)
 
@@ -525,7 +528,7 @@ def make_labels_level_img(
     }
     out_path = prefix if prefix else img_path
     sitk_io.write_reg_images(imgs_write, out_path)
-    if show:
+    if show and sitk:
         for img in imgs_write.values():
             if img: sitk.Show(img)
     

--- a/magmap/io/export_regions.py
+++ b/magmap/io/export_regions.py
@@ -1,5 +1,5 @@
 # Region labels export to data frames and CSV files
-# Author: David Young, 2019
+# Author: David Young, 2019, 2023
 """Region labels export to data frames and CSV files.
 
 Convert regions from ontology files or atlases to data frames.
@@ -186,7 +186,7 @@ def export_common_labels(img_paths, output_path):
 def make_density_image(
         img_path: str, scale: Optional[float] = None,
         shape: Optional[Sequence[int]] = None, suffix: Optional[str] = None, 
-        labels_img_sitk: Optional[sitk.Image] = None,
+        labels_img_sitk: Optional["sitk.Image"] = None,
         channel: Optional[Sequence[int]] = None,
         matches: Dict[Tuple[int, int], "colocalizer.BlobMatch"] = None,
         atlas_profile: Optional["atlas_prof.AtlasProfile"] = None,
@@ -474,7 +474,7 @@ def make_labels_diff_img(img_path, df_path, meas, fn_avg, prefix=None,
 def make_labels_level_img(
         img_path: Optional[str], level: int, prefix: Optional[str] = None,
         show: bool = False
-) -> Dict[str, sitk.Image]:
+) -> Dict[str, "sitk.Image"]:
     """Replace labels in an image with their parents at the given level.
     
     Labels that do not fall within a parent at that level will remain in place.

--- a/magmap/io/export_rois.py
+++ b/magmap/io/export_rois.py
@@ -13,7 +13,6 @@ from typing import List, Optional, TYPE_CHECKING
 import numpy as np
 import pandas as pd
 from matplotlib import pyplot as plt
-import SimpleITK as sitk
 
 from magmap.cv import cv_nd, detector
 from magmap.gui import roi_editor
@@ -157,7 +156,7 @@ def export_rois(
             print(img3d.shape, img3d.dtype, img3d_back.shape, img3d_back.dtype)
             print("sitk img:\n{}".format(img3d_back[0]))
             '''
-            sitk.WriteImage(img3d_sitk, path_img_nifti, False)
+            sitk_io.write_img(img3d_sitk, path_img_nifti)
             roi_ed = roi_editor.ROIEditor(img5d)
             print("shape", img3d.shape)
             roi_ed.plot_roi(
@@ -194,9 +193,8 @@ def export_rois(
                 img3d_truth[img3d_truth < 0.5] = 0
             _logger.debug("Exporting truth ROI of shape: %s", img3d_truth.shape)
             np.save(path_img_annot, img3d_truth)
-            sitk.WriteImage(
-                sitk_io.convert_img(img3d_truth), path_img_annot_nifti, 
-                False)
+            sitk_io.write_img(
+                sitk_io.convert_img(img3d_truth), path_img_annot_nifti)
             _logger.info(
                 "Wrote NIfTI formatted images: %s", path_img_annot_nifti)
             # avoid smoothing interpolation, using "nearest" instead

--- a/magmap/io/export_rois.py
+++ b/magmap/io/export_rois.py
@@ -1,5 +1,5 @@
 # ROI exporter for MagellanMapper
-# Author: David Young, 2017, 2019
+# Author: David Young, 2017, 2023
 """ROI exporter for MagellanMapper.
 
 Convert images and corresponding database entries into formats for 
@@ -15,14 +15,11 @@ import pandas as pd
 from matplotlib import pyplot as plt
 import SimpleITK as sitk
 
-from magmap.settings import config
-from magmap.cv import cv_nd
-from magmap.cv import detector
-from magmap.io import libmag
-from magmap.io import sqlite
-from magmap.plot import plot_3d
+from magmap.cv import cv_nd, detector
 from magmap.gui import roi_editor
-from magmap.io import df_io
+from magmap.io import df_io, libmag, sitk_io, sqlite
+from magmap.plot import plot_3d
+from magmap.settings import config
 from magmap.stats import vols
 
 if TYPE_CHECKING:
@@ -152,11 +149,11 @@ def export_rois(
             # WORKAROUND: for some reason SimpleITK gives a conversion error 
             # when converting from uint16 (>u2) Numpy array
             img3d = img3d.astype(np.float64)
-            img3d_sitk = sitk.GetImageFromArray(img3d)
+            img3d_sitk = sitk_io.convert_img(img3d)
             '''
             print(img3d_sitk)
             print("orig img:\n{}".format(img3d[0]))
-            img3d_back = sitk.GetArrayFromImage(img3d_sitk)
+            img3d_back = sitk_io.convert_img(img3d_sitk)
             print(img3d.shape, img3d.dtype, img3d_back.shape, img3d_back.dtype)
             print("sitk img:\n{}".format(img3d_back[0]))
             '''
@@ -198,7 +195,7 @@ def export_rois(
             _logger.debug("Exporting truth ROI of shape: %s", img3d_truth.shape)
             np.save(path_img_annot, img3d_truth)
             sitk.WriteImage(
-                sitk.GetImageFromArray(img3d_truth), path_img_annot_nifti, 
+                sitk_io.convert_img(img3d_truth), path_img_annot_nifti, 
                 False)
             _logger.info(
                 "Wrote NIfTI formatted images: %s", path_img_annot_nifti)

--- a/magmap/io/libmag.py
+++ b/magmap/io/libmag.py
@@ -162,6 +162,37 @@ def pad_seq(
     return seq
 
 
+def replace_seq(
+        seq: Sequence[Any], replacement: Sequence[Any]) -> np.ndarray:
+    """Replace elements in one sequence with those from another.
+    
+    Sequences will be converted to NumPy arrays to support multiple dimensions.
+    
+    Args:
+        seq: Sequence to be replaced.
+        replacement: Sequence to replace in ``seq``. Must be of the same
+            shape and type as those of ``seq``.
+
+    Returns:
+        ``seq`` as a new NumPy array with as many values ass possible replaced
+        by ``replacement``.
+
+    """
+    # convert to np to support multi-dimensional arrays
+    seq_np = np.array(seq)
+    tgt_np = np.array(replacement)
+    
+    # truncate to smallest shape in all dimension
+    shape = np.minimum(seq_np.shape, tgt_np.shape)
+    slices = []
+    for s in shape:
+        slices.append(slice(s))
+    slices = tuple(slices)
+    seq_np[slices] = tgt_np[slices]
+    
+    return seq_np
+
+
 def combine_arrs(arrs, filter_none=True, fn=None, **kwargs):
     """Combine arrays with array filtering.
     

--- a/magmap/io/libmag.py
+++ b/magmap/io/libmag.py
@@ -117,30 +117,37 @@ def roll_elements(arr, shift, axis=None):
     return arr
 
 
-def pad_seq(seq, n, pad=None):
-    """Pad a sequence with a given value or truncate the sequence to fit 
-    a given length.
+def pad_seq(
+        seq: Sequence[Any], n: int, pad: Optional[Any] = None) -> Sequence[Any]:
+    """Pad a sequence with a given value or truncate to fit a given length.
     
     Args:
-        seq (List): Sequence to fill in-place.
-        n (int): Target length.
-        pad (float, List): Value with which to fill; defaults to None.
-            If a sequence, filling with start with the first corresponding
-            missing value in ``seq``.
+        seq: Sequence to fill in-place.
+        n: Target length.
+        pad: Value with which to fill; defaults to None.
+            If a sequence, missing values in ``seq`` will be filled with
+            corresponding values in ``pad``.
     
     Returns:
-        :List: A truncated view of ``seq`` if the sequence is longer than ``n``
-        or ``seq`` as a List with ``pad`` appended to reach a length of ``n``.
+        A truncated view of ``seq`` if the sequence is longer than ``n``
+        or ``seq`` with ``pad`` appended to reach a length of ``n``. ``seq``
+        is modified in-place if it is extended and not a NumPy array.
+    
     """
     len_seq = len(seq)
     if len_seq >= n:
         # truncate if seq is longer than n is
         seq = seq[:n]
+    
     else:
-        # pad with the given value
         if isinstance(seq, np.ndarray):
             # convert to list if ndarray to allow mixing with None values
             seq = seq.tolist()
+        elif isinstance(seq, tuple):
+            # convert to list to allow adding values
+            seq = list(seq)
+
+        # pad with the given value
         if is_seq(pad):
             if len(pad) > len_seq:
                 # fill starting with corresponding first missing value
@@ -151,6 +158,7 @@ def pad_seq(seq, n, pad=None):
         else:
             # fill with pad value repeats
             seq += [pad] * (n - len_seq)
+    
     return seq
 
 

--- a/magmap/io/np_io.py
+++ b/magmap/io/np_io.py
@@ -458,7 +458,7 @@ def setup_images(
         if bg_atlas:
             # extract labels image from BrainGlobe atlas
             config.labels_img = bg_atlas.annotation
-            config.labels_img_sitk = sitk_io.numpy_to_sitk(config.labels_img)
+            config.labels_img_sitk = sitk_io.convert_img(config.labels_img)
         else:
             try:
                 # load labels image

--- a/magmap/io/sitk_io.py
+++ b/magmap/io/sitk_io.py
@@ -129,10 +129,10 @@ def replace_sitk_with_numpy(
         img_np, multichannel, sitk and isinstance(img_sitk, sitk.Image))
     
     # transfer original settings to new Image, matching length for ITK
-    spacing = libmag.pad_seq(tuple(spacing), len(img_sitk_back.GetSpacing()), 1)
-    origin = libmag.pad_seq(tuple(origin), len(img_sitk_back.GetOrigin()), 1)
-    img_sitk_back.SetSpacing(tuple(spacing))
-    img_sitk_back.SetOrigin(tuple(origin))
+    spacing = libmag.replace_seq(img_sitk_back.GetSpacing(), spacing)
+    origin = libmag.replace_seq(img_sitk_back.GetOrigin(), origin)
+    img_sitk_back.SetSpacing(spacing)
+    img_sitk_back.SetOrigin(origin)
     
     # convert directions to 2D arrays if necessary
     dir_np = np.array(direction)
@@ -144,8 +144,7 @@ def replace_sitk_with_numpy(
             np.array(dir_back), [len(img_sitk_back.GetSpacing())] * 2)
     
     # fill target direction with source, truncating it if necessary for ITK
-    shape = np.minimum(dir_np.shape, dir_back.shape)
-    dir_back[:shape[0], :shape[1]] = dir_np[:shape[0], :shape[1]]
+    dir_back = libmag.replace_seq(dir_back, dir_np)
     if is_dir_1d:
         dir_back = np.ravel(dir_back)
     

--- a/magmap/io/sitk_io.py
+++ b/magmap/io/sitk_io.py
@@ -27,23 +27,6 @@ from magmap.io import libmag
 EXTS_3D: Sequence[str] = (".mhd", ".mha", ".nii.gz", ".nii", ".nhdr", ".nrrd")
 # TODO: include all formats supported by SimpleITK
 
-# Mapping of NumPy dtypes to SimpleITK pixel IDs.
-_DTYPES_NP_SITK: Dict[str, Any] = {
-    np.dtype(np.character).name: sitk.sitkUInt8,
-    np.dtype(np.uint8).name: sitk.sitkUInt8,
-    np.dtype(np.uint16).name: sitk.sitkUInt16,
-    np.dtype(np.uint32).name: sitk.sitkUInt32,
-    np.dtype(np.uint64).name: sitk.sitkUInt64,
-    np.dtype(np.int8).name: sitk.sitkInt8,
-    np.dtype(np.int16).name: sitk.sitkInt16,
-    np.dtype(np.int32).name: sitk.sitkInt32,
-    np.dtype(np.int64).name: sitk.sitkInt64,
-    np.dtype(np.float32).name: sitk.sitkFloat32,
-    np.dtype(np.float64).name: sitk.sitkFloat64,
-    np.dtype(np.complex64).name: sitk.sitkComplexFloat32,
-    np.dtype(np.complex128).name: sitk.sitkComplexFloat64,
-}
-
 _logger = config.logger.getChild(__name__)
 
 
@@ -728,26 +711,6 @@ def load_numpy_to_sitk(
     sitk_img.SetOrigin([0, 0, -roi.shape[0] // 2])
     #sitk_img.SetOrigin([0, 0, -roi.shape[0]])
     return sitk_img
-
-
-def numpy_to_sitk(img: np.ndarray):
-    """Wrapper to convert a NumPy array to a SimpleITK Image object.
-    
-    Args:
-        img: NumPy array.
-
-    Returns:
-        ``img`` as a SimpleITK Image object with default settings.
-
-    """
-    try:
-        img_sitk = sitk.GetImageFromArray(img)
-    except TypeError:
-        # WORKAROUND: sitk may not match img's dtype to sitk pixel IDs; match
-        # based on dtype name instead of dtype object identity
-        img_sitk = sitk.Image(
-            img.shape[::-1], _DTYPES_NP_SITK[np.dtype(img.dtype).name])
-    return img_sitk
 
 
 def sitk_to_itk_img(sitk_img: "sitk.Image") -> "itk.Image":

--- a/magmap/settings/config.py
+++ b/magmap/settings/config.py
@@ -32,7 +32,14 @@ import numpy as np
 from magmap.settings import logs
 
 if TYPE_CHECKING:
-    import SimpleITK as sitk
+    try:
+        import itk
+    except ImportError:
+        itk = None
+    try:
+        import SimpleITK as sitk
+    except ImportError:
+        sitk = None
     from magmap.atlas import labels_meta, ontology
     from magmap.cv import detector
     from magmap.io import np_io
@@ -607,8 +614,6 @@ class RegNames(Enum):
     COMBINED = "combined.mhd"  # spliced into other registered names
 
 
-#: Path to labels image metadata file. 
-
 #: Loaded labels metadata.
 labels_metadata: Optional["labels_meta.LabelsMeta"] = None
 
@@ -620,10 +625,10 @@ labels_level: Optional[int] = None
 #: Numpy array of a labels image file, typically corresponding to ``img5d``.
 labels_img: Optional = None
 #: Labels image as a SimpleITK Image instance.
-labels_img_sitk: Optional["sitk.Image"] = None
+labels_img_sitk: Optional[Union["sitk.Image", "itk.Image"]] = None
 #: Original labels image, before any processing.
 labels_img_orig: Optional[np.ndarray] = None
-#: Scaling factors from ``labels_img`` to ``img5d``. 
+#: Scaling factors from ``labels_img`` to ``img5d``.
 labels_scaling: Optional[Sequence[float]] = None
 #: Labels reference IDs corresponding to the labels image values.
 labels_ref: Optional["ontology.LabelsRef"] = None
@@ -632,8 +637,8 @@ borders_img = None
 
 VOL_KEY = "volume"
 BLOBS_KEY = "blobs"
-VARIATION_BLOBS_KEY = "var_blobs" # variation in blob density
-VARIATION_EXP_KEY = "var_exp" # variation in experiment intensity
+VARIATION_BLOBS_KEY = "var_blobs"  # variation in blob density
+VARIATION_EXP_KEY = "var_exp"  # variation in experiment intensity
 GENOTYPE_KEY = "Geno"
 SUB_SEG_MULT = 100  # labels multiplier for sub-segmentations
 REGION_ALL = "all"

--- a/magmap/stats/atlas_stats.py
+++ b/magmap/stats/atlas_stats.py
@@ -1,5 +1,5 @@
 # Atlas measurements and statistics
-# Author: David Young, 2019, 2021
+# Author: David Young, 2019, 2023
 """Low-level measurement of atlases and statistics generation.
 
 Typically applied to specific types of atlases and less generalizable
@@ -10,7 +10,6 @@ from typing import Optional, Sequence
 
 import numpy as np
 import pandas as pd
-import SimpleITK as sitk
 
 from magmap.atlas import atlas_refiner, ontology
 from magmap.io import df_io, export_stack, libmag, np_io, sitk_io
@@ -562,7 +561,7 @@ def meas_landmark_dist(
     
     # transpose 2nd image with any config settings
     labels_imgs[1] = atlas_refiner.transpose_img(labels_imgs[1])
-    labels_imgs = [sitk.GetArrayFromImage(m) for m in labels_imgs]
+    labels_imgs = [sitk_io.convert_img(m) for m in labels_imgs]
     
     # set up output path and sample name based on 1st image's path
     out_path = libmag.make_out_path(libmag.combine_paths(

--- a/magmap/tests/test_libmag.py
+++ b/magmap/tests/test_libmag.py
@@ -4,6 +4,7 @@
 
 import unittest
 
+import numpy as np
 
 from magmap.io import libmag
 
@@ -32,6 +33,14 @@ class TestLibmag(unittest.TestCase):
         # modifies the original sequence
         self.assertSequenceEqual(libmag.pad_seq(seq, 4), ["a", "b", "c", None])
         self.assertSequenceEqual(seq, ["a", "b", "c", None])
+    
+    def test_replace_seq(self):
+        seq = [1, 2, 3]
+        np.testing.assert_array_equal(
+            libmag.replace_seq(seq, [10, 20]), [10, 20, 3])
+        np.testing.assert_array_equal(
+            libmag.replace_seq(seq, [10, 20, 30, 40]), [10, 20, 30])
+        np.testing.assert_array_equal(libmag.replace_seq(seq, []), [1, 2, 3])
     
     def test_flatten(self):
         self.assertSequenceEqual(

--- a/magmap/tests/test_libmag.py
+++ b/magmap/tests/test_libmag.py
@@ -10,6 +10,29 @@ from magmap.io import libmag
 
 class TestLibmag(unittest.TestCase):
     
+    def test_pad_seq(self):
+        seq = ["a", "b", "c"]
+        self.assertSequenceEqual(libmag.pad_seq(list(seq), 2), ["a", "b"])
+        self.assertSequenceEqual(libmag.pad_seq(list(seq), 3), ["a", "b", "c"])
+        self.assertSequenceEqual(
+            libmag.pad_seq(list(seq), 4), ["a", "b", "c", None])
+        self.assertSequenceEqual(
+            libmag.pad_seq(list(seq), 4, 1), ["a", "b", "c", 1])
+        self.assertSequenceEqual(
+            libmag.pad_seq(list(seq), 5, [1, 2, 3, 4, 5]), ["a", "b", "c", 4, 5])
+        
+        # fills with last pad value since pad is shorter than seq is
+        self.assertSequenceEqual(
+            libmag.pad_seq(list(seq), 5, [1, 2]), ["a", "b", "c", 2, 2])
+        
+        # modifies the original sequence
+        self.assertSequenceEqual(libmag.pad_seq(tuple(seq), 4), ["a", "b", "c", None])
+        self.assertSequenceEqual(seq, ["a", "b", "c"])
+        
+        # modifies the original sequence
+        self.assertSequenceEqual(libmag.pad_seq(seq, 4), ["a", "b", "c", None])
+        self.assertSequenceEqual(seq, ["a", "b", "c", None])
+    
     def test_flatten(self):
         self.assertSequenceEqual(
             list(libmag.flatten(["a", "b"])), ["a", "b"])

--- a/setup.py
+++ b/setup.py
@@ -50,10 +50,16 @@ _EXTRAS_GUI = [
 #: Optional dependencies for the 3D viewer.
 _EXTRAS_3D = ["mayavi"]
 
-#: Optional pre-built SimpleITK with Elastix.
-_SIMPLEITK = [
+#: Optional pre-built SimpleITK with Elastix for image I/O and registration.
+_EXTRAS_SIMPLEITK = [
     "simpleitk==2.0.2rc2.dev785+g8ac4f ; python_version < '3.8'",
     "simpleitk==2.3.0.dev117+g0640d ; python_version >= '3.8'",
+]
+
+#: Optional ITK and Elastix for image I/O and registration.
+_EXTRAS_ITK = [
+    "itk",
+    "itk-elastix",
 ]
 
 
@@ -80,11 +86,6 @@ config = {
         # PlotEditor performance regression with 3.3.0-3.3.1
         "matplotlib != 3.3.0, != 3.3.1",
         "pandas",
-        
-        # image registration toolkits
-        "itk",
-        "itk-elastix",
-        
         "PyYAML",
         "appdirs",
         # part of stdlib in Python >= 3.8
@@ -108,13 +109,15 @@ config = {
         "classifier": _EXTRAS_CLASSIFER,
         "gui": _EXTRAS_GUI,
         "3d": _EXTRAS_3D,
-        "simplitk": _SIMPLEITK,
+        "itk": _EXTRAS_ITK,
+        "simplitk": _EXTRAS_SIMPLEITK,
         
         # dependencies for most common tasks
         "most": [
             "matplotlib_scalebar",
             "pyamg",  # for Random-Walker segmentation "cg_mg" mode
             *_EXTRAS_GUI,
+            *_EXTRAS_ITK,
             *_EXTRAS_IMPORT,
         ],
         
@@ -126,6 +129,7 @@ config = {
             "scikit-learn",
             *_EXTRAS_GUI,
             *_EXTRAS_PANDAS,
+            *_EXTRAS_ITK,
             *_EXTRAS_IMPORT,
             *_EXTRAS_AWS,
             *_EXTRAS_JUPYTER,

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,13 @@ _EXTRAS_GUI = [
 #: Optional dependencies for the 3D viewer.
 _EXTRAS_3D = ["mayavi"]
 
+#: Optional pre-built SimpleITK with Elastix.
+_SIMPLEITK = [
+    "simpleitk==2.0.2rc2.dev785+g8ac4f ; python_version < '3.8'",
+    "simpleitk==2.3.0.dev117+g0640d ; python_version >= '3.8'",
+]
+
+
 # installation configuration
 config = {
     "name": "magellanmapper",
@@ -75,7 +82,6 @@ config = {
         "pandas",
         
         # image registration toolkits
-        "simpleitk",
         "itk",
         "itk-elastix",
         
@@ -102,6 +108,7 @@ config = {
         "classifier": _EXTRAS_CLASSIFER,
         "gui": _EXTRAS_GUI,
         "3d": _EXTRAS_3D,
+        "simplitk": _SIMPLEITK,
         
         # dependencies for most common tasks
         "most": [


### PR DESCRIPTION
Addresses #496. This PR change SimpleITK from a required to an optional dependency. Equivalent support for most SimpleITK functionality has been implemented through ITK-Elastix. I/O operations have been moved into wrapper functions that support both libraries, while #495 added support to ITK-Elastix in image registration functions.

To determine which library to use, the following approach is applied:
- Functions that take an image as input determine the library based on the type of the image, either `sitk.Image` or `itk.Image`
- If a function does not take an image, the type of other objects is used if available, eg the Transformix filter in registration functions
- If no arguments are available to specify type, SimpleITK will be used if installed
- Otherwise, ITK will be used and assumed to be installed