### PR TITLE
Fix running Mayavi on Windows

### DIFF
--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -41,6 +41,13 @@ except AttributeError:
     pass
 
 # import PyFace components after HiDPI adjustment
+try:
+    # WORKAROUND: Mayavi as of v4.8.1 uses the older qt4 instead of qt
+    from traits.etsconfig.api import ETSConfig
+    ETSConfig.toolkit = "qt4"
+except AttributeError:
+    print("Could not set Traits ETSConfig")
+    pass
 from pyface import confirmation_dialog
 from pyface.api import DirectoryDialog, FileDialog, OK, YES, CANCEL
 from pyface.image_resource import ImageResource

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,11 @@ _EXTRAS_GUI = [
 ]
 
 #: Optional dependencies for the 3D viewer.
-_EXTRAS_3D = ["mayavi"]
+_EXTRAS_3D = [
+    "mayavi",
+    # WORKAROUND: error in VTK 9.3.0 with Mayavi 4.8.1
+    "vtk < 9.3.0",
+]
 
 #: Optional pre-built SimpleITK with Elastix for image I/O and registration.
 _EXTRAS_SIMPLEITK = [


### PR DESCRIPTION
Mayavi gives an error when running with TraitsUI 8 (see https://github.com/enthought/mayavi/issues/1260). A workaround has been to set the `ETS_TOOLKIT="qt4"` environment variable, which worked on testing in macOS but not in Windows. As another workaround, set the `ETSConfig.toolkit` configuration instead, which avoids needing to set an environment variable and also works for Windows.

Also, install only VTK < 9.3 because of errors associated with VTK's latest update in the current Mayavi (4.8.1; see https://github.com/enthought/mayavi/issues/1286).