### PR TITLE
Use BrainGlobe Atlas API from PyPI

### DIFF
--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -188,7 +188,7 @@
 #### Python Dependency Changes
 
 - Python 3.8 is the default version now that Python 3.6 has reached End-of-Life
-- The BrainGlobe Atlas API package (`bg-atlasapi`) dependency has been added to access a suite of cloud-based atlases (#75, #443)
+- The BrainGlobe Atlas API package (`bg-atlasapi`) dependency has been added to access a suite of cloud-based atlases (#75, #443, #498)
 - The `dataclasses` backport is installed for Python < 3.7
 - `Tifffile` is now a direct dependency, previously already installed as a sub-dependency of other required packages
 - `Imagecodecs` is optional for `tifffile` but required for its uses here as of `tifffile v2022.7.28` and thus added as a dependency (#153)

--- a/setup.py
+++ b/setup.py
@@ -87,9 +87,7 @@ config = {
         "imagecodecs",
         # part of stdlib in Python >= 3.7
         "dataclasses ; python_version < '3.7'",
-        # BrainGlobe dependencies for access to cloud-hosted atlases, pinned
-        # to last commit supporting Python >= 3.6
-        "bg-atlasapi @ https://github.com/brainglobe/bg-atlasapi/archive/dbecd16b2f63a8e167543f3358452a756bad0e64.tar.gz",
+        "bg-atlasapi",
         "typing_extensions",
     ],
     "extras_require": {


### PR DESCRIPTION
We currently install the BrainGlobe Atlas API from a pre-release Git commit to use a download progress handler, but PyPI does not allow packages that depend on these releases outside of PyPI. Here we fall back to allow the current Atlas API release, without a progress handler. When the handler is not available, the progress bar will not become a busy indicator to show an indeterminate but ongoing download. This change also benefits atlases that do not report their full download size for some reason. We also tweaked the progress bar message so that it should update more reliably and show the atlas being downloaded.