### PR TITLE
Support generating regional heat maps from the volume metrics output

### DIFF
--- a/bin/sample_cmds_bash.ipynb
+++ b/bin/sample_cmds_bash.ipynb
@@ -520,17 +520,107 @@
     "\n",
     "TODO\n",
     "\n",
-    "### Volume metrics for each atlas region\n",
-    "\n",
-    "TODO\n",
-    "\n",
-    "### Blob colocalization\n",
-    "\n",
-    "TODO\n",
-    "\n",
     "### Build and test ground truth sets\n",
     "\n",
     "TODO"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Putting it together: quantify cells by region\n",
+    "\n",
+    "#### Regional quantification\n",
+    "\n",
+    "After detection cells and registering an atlas, we can put these together to measure the cells per region.\n",
+    "\n",
+    "First, generate a table of cells per atlas region:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "vscode": {
+     "languageId": "plaintext"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "./run.py --img \"$img\" --register vol_stats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next, combine regions into hierarchical structures. `level` sets the max (finest) hierarchical level, which allows only including high-level, larger structures (eg, `level=1`). In this case, we use a deep level to include all possible structures. `--atlas_profile combinesides` uses a profile that combines matching left and right regions and can be omitted to separate these regions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "vscode": {
+     "languageId": "plaintext"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "./run.py --img \"$img\" \\\n",
+    "  --register vol_stats \\\n",
+    "  --labels level=13 \\\n",
+    "  --atlas_profile combinesides"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Regional heat map\n",
+    "\n",
+    "The cell counts, region densities, and other metrics can be visualized by replacing each region with its metric value.\n",
+    "\n",
+    "First, generate this regional heat map, here shown for the density values. Here, `\"${img}_volumes_level13.csv\"` is the path to the hierarchical volume metrics file produced above. `--plot_labels x_col=\"Density\"` says to use the density column in this file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "vscode": {
+     "languageId": "plaintext"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "./run.py \"$img\" \"${img}_volumes_level13.csv\" \\\n",
+    "  --register labels_diff_stats \\\n",
+    "  --plot_labels x_col=\"Density\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next, open the regional heat map. `--plot_labels nan_color=black` sets unlabeled regions to black. After opening the image, turn down the labels opacity to see the heat map. `--labels binary='#00000000,#000000ff'` can also be added to make the labels transparent automatically. The colormap can be changed in the \"Adjust Image > Color\" panel setting."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "vscode": {
+     "languageId": "plaintext"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "./run.py \"$img\" \\\n",
+    "  --reg_suffixes annotationDiff_Density.mhd annotation.mhd \\\n",
+    "  --roi_profile diverging \\\n",
+    "  --plot_labels nan_color=black"
    ]
   },
   {


### PR DESCRIPTION
Labels difference images have been generated from the R pipeline output. Now, these images can be generated directly from the volume metrics output. In this case, the values are typically for a single sample, with the metric specified by `--plot_labels x_col=<column>`, producing a regional heat map.