### PR TITLE
Fix crosshairs for Matplotlib v3.9.0

### DIFF
--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -235,7 +235,7 @@
 - Supports TraitsUI v8 (#510)
 - Fixed error on deprecated NumPy data type aliases (#364)
 - Fixed `qt4 backend` error by avoiding PyQt v5.15.8 (#431)
-- Fixed erro on deprecated Matplotlib colormap access (#649)
+- Fixed for deprecations through Matplotlib v3.9 (#649, #657)
 
 #### R Dependency Changes
 

--- a/magmap/gui/plot_editor.py
+++ b/magmap/gui/plot_editor.py
@@ -398,8 +398,8 @@ class PlotEditor:
             self.vline.set_visible(show)
             if show:
                 # update positions of current crosshairs
-                self.hline.set_ydata(coord[1])
-                self.vline.set_xdata(coord[2])
+                self.hline.set_ydata([coord[1]])
+                self.vline.set_xdata([coord[2]])
     
     def set_show_label(self, val):
         """Set whether to show labels on hover.


### PR DESCRIPTION
Matplotlib v3.9.0 introduced a change wither `Line2D` x/y positions must be set with a sequence (see https://matplotlib.org/stable/api/prev_api_changes/api_changes_3.9.0.html#line2d), fixed here.