### PR TITLE
Workaround Matplotlib error when turning off alpha blending

### DIFF
--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -44,7 +44,7 @@
 - Image adjustment
   - Select colormaps for each channel (#574)
   - "Merge" option in the ROI panel to merge channels using additive blending (#492, #552)
-  - "Blend" option in the image adjustment panel to visualize alignment in overlaid images (#89, #450)
+  - "Blend" option in the image adjustment panel to visualize alignment in overlaid images (#89, #450, #607)
   - Image adjustment channels are radio buttons for easier selection (#212)
   - Fixed synchronization with image adjustment controls (#142, #576)
   - Fixed redundant triggers when adjusting the displayed image (#474)

--- a/magmap/gui/plot_editor.py
+++ b/magmap/gui/plot_editor.py
@@ -958,7 +958,13 @@ class PlotEditor:
                 plot_ax_img, brightness, contrast)
         if alpha is not None:
             # adjust and store opacity
-            plot_ax_img.ax_img.set_alpha(alpha)
+            try:
+                plot_ax_img.ax_img.set_alpha(alpha)
+            except ValueError:
+                # WORKAROUND: matplotlib v3.8 give an error when stored alpha
+                #   is an array and new alpha is a scalar
+                plot_ax_img.ax_img._alpha = None
+                plot_ax_img.ax_img.set_alpha(alpha)
             plot_ax_img.alpha = alpha
         return plot_ax_img
 


### PR DESCRIPTION
Alpha blending sets the image's alpha to an array, which leads to an error when turning off alpha blending and comparing the array to a scalar. As a workaround, manually reset the current alpha to avoid an error during this comparison.