### PR TITLE
Store the last opened image via the GUI in preferences

### DIFF
--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -30,7 +30,7 @@
 
 #### GUI
 
-- More preferences are saved, such as the figure save location and ROI Editor layout (#138, #201)
+- More preferences are saved, such as the figure save location and ROI Editor layout (#138, #201, #575)
 - Drag and remove loaded profiles in the Profiles tab table
 - "Help" buttons added to open the online documentation (#109)
 - Default confirmation labels can be set before detection (#115)

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -2210,11 +2210,15 @@ class Visualization(HasTraits):
     @observe("_filename_btn")
     def _filename_updated(self, evt):
         """Open a Pyface file dialog to set the main image path."""
-        open_dialog = FileDialog(
-            action="open", default_path=os.path.dirname(self._filename))
+        # get path from currently opened file or preferences
+        path = os.path.dirname(
+            self._filename) if self._filename else config.prefs.img_open_path
+        open_dialog = FileDialog(action="open", default_path=path)
+        
         if open_dialog.open() == OK:
-            # get user selected path
+            # get user selected path and save in preferences
             self._filename = open_dialog.path
+            config.prefs.img_open_path = self._filename
 
     @on_trait_change("_filename")
     def _image_path_updated(self):
@@ -2254,6 +2258,7 @@ class Visualization(HasTraits):
             self._setup_for_image()
             self.redraw_selected_viewer()
             self.update_imgadj_for_img()
+            config.prefs.img_open_path = self._filename
         else:
             print("Could not parse filename", self._filename)
         

--- a/magmap/settings/prefs_prof.py
+++ b/magmap/settings/prefs_prof.py
@@ -23,6 +23,9 @@ class PrefsProfile(profiles.SettingsDict):
 
     #: Import directory path.
     import_dir: str = ""
+    
+    #: Path to last opened image.
+    img_open_path: str = ""
 
     def __init__(self, *args, **kwargs):
         """Initialize a preferences profile dictionary.


### PR DESCRIPTION
Save the path to images loading through the GUI, whether through the image open button or by simply updating the image path. Initialize the file open dialog to this path's parent directory in a new session.