### PR TITLE
Show 3D blobs by region

### DIFF
--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -43,16 +43,6 @@
 - "Show all" in the Regions section of the ROI panel shows names for all labels (#145)
 - Atlas Editor planes can be reordered or turned off (#180)
 - EXPERIMENTAL: New viewer that displays each blob separately to verify blob classifications (#193)
-- Image adjustment
-  - Select colormaps for each channel (#574)
-  - Settings are preserved when redrawing the image (#613)
-  - "Merge" option in the ROI panel to merge channels using additive blending (#492, #552)
-  - "Blend" option in the image adjustment panel to visualize alignment in overlaid images (#89, #450, #607)
-  - Synced intensity range of "filtered" ROI and overview images (#613)
-  - Image adjustment channels are radio buttons for easier selection (#212)
-  - Fixed synchronization between images and adjustment controls (#142, #576)
-  - Fixed redundant triggers when adjusting the displayed image (#474)
-  - Fixed intensity sliders to cover the full range (#572, #576, #606, #613)
 - Images are rotated by dynamic transformation (#214, #471, #505)
 - Smoother, faster interactions with main plots, including atlas label name display, label editing, and pan and zoom navigation (#317, #335, #359, #367)
 - Atlas labels adapt better in zoomed images to stay within each plot (#317)
@@ -68,6 +58,25 @@
 - Fixed saving additional, old figures when using the save shortcut (#256)
 - Fixed lag in zoom direction change (#359)
 - Fixed conflict between shortcut to add blob and jumping to ROI plane (`ctrl+click`) by changing the jump shortcut to `j+click` (#456)
+- Fixed atlas messages to show up in the atlas tab
+
+##### 3D visualization
+
+- Cells can be shown for specific atlas regions (#651)
+- Multiple sets of 3D cells can be layered (#651)
+- "Raw" mode is disabled by default when atlas regions are present (#651)
+
+##### Image adjustment
+
+- Select colormaps for each channel (#574)
+- Settings are preserved when redrawing the image (#613)
+- "Merge" option in the ROI panel to merge channels using additive blending (#492, #552)
+- "Blend" option in the image adjustment panel to visualize alignment in overlaid images (#89, #450, #607)
+- Synced intensity range of "filtered" ROI and overview images (#613)
+- Image adjustment channels are radio buttons for easier selection (#212)
+- Fixed synchronization between images and adjustment controls (#142, #576)
+- Fixed redundant triggers when adjusting the displayed image (#474)
+- Fixed intensity sliders to cover the full range (#572, #576, #606, #613)
 
 #### CLI
 
@@ -123,7 +132,7 @@
 - Fixed match-based colocalizations when no matches are found (#117, #120)
 - Fixed slow loading of match-based colocalizations (#119, #123)
 
-#### Block processing
+##### Block processing
 
 - Match-based colocalizations use larger processing blocks to avoid gaps (#120)
 - Voxel density maps no longer require a registered image, or it can be used in place of full-size image metadata (#125, #226)
@@ -195,7 +204,7 @@
 
 #### Code base and docs
 
-- Blob column accessors are encapsulated in the `Blobs` class, which allows for flexibility in column inclusion and order (#133)
+- Blob column accessors are encapsulated in the `Blobs` class, which allows for flexibility in column inclusion and order (#133, #651)
 - Settings profiles are being migrated from dictionaries to data classes to document and configure settings more easily (#138)
 - Jupyter Notebook as a tutorial for running various tasks in the CLI (#122)
 - Documentation is now [hosted on ReadTheDocs](https://magellanmapper.readthedocs.io/en/latest/index.html), using the Furo theme (#225, #563)

--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -210,7 +210,7 @@
 - Python 3.9 is the default version now that Python 3.6 has reached End-of-Life, and NumPy no longer supports Python 3.8 (#559, #563)
 - Python 3.6-8 have been deprecated for removal in MM v1.7 and have separate pinned dependencies (`envs/requirements_py3<n>`) (#232, #379)
 - Custom dependency binaries are now built for Python 3.8-3.11 (#379)
-- The BrainGlobe Atlas API package (`bg-atlasapi`) dependency has been added to access a suite of cloud-based atlases (#75, #443, #498)
+- The BrainGlobe Atlas API package (`brainglobe-atlasapi`) dependency has been added to access a suite of cloud-based atlases (#75, #443, #498, #650)
 - The `dataclasses` backport is installed for Python < 3.7
 - `Tifffile` is now a direct dependency, previously already installed as a sub-dependency of other required packages
 - `Imagecodecs` is optional for `tifffile` but required for its uses here as of `tifffile v2022.7.28` and thus added as a dependency (#153)

--- a/magmap/cv/detector.py
+++ b/magmap/cv/detector.py
@@ -646,13 +646,10 @@ class Blobs:
         return cls.shift_blobs(
             blob, cls._get_abs_inds(), np.multiply, factor, True)
 
-    @classmethod
-    def remove_abs_blob_coords(
-            cls, blobs: np.ndarray, remove_extra: bool = False) -> np.ndarray:
+    def remove_abs_blob_coords(self, remove_extra: bool = False) -> np.ndarray:
         """Remove blob absolute coordinate columns.
         
         Args:
-            blobs: 2D array of blobs.
             remove_extra: True to also remove any extra columns not in
                 :attr:`cols_inds`; defaults to False.
 
@@ -660,8 +657,16 @@ class Blobs:
             ``blob`` modified in-place.
 
         """
-        inds = cls._col_inds.values() if remove_extra else slice(blobs.shape[1])
-        return blobs[:, [i for i in inds if i not in cls._get_abs_inds()]]
+        # get indices to keep potentially
+        inds = Blobs._col_inds.values() if remove_extra else slice(
+            self.blobs.shape[1])
+        
+        # remove absolute coordinate indices and update columns
+        inds = [i for i in inds if i not in Blobs._get_abs_inds()]
+        self.cols = [self.cols[i] for i in inds]
+        self.blobs = self.blobs[:, inds]
+        
+        return self.blobs
     
     @classmethod
     def replace_rel_with_abs_blob_coords(cls, blobs: np.ndarray) -> np.ndarray:

--- a/magmap/cv/detector.py
+++ b/magmap/cv/detector.py
@@ -81,16 +81,30 @@ class Blobs:
     
     class Cols(Enum):
         """Blob column names."""
+        #: z-coordinate.
         Z = "z"
+        #: y-coordinate.
         Y = "y"
+        #: x-coordinate.
         X = "x"
+        #: Radius.
         RADIUS = "radius"
+        #: Confirmation flag: -1 = unconfirmed, 0 = incorrect, 1 = correct.
         CONFIRMED = "confirmed"
+        #: "Truth" is given as -1 = not truth, 0 = not matched, 1 = matched,
+        #: where a "matched" truth blob is one that has a detected blob within
+        #: a given tolerance.
         TRUTH = "truth"
+        #: Channel.
         CHANNEL = "channel"
+        #: Absolute z-coordinate.
         ABS_Z = "abs_z"
+        #: Absolute y-coordinate.
         ABS_Y = "abs_y"
+        #: Absolute x-coordinate.
         ABS_X = "abs_x"
+        #: Region ID.
+        REGION = "region"
     
     #: Dictionary of column types to column indices in :attr:`blobs`.
     _col_inds: Dict["Cols", int] = {c: i for i, c in enumerate(Cols)}
@@ -307,25 +321,17 @@ class Blobs:
     ) -> np.ndarray:
         """Format blobs with the full set of fields.
          
-        Blobs in MagellanMapper can be assumed to start with ``z, y, x, radius``
-        but should use this class's functions to manipulate other fields to
-        ensure that the correct columns are accessed. This function adds
-        these fields: ``confirmation, truth, channel, abs z, abs y, abs x``.
-
-        "Confirmed" is given as -1 = unconfirmed, 0 = incorrect, 1 = correct.
-
-        "Truth" is given as -1 = not truth, 0 = not matched, 1 = matched, where
-        a "matched" truth blob is one that has a detected blob within a given
-        tolerance.
-
+        Blobs in MagellanMapper can be assumed to start with
+        ``z, y, x, radius``. This function should be called to set up all
+        additional columns so that they are accessed in the correct order.
+        The remaining fields in :class:`Blobs.Cols` will be added.
+        
         Args:
             channel: Channel to set. Defaults to None, in which case the channel
                 will not be updated.
 
         Returns:
-            Blobs array formatted as
-            ``[[z, y, x, radius, confirmation, truth, channel,
-              abs_z, abs_y, abs_x], ...]``.
+            Blobs array formatted as ``[[z, y, x, radius, ...], ...]``.
         
         """
         # target num of cols minus current cols

--- a/magmap/cv/stack_detect.py
+++ b/magmap/cv/stack_detect.py
@@ -446,10 +446,12 @@ def detect_blobs_blocks(
     if segments_all is not None:
         # remove the duplicated elements that were used for pruning
         blobs.replace_rel_with_abs_blob_coords(segments_all)
+        blobs.blobs = segments_all
         if coloc:
             colocs = segments_all[:, 10:10+num_chls_roi].astype(np.uint8)
+        
         # remove absolute coordinate and any co-localization columns
-        segments_all = blobs.remove_abs_blob_coords(segments_all, True)
+        segments_all = blobs.remove_abs_blob_coords(True)
         
         # compare detected blobs with truth blobs
         # TODO: assumes ground truth is relative to any ROI offset,

--- a/magmap/gui/vis_3d.py
+++ b/magmap/gui/vis_3d.py
@@ -356,7 +356,8 @@ class Vis3D:
             segs_in_mask: np.ndarray,
             cmap: np.ndarray,
             roi_offset: Sequence[int], roi_size: Sequence[int],
-            show_shadows: bool = False, flipz: bool = None
+            show_shadows: bool = False, flipz: bool = None,
+            clear: bool = False
     ) -> Tuple[float, float]:
         """Show 3D blobs as points.
 
@@ -375,6 +376,7 @@ class Vis3D:
             flipz: True to invert blobs along the z-axis to match
                 the handedness of Matplotlib with z progressing upward;
                 defaults to False.
+            clear: Clear existing blobs before showing new ones.
 
         Returns:
             Tuple of:
@@ -388,13 +390,15 @@ class Vis3D:
             return 0, 0
         if roi_offset is None:
             roi_offset = np.zeros(3, dtype=int)
-        if self.blobs3d:
+        if self.blobs3d and clear:
             for blob in self.blobs3d:
                 # remove existing blob glyphs from the pipeline
                 blob.remove()
+            self.blobs3d = []
+        elif not self.blobs3d:
+            self.blobs3d = []
         self.blobs3d_in = None
         self.matches3d = None
-        self.blobs3d = []
         
         settings = config.roi_profile
         # copy blobs with duplicate columns to access original values for

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -3575,25 +3575,25 @@ class Visualization(HasTraits):
     
     @on_trait_change("_region_id")
     def _region_id_changed(self):
-        """Center the viewer on the region specified in the corresponding 
+        """Center the viewer on the region specified in the corresponding
         text box.
         
-        :const:``_PREFIX_BOTH_SIDES`` can be given to specify IDs with 
-        both positive and negative values. All other non-integers will 
+        :const:``_PREFIX_BOTH_SIDES`` can be given to specify IDs with
+        both positive and negative values. All other non-integers will
         be ignored.
         """
         print("region ID: {}".format(self._region_id))
         if RegionOptions.APPEND.value in self._region_options:
-            self._roi_feedback = (
+            self._bg_feedback = (
                 "Add more regions, then uncheck \"Append\" to view them")
             return
         
         if config.labels_img is None:
-            self._roi_feedback = "No labels image loaded to find region"
+            self._bg_feedback = "No labels image loaded to find region"
             return
 
         if config.labels_ref is None or config.labels_ref.ref_lookup is None:
-            self._roi_feedback = "No labels reference loaded to find region"
+            self._bg_feedback = "No labels reference loaded to find region"
             return
 
         # user-given region can be a comma-delimited list of region IDs
@@ -3614,7 +3614,7 @@ class Visualization(HasTraits):
                 region_id = int(region_id)
             except ValueError:
                 # return if cannot convert to an integer
-                self._roi_feedback = (
+                self._bg_feedback = (
                     "Region ID must be an integer, or preceded by \"+/-n\" "
                     "to include labels from both sides"
                 )
@@ -3626,7 +3626,7 @@ class Visualization(HasTraits):
             config.labels_scaling, both_sides=both_sides,
             incl_children=incl_chil)
         if centroid is None:
-            self._roi_feedback = (
+            self._bg_feedback = (
                 "Could not find the region corresponding to ID {}"
                 .format(self._region_id))
             return

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -2144,9 +2144,14 @@ class Visualization(HasTraits):
                             libmag.get_if_within(suffix, 0, "")))
                     if suffix_stem in self._labels_img_names.selections:
                         labels_suffix = suffix_stem
+                
+            if config.labels_img is None and (
+                    Vis3dOptions.RAW.value not in self._check_list_3d):
+                # enable 3D vis "raw" mode if no labels image
+                self._check_list_3d.append(Vis3dOptions.RAW.value)
             
             # show main image lists in two dropdowns, where selecting a suffix
-            # from one list immediately moves it to the other 
+            # from one list immediately moves it to the other
             main_img_names_avail.insert(
                 0, self._MAIN_IMG_NAME_AVAIL_DEFAULT)
             self._main_img_names_avail.selections = main_img_names_avail
@@ -2943,8 +2948,7 @@ class Visualization(HasTraits):
         # get blobs in ROI and display as spheres in Mayavi viewer
         roi_size = self.roi_array[0].astype(int)
         show_shadows = Vis3dOptions.SHADOWS.value in self._check_list_3d
-        clear = (Vis3dOptions.CLEAR.value in self._check_list_3d or
-                 Vis3dOptions.RAW.value in self._check_list_3d)
+        clear = Vis3dOptions.CLEAR.value in self._check_list_3d
         scale, mask_size = self._vis3d.show_blobs(
             self.blobs, self.segs_in_mask, self.segs_cmap,
             self._curr_offset()[::-1], roi_size[::-1], show_shadows,
@@ -2956,7 +2960,6 @@ class Visualization(HasTraits):
         
         # set the blob mask size
         self._segs_mask_high = mask_size * 5
-        print("mask size", mask_size)
         self._segs_mask = mask_size
 
     @on_trait_change("_colocalize")

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -2684,7 +2684,7 @@ class Visualization(HasTraits):
     def detect_blobs(
             self, segs: Optional[np.ndarray] = None,
             blob_matches: Optional[
-                Sequence["magmap.cv.colocalizer.BlobMatch"]] = None,
+                Sequence["colocalizer.BlobMatch"]] = None,
             add_border: bool = False):
         """Detect blobs within the current ROI.
         

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -1071,8 +1071,7 @@ class Visualization(HasTraits):
             prefs.roi_styles, Styles2D.SQUARE.value, Styles2D)]
         # self._check_list_2d = [self._DEFAULTS_2D[1]]
         
-        self._check_list_3d = [
-            Vis3dOptions.RAW.value, Vis3dOptions.SURFACE.value]
+        self._check_list_3d = [Vis3dOptions.SURFACE.value]
         if (config.roi_profile["vis_3d"].lower()
                 == Vis3dOptions.SURFACE.value.lower()):
             # check "surface" if set in profile
@@ -3625,19 +3624,18 @@ class Visualization(HasTraits):
             self._img_region, config.resolutions[0])[:2]
 
         if Vis3dOptions.RAW.value in self._check_list_3d:
-            # in "raw" mode, simply center the current ROI on the label
+            # "raw" mode:; simply center the current ROI on the label
             # centroid, which may lie within a sub-label
             curr_roi_size = self.roi_array[0].astype(int)
             corner = np.subtract(
-                centroid, 
+                centroid,
                 np.around(np.divide(curr_roi_size[::-1], 2)).astype(int))
             self.z_offset, self.y_offset, self.x_offset = corner
             self._check_roi_position()
             self.show_3d()
         else:
-            # in non-"raw" mode, show the full label including sub-labels 
-            # without non-label areas; TODO: consider making default or 
-            # only option
+            # non-"raw", label mode: show the full label including sub-labels
+            # without non-label areas
             self.show_label_3d(region_ids)
         # sync with atlas editor to point at center of region
         self.sync_atlas_eds_coords(centroid)

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -2725,9 +2725,9 @@ class Visualization(HasTraits):
         # collect segments in ROI and padding region, ensuring coordinates
         # are relative to offset
         colocs = None
+        segs_all = None
         if config.blobs is None or config.blobs.blobs is None:
-            # on-the-fly blob detection, which includes border but not
-            # padding region; already in relative coordinates
+            # on-the-fly blob detection; already in relative coordinates
             roi = self.roi
             if config.roi_profile["thresholding"]:
                 # thresholds prior to blob detection
@@ -2746,9 +2746,10 @@ class Visualization(HasTraits):
                 if matches and len(matches) > 0:
                     # TODO: include all channel combos
                     self.blobs.blob_matches = matches[tuple(matches.keys())[0]]
-        else:
+        
+        elif segs is None or add_border or self._colocalize:
             # get all previously processed blobs in ROI plus additional
-            # padding region to show surrounding blobs
+            # margin for surrounding blobs and any colocalizations
             # TODO: set segs_all to None rather than empty list if no blobs?
             print("Selecting blobs in ROI from loaded blobs")
             segs_all, mask = detector.get_blobs_in_roi(

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -589,10 +589,11 @@ class Visualization(HasTraits):
     # label to display a tooltip
     _region_id = Str(
         tooltip="IDs: IDs of labels to navigate to. Add +/- to including both\n"
-                "sides. Separate multiple IDs by commas.\n"
+                "sides. Separate multiple IDs by commas. To also show loaded\n"
+                "blobs, check the blob channels in the \"Detect\" panel.\n\n"
                 "Both sides: include correspondings labels from opposite sides"
                 "\nChildren: include all children of the label\n"
-                "Append: append label IDs; uncheck to navigate to group\n"
+                "Append: append selected region\n"
                 "Show all: show abbreviations for all visible labels")
     _region_options = List
     
@@ -1995,6 +1996,13 @@ class Visualization(HasTraits):
         name = os.path.splitext(os.path.basename(config.filename))[0]
         self._post_3d_display(
             title="label3d_{}".format(name), show_orientation=False)
+        
+        blobs = config.blobs
+        if blobs is not None and self._segs_chls:
+            # show 3D blobs if loaded the any blob channel is checked
+            regions = blobs.get_blob_col(blobs.blobs, blobs.Cols.REGION)
+            blobs_in = blobs.blobs[np.isin(regions, label_id), ]
+            self.detect_blobs(blobs_in)
         
         # turn off stale flag from ROI changes
         self.stale_viewers[vis_handler.ViewerTabs.MAYAVI] = None

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -2943,9 +2943,12 @@ class Visualization(HasTraits):
         # get blobs in ROI and display as spheres in Mayavi viewer
         roi_size = self.roi_array[0].astype(int)
         show_shadows = Vis3dOptions.SHADOWS.value in self._check_list_3d
+        clear = (Vis3dOptions.CLEAR.value in self._check_list_3d or
+                 Vis3dOptions.RAW.value in self._check_list_3d)
         scale, mask_size = self._vis3d.show_blobs(
             self.blobs, self.segs_in_mask, self.segs_cmap,
-            self._curr_offset()[::-1], roi_size[::-1], show_shadows, self.flipz)
+            self._curr_offset()[::-1], roi_size[::-1], show_shadows,
+            self.flipz, clear)
         
         # set the max scaling based on the starting value
         self._scale_detections_high = scale * 5

--- a/magmap/io/np_io.py
+++ b/magmap/io/np_io.py
@@ -553,6 +553,14 @@ def setup_images(
             blobs.blobs[:, :4] = ontology.scale_coords(
                 blobs.blobs[:, :4], scaling)
         blobs.scaling = scaling
+        
+        if config.labels_img is not None:
+            # assign blobs to regions
+            coords = blobs.blobs[:, :3]
+            regions = ontology.get_label_ids_from_position(
+                coords.astype(int), config.labels_img)
+            blobs.format_blobs()
+            blobs.set_blob_col(blobs.blobs, blobs.Cols.REGION, regions)
 
 
 def get_num_channels(img: np.ndarray, is_3d: bool = False) -> int:

--- a/profiles/roi_blobs.yaml
+++ b/profiles/roi_blobs.yaml
@@ -1,6 +1,8 @@
 ---
 # 3D blob detection parameters
-# Copy this configuration template to a new file to customize settings
+# Copy this configuration template to a new file to customize settings.
+# For more details on parameters and ranges, see:
+# https://github.com/sanderslab/magellanmapper/blob/master/magmap/settings/roi_prof.py#L72-L97
 
 # many of these settings are used in the method described here:
 # https://scikit-image.org/docs/dev/api/skimage.feature.html#skimage.feature.blob_log
@@ -13,4 +15,23 @@ overlap: 0.5 # blob overlap fraction from 0-1; remove blob if above overlap
 # pixels to exclude along border after blob detection to avoid clumping
 # along image borders
 exclude_border: null # sequence in z,y,x
+
+# Preprocessing
+
+# intensity contrast stretching, from 0-100
+clip_vmin: 5
+clip_vmax: 99.5
+
+# intensity clipping after stretch, from 0-1
+clip_min: 0.2
+clip_max: 1.0
+
+# denoising, typical default is 0.1
+tot_var_denoise: null
+
+# anisotropic resizing factor; setting any value triggers resizing to be
+# isotropic, and the vals given here are multipliers in z,y,x after this
+# isotropic scaling; eg (0.7, 1, 1) rescales the z-axis to be 0.7x isotropic
+isotropic_vis: null
+
 ...


### PR DESCRIPTION
3D blobs have been shown for ROIs but not for specific regions. Now selecting a region in the "Atlases" panel will display these blobs for just the selected region. This will occur when a blobs file has been loaded, and any blob channels are selected in the "Detect" panel.

To support these changes, the `Blobs` class has been undergoing cleanup to generalize access to different columns and adding new ones.

Additional changes:
- The `Raw` 3D option is now off by default since users are most likely showing 3D regions instead of 3D ROIs
- Feedback from the regions control is displayed in the same panel rather than in the "ROI" panel
- Reloaded a saved ROI will no longer run detection in surrounding areas to avoid confusion about what blobs came from where
- Blobs archive version bumped to v5 to correct the stored blob columns, which should not include the absolute coordinates since they are removed after blob detection
- More blob setting examples have been added to the sample `profiles/roi_blobs.yaml` file