### PR TITLE
Extend image adjustment sliders to use full intensity range

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -207,6 +207,16 @@ These package versions are used for automated testing (continuous integration).
 | `pandas_plus` | Exports styled and Excel formats | |
 | `simpleitk` | Custom SimpleITK with Elastix | |
 
+To add an install group:
+
+```shell
+pip install "magellanmapper[3d]" # add "3d" group
+pip install "magellanmapper[3d,gui]" # add two groups
+pip install -e ".[3d]" # same but for editable install from clone
+```
+
+The same commands can be run to add groups after initial installation.
+
 ### Optional Dependency Build and Runtime Requirements
 
 #### Custom packages

--- a/docs/install.md
+++ b/docs/install.md
@@ -390,6 +390,27 @@ Additional errors:
 ### Mayavi/VTK errors
 
 ```
+root - ERROR - The traitsui.qt4.* modules have moved to traitsui.qt.*.
+
+Applications which require backwards compatibility can either:
+
+- set the ETS_QT4_IMPORTS environment variable
+- set the ETS_TOOLKIT environment variable to "qt4",
+- the ETSConfig.toolkit to "qt4"
+- install a ShadowedModuleFinder into sys.meta_path::
+
+    import sys
+    from pyface.ui import ShadowedModuleFinder
+
+    sys.meta_path.append(ShadowedModuleFinder(
+        package="traitsui.qt4.",
+        true_package="traitsui.qt.",
+    ))
+```
+
+At least as of Mayavi 4.8.1, Mayavi will not load TraitsUI 8. Workaround is to run in the shell before launching MM: `export ETS_TOOLKIT="qt4"`
+
+```
 Numpy is required to build Mayavi correctly, please install it first
 ```
 

--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -47,6 +47,7 @@
   - Image adjustment channels are radio buttons for easier selection (#212)
   - Fixed synchronization between the ROI Editor and image adjustment controls after initialization (#142)
   - Fixed redundant triggers when adjusting the displayed image (#474)
+  - Fixed intensity sliders to cover the full range (#572)
 - Images are rotated by dynamic transformation (#214, #471, #505)
 - Smoother, faster interactions with main plots, including atlas label name display, label editing, and pan and zoom navigation (#317, #335, #359, #367)
 - Atlas labels adapt better in zoomed images to stay within each plot (#317)

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -857,30 +857,30 @@ class Visualization(HasTraits):
                      name="object._imgadj_chls_names.selections", cols=8)),
         ),
         HGroup(
-            Item("_imgadj_min", label="Minimum", editor=RangeEditor(
+            Item("_imgadj_min", label="Min", editor=RangeEditor(
                      low_name="_imgadj_min_low", high_name="_imgadj_min_high",
-                     mode="slider", format_str="%.4g")),
+                     mode="xslider", format_str="%.1g")),
             Item("_imgadj_min_auto", label="Auto", editor=BooleanEditor()),
         ),
         HGroup(
-            Item("_imgadj_max", label="Maximum", editor=RangeEditor(
+            Item("_imgadj_max", label="Max", editor=RangeEditor(
                      low_name="_imgadj_max_low", high_name="_imgadj_max_high",
-                     mode="slider", format_str="%.4g")),
+                     mode="xslider", format_str="%.1g")),
             Item("_imgadj_max_auto", label="Auto", editor=BooleanEditor()),
         ),
         HGroup(
             Item("_imgadj_brightness", label="Brightness", editor=RangeEditor(
                      low_name="_imgadj_brightness_low",
                      high_name="_imgadj_brightness_high", mode="slider",
-                     format_str="%.4g"))
+                     format_str="%.1g"))
         ),
         HGroup(
             Item("_imgadj_contrast", label="Contrast", editor=RangeEditor(
-                     low=0.0, high=2.0, mode="slider", format_str="%.3g")),
+                     low=0.0, high=2.0, mode="slider", format_str="%.1g")),
         ),
         HGroup(
             Item("_imgadj_alpha", label="Opacity", editor=RangeEditor(
-                 low=0.0, high=1.0, mode="slider", format_str="%.3g")),
+                 low=0.0, high=1.0, mode="slider", format_str="%.1g")),
         ),
         
         HGroup(
@@ -888,7 +888,7 @@ class Visualization(HasTraits):
             Item("_imgadj_alpha_blend_check", label="Blend",
                  enabled_when="not _merge_chls"),
             Item("_imgadj_alpha_blend", show_label=False, editor=RangeEditor(
-                 low=0.0, high=1.0, mode="slider", format_str="%.3g"),
+                 low=0.0, high=1.0, mode="slider", format_str="%.1g"),
                  enabled_when="_imgadj_alpha_blend_check"),
         ),
         label="Adjust Image",
@@ -1281,24 +1281,15 @@ class Visualization(HasTraits):
 
     @on_trait_change("_imgadj_name")
     def _update_imgadj_limits(self):
+        """Update image intensity limits."""
         img3d = self._img3ds.get(self._imgadj_name)
         if img3d is None: return
         info = libmag.get_dtype_info(img3d)
         self._setup_imgadj_channels()
 
-        # min/max based on near min/max pre-calculated from whole image
-        # including all channels, falling back to data type range; cannot
-        # used percentile or else need to load whole image from disk
-        min_inten = 0
-        if config.near_min is not None:
-            min_near_min = min(config.near_min)
-            if min_near_min < 0:
-                # set min to 0 unless near min is < 0
-                min_inten = 2 * min_near_min
-        # default near max is an array of -1; assume that measured near
-        # max values are positive
-        max_near_max = -1 if config.near_max is None else max(config.near_max)
-        max_inten = info.max if max_near_max < 0 else max_near_max * 2
+        # min/max based data type; slider has range adjustments
+        min_inten = info.min
+        max_inten = info.max
         self._imgadj_min_low = min_inten
         self._imgadj_min_high = max_inten
         self._imgadj_max_low = min_inten


### PR DESCRIPTION
The adjustment sliders have attempted to adapt to the majority of signal in the image to increase precision of slider adjustments by limiting the range. The full range is sometimes necessary, however, to obtain the optimal viewing intensity. The workaround has been to manually enter values into the intensity text boxes.

This PR changes the sliders to the TraitsUI large range mode, which adds additional button to navigate to smaller or larger ranges. Remove the automated limit adjustments since the full range can now be navigated. The auto-intensity still attempts to select an appropriate starting intensity, which also positions the slider in an appropriate starting slider range. Additionally, reduce the number of decimal points in slider values and size of names since the large range sliders take up considerably more horizontal space.