### PR TITLE
Fix removal of `selem` parameter in Scikit-image v0.20

### DIFF
--- a/magmap/cv/colocalizer.py
+++ b/magmap/cv/colocalizer.py
@@ -390,7 +390,12 @@ def colocalize_blobs(roi, blobs, thresh=None):
         mask = np.copy(mask_roi) * -1
         mask[tuple(libmag.coords_for_indexing(
             blobs_roi[blobs_chl_mask, :3].astype(int)))] = blobs_range
-        mask = morphology.dilation(mask, selem=selem)
+        try:
+            # Scikit-image >= v0.20
+            mask = morphology.dilation(mask, footprint=selem)
+        except TypeError:
+            # Scikit-image < v0.20
+            mask = morphology.dilation(mask, selem=selem)
         mask_roi_chls.append(mask)
         
         if thresh == "min":


### PR DESCRIPTION
Change this parameter to its replacement, `footprint` (see Scikit-image[ v0.20 release notes](https://scikit-image.org/docs/dev/release_notes/release_0.20.html#completed-deprecations)).