### PR TITLE
Fix remembering the labels image opacity

### DIFF
--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -42,7 +42,7 @@
 - Atlas Editor planes can be reordered or turned off (#180)
 - EXPERIMENTAL: New viewer that displays each blob separately to verify blob classifications (#193)
 - Image adjustment
-  - "Merge" option in the ROI panel to merge channels using additive blending (#492)
+  - "Merge" option in the ROI panel to merge channels using additive blending (#492, #552)
   - "Blend" option in the image adjustment panel to visualize alignment in overlaid images (#89, #450)
   - Image adjustment channels are radio buttons for easier selection (#212)
   - Fixed synchronization between the ROI Editor and image adjustment controls after initialization (#142)

--- a/magmap/gui/plot_editor.py
+++ b/magmap/gui/plot_editor.py
@@ -513,7 +513,7 @@ class PlotEditor:
         imgs2d = [self._get_img2d(0, self.img3d, self.max_intens_proj)]
         self._channels = [config.channel]
         cmaps = [config.cmaps]
-        alphas = self.alpha_img3d
+        alphas = list(self.alpha_img3d)
         alpha_is_default = True
         alpha_blends = [None]
         shapes = [self._img3d_shapes[0][1:3]]


### PR DESCRIPTION
Commit b754375e3cca72f1da1d8a407e93675cd3d59b80 introduced a regression where alpha values would repeatedly be appended to a single list instead of creating a new list each time a new image was shown, fixed here.