### PR TITLE
Test fresh dependencies in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,6 +59,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Cache pip
         uses: actions/cache@v3
+        if: ${{ matrix.dependencies == 'pinned' }}
         with:
           # python environment path from setup-python
           path: ${{ env.pythonLocation }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10, 3.11]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
         dependencies:
           - pinned
           - fresh
@@ -34,6 +34,10 @@ jobs:
             python-version: 3.8
           - os: ubuntu-20.04
             python-version: 3.9
+          - os: ubuntu-20.04
+            python-version: "3.10"
+          - os: ubuntu-20.04
+            python-version: "3.11"
           - os: ubuntu-latest
             python-version: 3.6
     

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,9 +24,6 @@ jobs:
       matrix:
         os: [ubuntu-20.04, ubuntu-latest, macos-latest, windows-latest]
         python-version: [3.6, 3.7, 3.8, 3.9]
-        include:
-          - os: macos-latest
-            python-version: 3.7.16
         exclude:
           - os: ubuntu-20.04
             python-version: 3.7
@@ -36,12 +33,10 @@ jobs:
             python-version: 3.9
           - os: ubuntu-latest
             python-version: 3.6
-          - os: macos-latest
-            python-version: 3.7
     
     env:
       # set requirements path based on Python version
-      REQS: ${{ matrix.python-version == '3.6' && 'envs/requirements_py36' || matrix.python-version == '3.7' && 'envs/requirements_py37' || matrix.python-version == '3.7.16' && 'envs/requirements_py37' || 'envs/requirements.txt'}}
+      REQS: ${{ matrix.python-version == '3.6' && 'envs/requirements_py36' || matrix.python-version == '3.7' && 'envs/requirements_py37' || 'envs/requirements.txt'}}
 
     steps:
       - name: Check out repo

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10, 3.11]
         dependencies:
           - pinned
           - fresh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,9 @@ jobs:
       matrix:
         os: [ubuntu-20.04, ubuntu-latest, macos-latest, windows-latest]
         python-version: [3.6, 3.7, 3.8, 3.9]
+        dependencies:
+          - pinned
+          - fresh
         exclude:
           - os: ubuntu-20.04
             python-version: 3.7
@@ -57,13 +60,22 @@ jobs:
           path: ${{ env.pythonLocation }}
           # check for cache from the corresponding requirements file
           key: ${{ env.pythonLocation }}-pip-${{ hashFiles(env.REQS) }}
-      - name: Install dependencies
-        env:
-          QT_QPA_PLATFORM: offscreen
+      - name: Set up dependencies
         run: |
           python -m pip install --upgrade pip setuptools wheel
           pip install flake8
+      - name: Install pinned dependencies
+        if: ${{ matrix.dependencies == 'pinned' }}
+        env:
+          QT_QPA_PLATFORM: offscreen
+        run: |
           pip install -r ${{ env.REQS }}
+      - name: Install fresh dependencies
+        if: ${{ matrix.dependencies == 'fresh' }}
+        env:
+          QT_QPA_PLATFORM: offscreen
+        run: |
+          pip install .
       - name: Lint with flake8
         run: |
           # stop the build if there are Python syntax errors or undefined names

--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -189,6 +189,7 @@
 - Jupyter Notebook as a tutorial for running various tasks in the CLI (#122)
 - Documentation is now [hosted on ReadTheDocs](https://magellanmapper.readthedocs.io/en/latest/index.html), using the Furo theme (#225)
 - Default arguments are documented in API auto-docs (#485)
+- Expand continuous integration testing to both pinned and fresh dependencies across Python 3.6-3.11 (#75, #101, #252, #342, #538)
 
 ### Dependency Updates
 


### PR DESCRIPTION
The CI has been testing pinned dependencies using the current `requirements.txt` file. Dependency packages are cached, updated only when this file changes, and updated to the specific versions of all dependencies in this file. While this setup reduces time CI setup time, it does not test updates to the latest dependency updates that may cause installation breakages, such as those addressed in #431 and #510.

This PR test these latest dependencies by adding a CI setup configuration for "fresh" dependencies. In this setup, Pip skips the cache and installs the current dependency versions rather than using `requirements.txt`. Installation without any install groups has fewer dependencies than `requirements.txt` does since requirements has dependencies from extra install groups. Without these dependencies, the fresh install footprint is considerably smaller and remains fairly snappy.

Changes were partially inspired by [here](https://github.com/TileDB-Inc/TileDB-Cloud-Py/pull/429). This PR also reverts commit 47185af590cbf72eca58bfeb3cce812c88edfc96 now that the CI no longer requires pinning Python 3.7 at 3.7.16 for macOS now that the runner has been fixed (see https://github.com/actions/setup-python/issues/682).