### PR TITLE
Remove `verify_tol_factor` from identical block settings check

### DIFF
--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -117,12 +117,13 @@
 - Fixed match-based colocalizations when no matches are found (#117, #120)
 - Fixed slow loading of match-based colocalizations (#119, #123)
 
-#### Volumetric image processing
+#### Block processing
 
 - Match-based colocalizations use larger processing blocks to avoid gaps (#120)
 - Voxel density maps no longer require a registered image, or it can be used in place of full-size image metadata (#125, #226)
 - Grid search profiles are now layered on top of one another rather than applied in sequential runs for consistency with ROI and atlas profiles (#138)
 - Fixed 3D surface area measurement with Scikit-image >= v0.19
+- Fixed preprocessing to use the same blocks even if `verify_tol_factor` differs (#603)
 
 #### I/O
 

--- a/magmap/settings/roi_prof.py
+++ b/magmap/settings/roi_prof.py
@@ -36,7 +36,6 @@ class ROIProfile(profiles.SettingsDict):
         "segment_size",
         "denoise_size",
         "prune_tol_factor",
-        "verify_tol_factor",
         "sub_stack_max_pixels",
         "isotropic",
     )


### PR DESCRIPTION
Block processing uses the same blocks for all channels if all the relevant settings for the block are the same across these channels. The tolerance factor verification setting has been checked but does not influence the block's processing, so it can be removed from this settings check.