### PR TITLE
Fix ReadTheDocs for Python 3.9

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,7 +12,7 @@ build:
     - libsm6
     - libgl1-mesa-glx
   tools:
-    python: "3.8"
+    python: "3.9"
     # You can also specify other tool versions:
     # nodejs: "16"
     # rust: "1.55"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -57,7 +57,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'MagellanMapper'
-copyright = '2017-2022, David Young'
+copyright = '2017-2023, David Young'
 author = 'David Young'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/install.md
+++ b/docs/install.md
@@ -35,7 +35,7 @@ The `mm` entry points was added in v1.6.0 to facilitate launching from installed
 
 ### Install using Pip
 
-Install using Pip with Python >= 3.6 (see [Python versions](#python-version-support); [virtual environment](https://realpython.com/python-virtual-environments-a-primer/) recommended):
+Install using Pip with Python >= 3.6 (see [Python versions](#python-version-support); Python >= 3.9 and [virtual environment](https://realpython.com/python-virtual-environments-a-primer/) recommended):
 
 ```shell
 pip install "magellanmapper[most]" --extra-index-url https://pypi.fury.io/dd8/
@@ -172,7 +172,7 @@ Sometimes a virtual environment update is required for new depdendencies.
 
 | MagellanMapper Version | Python Versions Supported | Notes |
 |-----|-----|-----|
-| 1.7 (planned) | 3.8-3.11 | 3.6-3.7 to be removed |
+| 1.7 (planned) | 3.9-3.11 | 3.6-3.8 to be removed |
 | >=1.6b1 | 3.6-3.11 | Defaults to 3.9. GUI support added for 3.10-3.11 in MM 1.6b2. |
 | 1.6a1-a3 | 3.6-3.9 | GUI support added for 3.9; MM 1.6a2 base group no longer installs GUI |
 | 1.4-1.5 | 3.6-3.9 | No GUI support in 3.9 |

--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -187,7 +187,7 @@
 - Blob column accessors are encapsulated in the `Blobs` class, which allows for flexibility in column inclusion and order (#133)
 - Settings profiles are being migrated from dictionaries to data classes to document and configure settings more easily (#138)
 - Jupyter Notebook as a tutorial for running various tasks in the CLI (#122)
-- Documentation is now [hosted on ReadTheDocs](https://magellanmapper.readthedocs.io/en/latest/index.html), using the Furo theme (#225)
+- Documentation is now [hosted on ReadTheDocs](https://magellanmapper.readthedocs.io/en/latest/index.html), using the Furo theme (#225, #563)
 - Default arguments are documented in API auto-docs (#485)
 - Expand continuous integration testing to both pinned and fresh dependencies across Python 3.6-3.11 (#75, #101, #252, #342, #538)
 
@@ -196,8 +196,8 @@
 #### Python Dependency Changes
 
 - Python 3.10-3.11 are now supported (#379, #517)
-- Python 3.9 is the default version now that Python 3.6 has reached End-of-Life, and NumPy no longer supports Python 3.8 (#559)
-- Python 3.6 and 3.7 have been deprecated for removal in MM v1.7 and have separate pinned dependencies (`envs/requirements_py3<n>`) (#232, #379)
+- Python 3.9 is the default version now that Python 3.6 has reached End-of-Life, and NumPy no longer supports Python 3.8 (#559, #563)
+- Python 3.6-8 have been deprecated for removal in MM v1.7 and have separate pinned dependencies (`envs/requirements_py3<n>`) (#232, #379)
 - Custom dependency binaries are now built for Python 3.8-3.11 (#379)
 - The BrainGlobe Atlas API package (`bg-atlasapi`) dependency has been added to access a suite of cloud-based atlases (#75, #443, #498)
 - The `dataclasses` backport is installed for Python < 3.7


### PR DESCRIPTION
#559 did not update the ReadTheDocs documentation configuration to use Python 3.9, which is required to build the docs environment using the existing `requirements.txt` file.