### PR TITLE
Exclude negative intensities by default in image sliders

### DIFF
--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -48,7 +48,7 @@
   - Image adjustment channels are radio buttons for easier selection (#212)
   - Fixed synchronization with image adjustment controls (#142, #576)
   - Fixed redundant triggers when adjusting the displayed image (#474)
-  - Fixed intensity sliders to cover the full range (#572, #576)
+  - Fixed intensity sliders to cover the full range (#572, #576, #606)
 - Images are rotated by dynamic transformation (#214, #471, #505)
 - Smoother, faster interactions with main plots, including atlas label name display, label editing, and pan and zoom navigation (#317, #335, #359, #367)
 - Atlas labels adapt better in zoomed images to stay within each plot (#317)

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -1306,8 +1306,18 @@ class Visualization(HasTraits):
         info = libmag.get_dtype_info(img3d)
         self._setup_imgadj_channels()
 
+        # default to only include non-neg intensities
+        min_inten = 0
+        if config.near_min is not None:
+            # check for neg intensities from min/max pre-calculated from whole
+            # image for all channels; cannot used percentile or else need to
+            # load whole image from disk
+            min_near_min = min(config.near_min)
+            if min_near_min < 0:
+                min_inten = info.min
+        
         # min/max based data type; slider has range adjustments
-        min_inten = info.min
+        min_inten = min_inten
         max_inten = info.max
         self._imgadj_min_low = min_inten
         self._imgadj_min_high = max_inten


### PR DESCRIPTION
Although the data type may allow negative values, these values are often not used in images and may create confusion in the image sliders. Exclude these values by default, unless the image's precalculated near minimum is negative.