### PR TITLE
Add navigation to the sample commands Jupyter Notebook

### DIFF
--- a/bin/sample_cmds_bash.ipynb
+++ b/bin/sample_cmds_bash.ipynb
@@ -15,7 +15,8 @@
     "\n",
     "## Navigation\n",
     "\n",
-    "- [Prereqs](#prereqs): only necessary if running as a Notebook:\n",
+    "- [Prereqs](#prereqs) (only necessary if running as a Notebook)\n",
+    "- [Conventions](#conventions)\n",
     "- [Image import](#image-import)\n",
     "- [Atlas registration](#atlas-registration)\n",
     "- [Cell detection](#cell-detection)\n",
@@ -27,7 +28,7 @@
    "id": "778b0276-5092-485a-8150-6653cdb19d37",
    "metadata": {},
    "source": [
-    "## Prereqs<a id=\"prereqs\"></a>\n",
+    "## Prereqs to run the Notebook<a id=\"prereqs\"></a>\n",
     "\n",
     "**This section is only necessary if running the Notebook.** If you only want to copy commands into your own script, you can skip this section.\n",
     "\n",
@@ -119,6 +120,16 @@
     "fi\n",
     "cd \"$BASE_DIR\"\n",
     "echo \"Set up paths\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8be2dce1",
+   "metadata": {},
+   "source": [
+    "## Conventions<a id=\"conventions\"></a>\n",
+    "\n",
+    "- Coordinates are given as `x,z,z` for this CLI (but in NumPy, `z,y,x`, order for the API)"
    ]
   },
   {
@@ -522,17 +533,21 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "id": "7f9eb98f-1850-4764-bc59-e82f282107c5",
    "metadata": {},
-   "outputs": [],
    "source": [
     "#### Limit blob detection to an ROI\n",
     "\n",
-    "TODO\n",
-    "\n",
-    "### Build and test ground truth sets\n",
+    "TODO"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "80cad24f",
+   "metadata": {},
+   "source": [
+    "#### Build and test ground truth sets<a id=\"truth-sets\"></a>\n",
     "\n",
     "TODO"
    ]
@@ -1013,8 +1028,6 @@
    "source": [
     "## Export Images\n",
     "\n",
-    "TODO\n",
-    "\n",
     "### Export region IDs\n",
     "\n",
     "Build a table of regions, their IDs, and the parent region IDs at an ontology level, where:\n",
@@ -1035,6 +1048,190 @@
    "outputs": [],
    "source": [
     "mm out --register export_regions --labels \"${atlas_dir}/ontology1.json\" level=1 orig_colors=0"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fd2efd4b",
+   "metadata": {},
+   "source": [
+    "### Export image planes and ROIs\n",
+    "\n",
+    "#### Export individual full image planes from a volumetric image\n",
+    "\n",
+    "- `--savefig`: can be image extensions such as `png`, `jpg`, or `pdf`\n",
+    "- `--slice`: given as `start,stop,step`. Follows Python `slice` syntax, so 1 argument = `stop`, 2 = `start,stop`, and 3 = `start,stop,step`. `none` can be used for \"all\".\n",
+    "- `--plot_labels text_pos=\"0.01,0.95\"`: labels each plane with its index, eg `z-plane: 100`, at the given position, eg here at the top left corner\n",
+    "- `--plot_labels padding=-0.5`: adjust padding around the plane, eg reducing slightly here\n",
+    "- `--plane yz`: export the yz-plane instead. `xz` = z-plane, `xz` = y-plane, `yz` = x-plane.\n",
+    "- `--transform rescale=0.5`: scale down by 0.5x\n",
+    "\n",
+    "*Example*: export the `z = 100` plane (stops at plane `101`):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cab3ed1c",
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "mm \"$img\" --proc extract --savefig png --slice 100,101"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e3fc95fd",
+   "metadata": {},
+   "source": [
+    "*Example*: export every 10th plane from `z = 100` to `z = 200` (non-inclusive):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c202b59f",
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "mm \"$img\" --proc extract --savefig png --slice 100,200,10"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "420cd4e8",
+   "metadata": {},
+   "source": [
+    "#### Export individual planes from ROIs\n",
+    "\n",
+    "Similar as above, but use `offset`/`size` instead of `slice`:\n",
+    "- `--offset`: starting coordinate of ROI\n",
+    "- `--size`: size of ROI\n",
+    "- Note that if switching to another plane (eg `--plane yz`), resolutions are not scaled currently\n",
+    "\n",
+    "*Example*: export an ROI from `x = 10-14`, `y = 20-26`, `z = 0-1` as two z-planes (`z = 0` and `z = 1`):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ad0cba2c",
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "mm \"$img\" --proc extract --savefig png -offset 10,20,0 --size 5,7,2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0bdc84f8",
+   "metadata": {},
+   "source": [
+    "#### Export an animated GIF or MP4\n",
+    "\n",
+    "Simply replace `extract` with `animated` in the above commands.\n",
+    "\n",
+    "*Example*: animate every plane in the whole stack:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "18e8068b",
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "mm \"$img\" --proc animated --savefig mp4"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d7d4376e",
+   "metadata": {},
+   "source": [
+    "*Example*: generate an animated GIF from `z = 100` to the end:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "88163449",
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "mm \"$img\" --proc animated --savefig gif --slice 100,none"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a32012c1",
+   "metadata": {},
+   "source": [
+    "#### Export raw planes\n",
+    "\n",
+    "The prior commands exported image planes after rendering them in Matplotlib, including scaling, intensity ranging, and adding a scale bar. To export raw, unprocessed planes, use `export_planes` instead.\n",
+    "\n",
+    "*Example*: same as an earlier example, but extracted withour processing to TIF format:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b46e1b82",
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "mm \"$img\" --proc extract_planes --savefig tif --slice 100,200,10"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8c82542e",
+   "metadata": {},
+   "source": [
+    "#### Export ROIs with blob detections\n",
+    "\n",
+    "ROIs stored in a [truth set database](#truth-sets) can be exported with detections overlaid. This command automates output similar to the ROI Editor for all ROIs stored in the database.\n",
+    "\n",
+    "*Example*: Output each ROI in the default truth set DB for the image as a PDF of the ROI with blob detections overlaid:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4b52543f",
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "mm \"$img\" --proc export_rois --savefig pdf --truth_db view"
    ]
   },
   {

--- a/bin/sample_cmds_bash.ipynb
+++ b/bin/sample_cmds_bash.ipynb
@@ -7,11 +7,19 @@
    "source": [
     "# Sample commands for MagellanMapper tasks\n",
     "\n",
-    "This notebook demonstrates using MagellanMapper through its command-line interface. You can use the script in various ways:\n",
-    "1. Copy the commands to your own Bash shell script\n",
-    "1. Modify this notebook with your own image paths and run blocks for your desired tasks\n",
+    "This notebook demonstrates using MagellanMapper through its command-line interface. The main purpose is to ***demo commands that you can copy into your own Bash shell script**.\n",
     "\n",
-    "**Note**: This notebook is a work-in-progress, migrating commands from the [sample commands script](https://github.com/sanderslab/magellanmapper/blob/master/bin/sample_cmds.sh) to here. Please check back for updates!"
+    "The commands are also given in Jupyter Notebook format so that you can modify this notebook with your own image paths and run blocks for your desired tasks, though this requires [prereqs](#prereqs).\n",
+    "\n",
+    "**Note**: This notebook is a work-in-progress, migrating commands from the [sample commands script](https://github.com/sanderslab/magellanmapper/blob/master/bin/sample_cmds.sh) to here. Please check back for updates!\n",
+    "\n",
+    "## Navigation\n",
+    "\n",
+    "- [Prereqs](#prereqs): only necessary if running as a Notebook:\n",
+    "- [Image import](#image-import)\n",
+    "- [Atlas registration](#atlas-registration)\n",
+    "- [Cell detection](#cell-detection)\n",
+    "- [3D visualization](#3d-visualization)"
    ]
   },
   {
@@ -20,6 +28,10 @@
    "metadata": {},
    "source": [
     "## Prereqs\n",
+    "\n",
+    "**This section is only necessary if running the Notebook.** If you only want to copy commands into your own script, you can skip this section.\n",
+    "\n",
+    "### Set up JupyterLab\n",
     "\n",
     "- We assume that you've [installed MagellanMapper](https://github.com/sanderslab/magellanmapper#installation) in a Python environment or from the standalone installer\n",
     "- If you're using a Python environment, activate it (eg `conda activate mag` or `source <path-to-venv>/bin/activate`) before running this Notebook\n",
@@ -70,7 +82,7 @@
    "id": "21d17006-8be2-45c6-87eb-4f666f1cbb6e",
    "metadata": {},
    "source": [
-    "## Set up image paths\n",
+    "### Set up image paths\n",
     "\n",
     "First, let's set up variables to your image paths. The key variable to update is the path to your original image, `img_to_import`. This path minus its extension becomes the \"base path\" that can be used for most commands, including those on downstream output files."
    ]

--- a/bin/sample_cmds_bash.ipynb
+++ b/bin/sample_cmds_bash.ipynb
@@ -27,7 +27,7 @@
    "id": "778b0276-5092-485a-8150-6653cdb19d37",
    "metadata": {},
    "source": [
-    "## Prereqs\n",
+    "## Prereqs<a id=\"prereqs\"></a>\n",
     "\n",
     "**This section is only necessary if running the Notebook.** If you only want to copy commands into your own script, you can skip this section.\n",
     "\n",
@@ -126,7 +126,7 @@
    "id": "48f131f7-fa32-446f-9d27-827e1a400071",
    "metadata": {},
    "source": [
-    "## Image import\n",
+    "## Image import<a id=\"image-import\"></a>\n",
     "\n",
     "MagellanMapper typically requires images to be imported into a NumPy format (NPY) for faster access and lower memory usage. We use BioFormats to import from many formats, including proprietary microscopy formats."
    ]
@@ -269,7 +269,7 @@
    "id": "ce7ef87a-2af8-4ceb-86a9-4c73c393cedb",
    "metadata": {},
    "source": [
-    "## Atlas Registration\n",
+    "## Atlas Registration<a id=\"atlas-registration\"></a>\n",
     "\n",
     "MagellanMapper implements the [Elastix](https://elastix.lumc.nl/) registration toolkit (via [SimpleElastix](https://github.com/SuperElastix/SimpleElastix) to align atlases to your samples. Registering an atlas allows analyses of volume, cell counts, etc by anatomical region."
    ]
@@ -462,7 +462,7 @@
     "tags": []
    },
    "source": [
-    "## Cell Detection\n",
+    "## Cell Detection<a id=\"cell-detection\"></a>\n",
     "\n",
     "We use a blob detector to locate cells within an image. This detector identifies areas that are bright compared to their surroundings. We use profiles to adjust parameters for blob sizes, sensitivity thresholds, etc.\n",
     "\n",
@@ -539,6 +539,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "832a22c8",
    "metadata": {},
    "source": [
     "### Putting it together: quantify cells by region\n",
@@ -553,6 +554,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "7e5dd011",
    "metadata": {
     "vscode": {
      "languageId": "plaintext"
@@ -565,6 +567,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "9409a621",
    "metadata": {},
    "source": [
     "Next, combine regions into hierarchical structures. `level` sets the max (finest) hierarchical level, which allows only including high-level, larger structures (eg, `level=1`). In this case, we use a deep level to include all possible structures. `--atlas_profile combinesides` uses a profile that combines matching left and right regions and can be omitted to separate these regions."
@@ -573,6 +576,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "43d2a58c",
    "metadata": {
     "vscode": {
      "languageId": "plaintext"
@@ -588,6 +592,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "618ebbc0",
    "metadata": {},
    "source": [
     "#### Regional heat map\n",
@@ -600,6 +605,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "d7684a32",
    "metadata": {
     "vscode": {
      "languageId": "plaintext"
@@ -614,6 +620,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "5e576a09",
    "metadata": {},
    "source": [
     "Next, open the regional heat map. `--plot_labels nan_color=black` sets unlabeled regions to black. After opening the image, turn down the labels opacity to see the heat map. `--labels binary='#00000000,#000000ff'` can also be added to make the labels transparent automatically. The colormap can be changed in the \"Adjust Image > Color\" panel setting."
@@ -622,6 +629,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "73c8e361",
    "metadata": {
     "vscode": {
      "languageId": "plaintext"
@@ -821,7 +829,7 @@
     "tags": []
    },
    "source": [
-    "## 3D Visualization\n",
+    "## 3D Visualization<a id=\"3d-visualization\"></a>\n",
     "\n",
     "You can render your images as 3D surfaces with spheres for detected cells. MagellanMapper uses VTK in Mayavi to draw and interact with these surfaces in 3D.\n",
     "\n",

--- a/bin/sample_cmds_bash.ipynb
+++ b/bin/sample_cmds_bash.ipynb
@@ -1007,10 +1007,43 @@
     "\n",
     "TODO\n",
     "\n",
+    "### Export region IDs\n",
+    "\n",
+    "Build a table of regions, their IDs, and the parent region IDs at an ontology level, where:\n",
+    "- `\"${atlas_dir}/ontology1.json\"`: path to your atlas's ontology file\n",
+    "- `level`: show the parent at this ontology level for each region\n",
+    "- `orig_colors`: set 0 or \"none\" = export all labels; 1 = only drawn labels for the given atlas, which will also export the RGB values for the atlas labels"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c769e841",
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "mm out --register export_regions --labels \"${atlas_dir}/ontology1.json\" level=1 orig_colors=0"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d0cf4fe6",
+   "metadata": {},
+   "source": [
     "## Image Transformations\n",
     "\n",
-    "TODO\n",
-    "\n",
+    "TODO"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "65606a45",
+   "metadata": {},
+   "source": [
     "## Generate a new atlas\n",
     "\n",
     "TODO"

--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -208,7 +208,7 @@
 
 - Blob column accessors are encapsulated in the `Blobs` class, which allows for flexibility in column inclusion and order (#133, #651)
 - Settings profiles are being migrated from dictionaries to data classes to document and configure settings more easily (#138)
-- Jupyter Notebook as a tutorial for running various tasks in the CLI (#122)
+- Jupyter Notebook as a tutorial for running various tasks in the CLI (#122, #659)
 - Documentation is now [hosted on ReadTheDocs](https://magellanmapper.readthedocs.io/en/latest/index.html), using the Furo theme (#225, #563)
 - Default arguments are documented in API auto-docs (#485)
 - Expand continuous integration testing to both pinned and fresh dependencies across Python 3.6-3.12 (#75, #101, #252, #342, #538, #640)

--- a/magmap/io/cli.py
+++ b/magmap/io/cli.py
@@ -81,7 +81,7 @@ def _parse_none(
 
     """
     if not libmag.is_seq(none):
-        none = tuple(none)
+        none = [none]
     if arg.lower() in none:
         return None
     return arg if fn is None else fn(arg)


### PR DESCRIPTION
Adds navigation links by using anchors tags. This navigation currently only works on viewers such as this:
https://nbviewer.org/github/sanderslab/magellanmapper/blob/cleanup_notebook/bin/sample_cmds_bash.ipynb

In the GitHub viewer, the links apparently do not work because the page is shown within an iframe, and the links simply open the parent folder in the GitHub repo navigator.