### PR TITLE
Fix reversing image spacing for images loaded by ITK

### DIFF
--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -82,7 +82,7 @@
 - Masks with angle planes can be constructed (#252)
 - `register.RegImgs` is a data class to track registered images (#335)
 - Supports image I/O and registration through ITK
-  - `ITK-Elastix` support has been added as an alternative to `SimpleITK` (#495, #500)
+  - `ITK-Elastix` support has been added as an alternative to `SimpleITK` (#495, #500, #504)
   - Both libraries are now optional rather than required dependencies (#497)
   - Better support for image direction metadata (#497)
 - Fixed changes to large label IDs during registration (#303)

--- a/magmap/atlas/atlas_refiner.py
+++ b/magmap/atlas/atlas_refiner.py
@@ -402,7 +402,7 @@ def _curate_labels(img, img_ref, mirror=None, edge=None, expand=None,
         # be overwritten
         img_smoothed = img_np[:mirrori]
         img_smoothed_orig = np.copy(img_smoothed)
-        spacing = img.GetSpacing()[::-1]
+        spacing = tuple(img.GetSpacing())[::-1]
         if libmag.is_seq(smooth):
             # test sequence of filter sizes via multiprocessing for metrics
             # only, in which case the images will be left unchanged
@@ -1546,7 +1546,7 @@ def import_atlas(
     sitk_io.write_reg_images(
         imgs_write, name_prefix, copy_to_suffix=True, 
         ext=os.path.splitext(path_atlas)[1])
-    config.resolutions = [img_atlas.GetSpacing()[::-1]]
+    config.resolutions = [tuple(img_atlas.GetSpacing())[::-1]]
     img_ref_np = sitk_io.convert_img(img_atlas)
     img_ref_np = img_ref_np[None]
     importer.save_np_image(img_ref_np, name_prefix, 0)
@@ -1625,7 +1625,7 @@ def measure_atlas_refinement(
     thresh = atlas_profile["atlas_threshold_all"]
     thresh_atlas = img_atlas_np > thresh
     compactness, _, _ = cv_nd.compactness_3d(
-        thresh_atlas, img_atlas.GetSpacing()[::-1])
+        thresh_atlas, tuple(img_atlas.GetSpacing())[::-1])
     metrics[config.SmoothingMetrics.COMPACTNESS] = [compactness]
 
     _logger.info("\nWhole atlas stats:")

--- a/magmap/atlas/edge_seg.py
+++ b/magmap/atlas/edge_seg.py
@@ -124,7 +124,7 @@ def make_edge_images(path_img, show=True, atlas=True, suffix=None,
     # load atlas image, set resolution from it
     atlas_sitk = sitk_io.load_registered_img(
         path_atlas, atlas_suffix, get_sitk=True)
-    config.resolutions = np.array([atlas_sitk.GetSpacing()[::-1]])
+    config.resolutions = np.array([tuple(atlas_sitk.GetSpacing())[::-1]])
     atlas_np = sitk_io.convert_img(atlas_sitk)
     
     if config.rgb:
@@ -172,7 +172,7 @@ def make_edge_images(path_img, show=True, atlas=True, suffix=None,
     labels_sitk_edge = None
     if config.atlas_profile["meas_edge_dists"]:
         dist_to_orig, labels_edge = edge_distances(
-            labels_img_np, atlas_edge, spacing=atlas_sitk.GetSpacing()[::-1])
+            labels_img_np, atlas_edge, spacing=tuple(atlas_sitk.GetSpacing())[::-1])
         dist_sitk = sitk_io.replace_sitk_with_numpy(atlas_sitk, dist_to_orig)
         labels_sitk_edge = sitk_io.replace_sitk_with_numpy(
             labels_sitk, labels_edge)
@@ -341,7 +341,7 @@ def edge_aware_segmentation(
         cond.append("smoothing")
         df_aggr, df_raw = atlas_refiner.smooth_labels(
             labels_seg, smoothing, smoothing_mode,
-            meas_smoothing, labels_sitk.GetSpacing()[::-1])
+            meas_smoothing, tuple(labels_sitk.GetSpacing())[::-1])
         df_base_path = os.path.splitext(mod_path)[0]
         if df_raw is not None:
             # write raw smoothing metrics
@@ -482,7 +482,7 @@ def merge_atlas_segmentations(img_paths, show=True, atlas=True, suffix=None):
                 # make edge distance images and stats
                 dist_to_orig, labels_edge = edge_distances(
                     labels_np, path=path,
-                    spacing=labels_sitk.GetSpacing()[::-1])
+                    spacing=tuple(labels_sitk.GetSpacing())[::-1])
                 dist_sitk = sitk_io.replace_sitk_with_numpy(
                     labels_sitk, dist_to_orig)
                 labels_sitk_edge = sitk_io.replace_sitk_with_numpy(

--- a/magmap/atlas/register.py
+++ b/magmap/atlas/register.py
@@ -984,7 +984,7 @@ def register(
     fixed_img_orig_np = sitk_io.convert_img(fixed_img_orig)
     thresh_atlas = fixed_img_orig_np > filters.threshold_mean(fixed_img_orig_np)
     compactness, _, _ = cv_nd.compactness_3d(
-        thresh_atlas, fixed_img_orig.GetSpacing()[::-1])
+        thresh_atlas, tuple(fixed_img_orig.GetSpacing())[::-1])
     
     # save basic metrics in CSV file
     basename = libmag.get_filename_without_ext(fixed_file)
@@ -1734,7 +1734,7 @@ def volumes_by_id(
                 img_sitk = sitk_io.load_registered_img(
                     mod_path, config.RegNames.IMG_ATLAS.value, get_sitk=True)
             img_np = sitk_io.convert_img(img_sitk)
-            spacing = img_sitk.GetSpacing()[::-1]
+            spacing = tuple(img_sitk.GetSpacing())[::-1]
             
             # load labels in order of priority: config > full labels
             # > truncated labels; required so give exception if not found
@@ -1925,7 +1925,7 @@ def volumes_by_id_compare(img_paths, labels_ref_paths, unit_factor=None,
                     img_path, config.RegNames.IMG_LABELS.value, get_sitk=True)
             labels_imgs_sitk.append(img)
         labels_imgs = [sitk_io.convert_img(img) for img in labels_imgs_sitk]
-        spacing = labels_imgs_sitk[0].GetSpacing()[::-1]
+        spacing = tuple(labels_imgs_sitk[0].GetSpacing())[::-1]
         
         # load heat map of nuclei per voxel if available based on 1st path
         try:

--- a/magmap/io/sitk_io.py
+++ b/magmap/io/sitk_io.py
@@ -396,7 +396,7 @@ def read_sitk_files(
         _logger.warn(
             "MagellanMapper image metadata file not loaded; will fallback to "
             "%s for metadata", loaded_path)
-        config.resolutions = np.array([img_sitk.GetSpacing()[::-1]])
+        config.resolutions = np.array([tuple(img_sitk.GetSpacing())[::-1]])
         _logger.debug("set resolutions to %s", config.resolutions)
     
     # add time axis and insert into Image5d with original name


### PR DESCRIPTION
The spacing object must be cast to a standard sequence before reversal.