### PR TITLE
Fix displaying atlas labels on rotated images

### DIFF
--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -45,7 +45,7 @@
   - Image adjustment channels are radio buttons for easier selection (#212)
   - Fixed synchronization between the ROI Editor and image adjustment controls after initialization (#142)
   - Fixed redundant triggers when adjusting the displayed image (#474)
-- Images are rotated by dynamic transformation (#214, #471)
+- Images are rotated by dynamic transformation (#214, #471, #505)
 - Smoother, faster interactions with main plots, including atlas label name display, label editing, and pan and zoom navigation (#317, #335, #359, #367)
 - Atlas labels adapt better in zoomed images to stay within each plot (#317)
 - Fixed to reset the ROI selector when redrawing (#115)

--- a/magmap/plot/plot_support.py
+++ b/magmap/plot/plot_support.py
@@ -807,7 +807,9 @@ class ImageOverlayer:
         # small annotations with subtle background in case label is dark
         args = dict(
             fontsize="x-small", clip_on=True, horizontalalignment="center",
-            verticalalignment="center", bbox=bbox, transform=self._transform)
+            verticalalignment="center", bbox=bbox)
+        if self._transform and self._transform.transform:
+            args["transform"] = self._transform.transform
         text_color = "k"
         facecolor = "xkcd:silver"
         for label_id, label in labels.items():


### PR DESCRIPTION
PR #471 introduced a regression where the transformation data class was added as an argument to the Matplotlib text annotation when only the transform itself should be added. Add this transform only when both the data class instance and transform are present since a transform of None also appears to override any default transform.