### PR TITLE
Fix Matplotlib colormap access

### DIFF
--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -148,6 +148,7 @@
 - Fixed to store the image path when loading a registered image as the main image, which fixes saving the experiment name used when saving blobs (#139)
 - Fixed parsing some metadata when importing files with Bio-Formats (#502)
 - Fixed `--proc extract` for extracting a slice of multiple planes (#611)
+- Fixed slice arguments such as `--slice "0,3"` to not interpret `0` as `None` (#649)
 
 #### Server pipelines
 
@@ -225,6 +226,7 @@
 - Supports TraitsUI v8 (#510)
 - Fixed error on deprecated NumPy data type aliases (#364)
 - Fixed `qt4 backend` error by avoiding PyQt v5.15.8 (#431)
+- Fixed erro on deprecated Matplotlib colormap access (#649)
 
 #### R Dependency Changes
 

--- a/magmap/io/cli.py
+++ b/magmap/io/cli.py
@@ -65,19 +65,23 @@ def _parse_coords(arg: str, rev: bool = False) -> List[Tuple[int, ...]]:
 
 
 def _parse_none(
-        arg: Any, fn: Optional[Callable] = None) -> Any:
+        arg: Any, fn: Optional[Callable] = None,
+        none: Sequence[str] = ("none", "0")) -> Any:
     """Parse arguments with support for conversion to None.
     
     Args:
         arg: Argument to potentially convert.
         fn: Function to apply to ``arg`` if not converted; defaults to None.
+        none: Sequence of strings to convert to None.
 
     Returns:
         None if ``arg`` is "none" or "0"; otherwise, returns ``fn(arg)`` if
         ``fn`` is given, or ``arg`` unchanged.
 
     """
-    if arg.lower() in ("none", "0"):
+    if not libmag.is_seq(none):
+        none = tuple(none)
+    if arg.lower() in none:
         return None
     return arg if fn is None else fn(arg)
 
@@ -645,11 +649,11 @@ def process_cli_args():
         print("Set plot_2d type to {}".format(config.plot_2d_type))
 
     if args.slice:
-        # specify a generic slice by command-line, assuming same order 
-        # of arguments as for slice built-in function and interpreting 
+        # specify a generic slice by command-line, assuming same order
+        # of arguments as for slice built-in function and interpreting
         # "none" string as None
         config.slice_vals = args.slice.split(",")
-        config.slice_vals = [_parse_none(val.lower(), int)
+        config.slice_vals = [_parse_none(val.lower(), int, "none")
                              for val in config.slice_vals]
         print("Set slice values to {}".format(config.slice_vals))
     if args.delay:
@@ -718,7 +722,7 @@ def process_cli_args():
         print("Set vmins to", config.vmins)
     
     if args.vmax:
-        # specify vmax levels and copy to vmax overview used for plotting 
+        # specify vmax levels and copy to vmax overview used for plotting
         # and updated for normalization
         config.vmaxs = [
             libmag.get_int(val) for val in args.vmax.split(",")]

--- a/magmap/plot/colormaps.py
+++ b/magmap/plot/colormaps.py
@@ -7,7 +7,12 @@ from enum import Enum, auto
 from typing import Dict, Optional, Sequence, Tuple, Union
 
 import numpy as np
-from matplotlib import colormaps as mpl_cmaps
+try:
+    from matplotlib import colormaps as mpl_cmaps
+    cm = None
+except ImportError:
+    mpl_cmaps = None
+    from matplotlib import cm
 from matplotlib import colors
 
 from magmap.settings import config
@@ -532,7 +537,11 @@ def get_cmap(
         cmap = config.cmaps[n] if n < len(cmap) else None
     if isinstance(cmap, str):
         # cmap given as a standard Matplotlib colormap name
-        cmap = mpl_cmaps[cmap]
+        if mpl_cmaps:
+            cmap = mpl_cmaps[cmap]
+        else:
+            # fallback to Matplotlib API for < v3.9
+            cmap = cm.get_cmap(cmap)
     elif isinstance(cmap, config.Cmaps):
         # assume default colormaps have been initialized
         cmap = CMAPS[cmap]

--- a/magmap/plot/colormaps.py
+++ b/magmap/plot/colormaps.py
@@ -7,7 +7,7 @@ from enum import Enum, auto
 from typing import Dict, Optional, Sequence, Tuple, Union
 
 import numpy as np
-from matplotlib import cm
+from matplotlib import colormaps
 from matplotlib import colors
 
 from magmap.settings import config
@@ -532,7 +532,7 @@ def get_cmap(
         cmap = config.cmaps[n] if n < len(cmap) else None
     if isinstance(cmap, str):
         # cmap given as a standard Matplotlib colormap name
-        cmap = cm.get_cmap(cmap)
+        cmap = colormaps[cmap]
     elif isinstance(cmap, config.Cmaps):
         # assume default colormaps have been initialized
         cmap = CMAPS[cmap]

--- a/magmap/plot/colormaps.py
+++ b/magmap/plot/colormaps.py
@@ -7,7 +7,7 @@ from enum import Enum, auto
 from typing import Dict, Optional, Sequence, Tuple, Union
 
 import numpy as np
-from matplotlib import colormaps
+from matplotlib import colormaps as mpl_cmaps
 from matplotlib import colors
 
 from magmap.settings import config
@@ -532,7 +532,7 @@ def get_cmap(
         cmap = config.cmaps[n] if n < len(cmap) else None
     if isinstance(cmap, str):
         # cmap given as a standard Matplotlib colormap name
-        cmap = colormaps[cmap]
+        cmap = mpl_cmaps[cmap]
     elif isinstance(cmap, config.Cmaps):
         # assume default colormaps have been initialized
         cmap = CMAPS[cmap]


### PR DESCRIPTION
Fixes access to Matplotlib colormaps from the deprecated `cm.get_cmap` to the `colormaps[<name>]` API. Also fixes CLI slice arguments such as `--slice 0,3` to not convert `0` to `None`.