### PR TITLE
Select colormaps in the GUI

### DIFF
--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -42,6 +42,7 @@
 - Atlas Editor planes can be reordered or turned off (#180)
 - EXPERIMENTAL: New viewer that displays each blob separately to verify blob classifications (#193)
 - Image adjustment
+  - Select colormaps for each channel (#574)
   - "Merge" option in the ROI panel to merge channels using additive blending (#492, #552)
   - "Blend" option in the image adjustment panel to visualize alignment in overlaid images (#89, #450)
   - Image adjustment channels are radio buttons for easier selection (#212)

--- a/magmap/io/np_io.py
+++ b/magmap/io/np_io.py
@@ -518,9 +518,10 @@ def setup_images(
         config.img5d.img = config.image5d
         config.image5d_is_roi = True
 
-    # add any additional image5d thresholds for multichannel images, such 
+    # add any additional image5d thresholds for multichannel images, such
     # as those loaded without metadata for these settings
-    colormaps.setup_cmaps()
+    if not colormaps.CMAPS:
+        colormaps.setup_cmaps()
     num_channels = get_num_channels(config.image5d)
     config.near_max = libmag.pad_seq(config.near_max, num_channels, -1)
     config.near_min = libmag.pad_seq(config.near_min, num_channels, 0)

--- a/magmap/plot/colormaps.py
+++ b/magmap/plot/colormaps.py
@@ -1,10 +1,10 @@
 # Colormaps for MagellanMapper
-# Author: David Young, 2018, 2020
+# Author: David Young, 2018, 2023
 """Custom colormaps for MagellanMapper.
 """
 
 from enum import Enum, auto
-from typing import Optional, Sequence, Tuple, Union
+from typing import Dict, Optional, Sequence, Tuple, Union
 
 import numpy as np
 from matplotlib import cm
@@ -15,7 +15,7 @@ from magmap.io import libmag
 
 #: Dict[:class:`config.Cmaps`, :obj:`colors.LinearSegmentedColormap`]:
 # Default colormaps.
-CMAPS = {}
+CMAPS: Dict["config.Cmaps", colors.LinearSegmentedColormap] = {}
 
 _logger = config.logger.getChild(__name__)
 
@@ -507,22 +507,24 @@ def setup_labels_cmap(
     return cmap_labels
 
 
-def get_cmap(cmap, n=None):
+def get_cmap(
+        cmap: Union[str, "config.Cmaps"], n: Optional[int] = None
+) -> Optional[colors.LinearSegmentedColormap]:
     """Get colormap from a list of colormaps, string, or enum.
     
-    If ``n`` is given, ``cmap`` is assumed to be a list from which a colormap 
-    will be retrieved. Colormaps that are strings will be converted to 
-    the associated standard `Colormap` object, while enums in 
-    :class:``config.Cmaps`` will be used to retrieve a `Colormap` object 
+    If ``n`` is given, ``cmap`` is assumed to be a list from which a colormap
+    will be retrieved. Colormaps that are strings will be converted to
+    the associated standard `Colormap` object, while enums in
+    :class:``config.Cmaps`` will be used to retrieve a `Colormap` object
     from :const:``CMAPS``, which is assumed to have been initialized.
     
     Args:
         cmap: Colormap given as a string of Enum or list of colormaps.
-        n: Index of `cmap` to retrieve a colormap, assuming that `cmap` 
+        n: Index of `cmap` to retrieve a colormap, assuming that `cmap`
             is a sequence. Defaults to None to use `cmap` directly.
     
     Returns:
-        The ``Colormap`` object, or None if no corresponding colormap 
+        The ``Colormap`` object, or None if no corresponding colormap
         is found.
     """
     if n is not None:


### PR DESCRIPTION
Colormaps have been customized using ROI profiles, but there has been no way to directly change colormaps through the GUI. This PR adds a searchable selector in the image adjustment panel to select a colormap for each channel, dynamically updating the image with the selected colormap. Available colormaps are all those in Matplotlib plus the custom dark-to-color maps generated in MM.