### PR TITLE
Support Python 3.12

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-13, macos-latest, windows-latest]
         python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
         dependencies:
           - pinned
@@ -30,6 +30,10 @@ jobs:
         exclude:
           - os: ubuntu-latest
             python-version: 3.6
+          - os: macos-13
+            python-version: 3.10
+          - os: macos-13
+            python-version: 3.11
           - os: macos-latest
             python-version: 3.6
           - os: macos-latest
@@ -41,19 +45,10 @@ jobs:
         include:
           - os: ubuntu-20.04
             python-version: 3.6
-            dependencies: ["pinned", "fresh"]
-          - os: macos-13
+            dependencies: pinned
+          - os: ubuntu-20.04
             python-version: 3.6
-            dependencies: ["pinned", "fresh"]
-          - os: macos-13
-            python-version: 3.7
-            dependencies: ["pinned", "fresh"]
-          - os: macos-13
-            python-version: 3.8
-            dependencies: ["pinned", "fresh"]
-          - os: macos-13
-            python-version: 3.9
-            dependencies: ["pinned", "fresh"]
+            dependencies: fresh
     
     env:
       # set requirements path based on Python version

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,14 +41,19 @@ jobs:
         include:
           - os: ubuntu-20.04
             python-version: 3.6
+            dependencies: ["pinned", "fresh"]
           - os: macos-13
             python-version: 3.6
+            dependencies: ["pinned", "fresh"]
           - os: macos-13
             python-version: 3.7
+            dependencies: ["pinned", "fresh"]
           - os: macos-13
             python-version: 3.8
+            dependencies: ["pinned", "fresh"]
           - os: macos-13
             python-version: 3.9
+            dependencies: ["pinned", "fresh"]
     
     env:
       # set requirements path based on Python version

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
         dependencies:
           - pinned
           - fresh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,24 +22,33 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
         dependencies:
           - pinned
           - fresh
         exclude:
-          - os: ubuntu-20.04
-            python-version: 3.7
-          - os: ubuntu-20.04
-            python-version: 3.8
-          - os: ubuntu-20.04
-            python-version: 3.9
-          - os: ubuntu-20.04
-            python-version: "3.10"
-          - os: ubuntu-20.04
-            python-version: "3.11"
           - os: ubuntu-latest
             python-version: 3.6
+          - os: macos-latest
+            python-version: 3.6
+          - os: macos-latest
+            python-version: 3.7
+          - os: macos-latest
+            python-version: 3.8
+          - os: macos-latest
+            python-version: 3.9
+        include:
+          - os: ubuntu-20.04
+            python-version: 3.6
+          - os: macos-13
+            python-version: 3.6
+          - os: macos-13
+            python-version: 3.7
+          - os: macos-13
+            python-version: 3.8
+          - os: macos-13
+            python-version: 3.9
     
     env:
       # set requirements path based on Python version

--- a/README.md
+++ b/README.md
@@ -110,4 +110,4 @@ To try out functions with sample images, download any of these files:
 
 Licensed under the open-source [BSD-3 license](LICENSE.txt)
 
-Author: David Young, 2017, 2023, Stephan Sanders Lab
+Author: David Young, 2017, 2024, Stephan Sanders Lab

--- a/bin/setup_venv.sh
+++ b/bin/setup_venv.sh
@@ -70,7 +70,7 @@ fi
 # check for Python availability and version requirement
 py_ver_majmin="" # found Python version in x.y format
 py_ver_min=(3 6) # minimum supported Python version
-py_vers=(3.8 3.7 3.6 3.9 3.10 3.11) # range of versions currently supported
+py_vers=(3.8 3.7 3.6 3.9 3.10 3.11 3.12) # range of versions currently supported
 py_vers_prebuilt_deps=(3.6 3.7 3.8 3.9 3.10 3.11) # vers with custom prebuilt deps
 for ver in "${py_vers[@]}"; do
   # prioritize specific versions in case "python" points to lower version,

--- a/docs/install.md
+++ b/docs/install.md
@@ -14,7 +14,25 @@
 
 MagellanMapper supports several Python setups.
 
-### Install using Conda
+### Quick Install
+
+Install MagellanMapper with its graphical interface and registration tools:
+
+```shell
+pip install "magellanmapper[gui,itk]"
+```
+
+Then launch MagellanMapper:
+
+```shell
+mm
+```
+
+See [below](#dependencies) for supported Python versions and adding install groups.
+
+See our [vignette](https://github.com/sanderslab/magellanmapper/blob/master/bin/sample_cmds_bash.ipynb) for getting started on MM!
+
+### Full install using Conda
 
 If you use Conda (available [here](https://docs.conda.io/en/latest/miniconda.html)), you can install MagellanMapper into a new environment named `mag` (or replace with desired name):
 
@@ -33,7 +51,7 @@ Conda will also install Java, which we use to read proprietary image formats.
 
 The `mm` entry points was added in v1.6.0 to facilitate launching from installed packages.
 
-### Install using Pip
+### Full install using Pip
 
 Install using Pip with Python >= 3.6 (see [Python versions](#python-version-support); Python >= 3.9 and [virtual environment](https://realpython.com/python-virtual-environments-a-primer/) recommended):
 
@@ -173,7 +191,7 @@ Sometimes a virtual environment update is required for new dependencies.
 | MagellanMapper Version | Python Versions Supported | Notes |
 |-----|-----|-----|
 | 1.7 (planned) | 3.9-3.11 | 3.6-3.8 to be removed |
-| >=1.6b1 | 3.6-3.11 | Defaults to 3.9. GUI support added for 3.10-3.11 in MM 1.6b2. |
+| >=1.6b1 | 3.6-3.11 | Defaults to 3.9. GUI support added for 3.10-3.11 in MM 1.6b2, 3.12 in MM 1.6b5. |
 | 1.6a1-a3 | 3.6-3.9 | GUI support added for 3.9; MM 1.6a2 base group no longer installs GUI |
 | 1.4-1.5 | 3.6-3.9 | No GUI support in 3.9 |
 | < 1.4 | 3.6 | Initial releases |

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -1,8 +1,12 @@
 # Running Pipelines in MagellanMapper
 
-TODO: update for new pipelines
+## Vignette
+
+See our [vignette](https://github.com/sanderslab/magellanmapper/blob/master/bin/sample_cmds_bash.ipynb) for examples on using MM.
 
 ## Start a processing pipeline
+
+**Note**: This pipeline script is deprecated. See our vignette above for running similar pipelines.
 
 Automated processing will attempt to scale based on your system resources but may require some manual intervention. This pipeline has been tested on a Macbook Pro laptop and AWS EC2 Linux (RHEL and Amazon Linux based) instances.
 

--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -7,7 +7,7 @@
 - Smoother, faster interactions with main plots, including atlas label name display, label editing, and pan and zoom navigation
 - Available as binary wheel to install without requiring the source code
 - Faster, lighter installation with fewer required dependency packages
-- Extends suppor to Python 3.11 and defaults to Python 3.9
+- Extends support to Python 3.12 and defaults to Python 3.9
 - Simpler entry point to launch MagellanMapper: `mm`
 - Supports ITK-Elastix for image registration
 - Atlases can be downloaded directly through [`BrainGlobe`](https://github.com/brainglobe/bg-atlasapi) (see the new "Atlases" panel)
@@ -199,13 +199,13 @@
 - Jupyter Notebook as a tutorial for running various tasks in the CLI (#122)
 - Documentation is now [hosted on ReadTheDocs](https://magellanmapper.readthedocs.io/en/latest/index.html), using the Furo theme (#225, #563)
 - Default arguments are documented in API auto-docs (#485)
-- Expand continuous integration testing to both pinned and fresh dependencies across Python 3.6-3.11 (#75, #101, #252, #342, #538)
+- Expand continuous integration testing to both pinned and fresh dependencies across Python 3.6-3.12 (#75, #101, #252, #342, #538, #640)
 
 ### Dependency Updates
 
 #### Python Dependency Changes
 
-- Python 3.10-3.11 are now supported (#379, #517)
+- Python 3.10-3.12 are now supported (#379, #517, #640)
 - Python 3.9 is the default version now that Python 3.6 has reached End-of-Life, and NumPy no longer supports Python 3.8 (#559, #563)
 - Python 3.6-8 have been deprecated for removal in MM v1.7 and have separate pinned dependencies (`envs/requirements_py3<n>`) (#232, #379)
 - Custom dependency binaries are now built for Python 3.8-3.11 (#379)

--- a/envs/requirements.txt
+++ b/envs/requirements.txt
@@ -14,7 +14,7 @@ importlib_metadata==7.1.0
 importlib_resources==6.4.0
 itk==5.4rc3
 itk-core==5.4rc3
-itk-elastix==0.19.1
+itk-elastix==0.19.2
 itk-filtering==5.4rc3
 itk-io==5.4rc3
 itk-numerics==5.4rc3

--- a/magmap/atlas/ontology.py
+++ b/magmap/atlas/ontology.py
@@ -344,20 +344,22 @@ class LabelsRef:
         return self
 
 
-def convert_itksnap_to_df(path):
-    """Convert an ITK-SNAP labels description file to a CSV file 
-    compatible with MagellanMapper.
+def convert_itksnap_to_df(path: str):
+    """Convert an ITK-SNAP labels description file to a CSV file.
+    
+    MagellanMapper can read this type of CSV file.
 
     Args:
         path: Path to description file.
 
     Returns:
         Pandas data frame of the description file.
+    
     """
-    # load description file and convert contiguous spaces to separators, 
+    # load description file and convert contiguous spaces to separators,
     # remove comments, and add headers
     df = pd.read_csv(
-        path, sep="\s+", comment="#",
+        path, sep=r"\s+", comment="#",
         names=[e.value for e in config.ItkSnapLabels])
     return df
 

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -441,16 +441,16 @@ class Visualization(HasTraits):
         tooltip="Colormap for the channel. Start typing to search.")
     _imgadj_color_names = Instance(TraitsList)
     _imgadj_min = Float
-    _imgadj_min_low = Float(0)
-    _imgadj_min_high = Float
+    _imgadj_min_low = Float(0)  # must have val in Python >= 3.10
+    _imgadj_min_high = Float(1)  # must have val > min in Python >= 3.12
     _imgadj_min_auto = Bool
     _imgadj_max = Float
     _imgadj_max_low = Float(0)
-    _imgadj_max_high = Float
+    _imgadj_max_high = Float(1)
     _imgadj_max_auto = Bool
     _imgadj_brightness = Float
     _imgadj_brightness_low = Float(0)
-    _imgadj_brightness_high = Float
+    _imgadj_brightness_high = Float(1)
     _imgadj_contrast = Float
     _imgadj_alpha = Float
     _imgadj_alpha_blend = Float(0.5)

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ config = {
     "url": "https://github.com/sanderslab/magellanmapper",
     "author_email": "david@textflex.com",
     "license": "BSD-3",
-    "version": "1.6b4",
+    "version": "1.6b5",
     "packages": setuptools.find_packages(),
     "scripts": [],
     "python_requires": ">=3.6",


### PR DESCRIPTION
The GUI has not worked in Python 3.12, fixed here.

Note that ITK does not currently provide binaries for Python 3.12, so the install group for it needs to be excluded for now. Install MM with only the GUI:

```
pip install "magellanmapper[gui]"
```