### PR TITLE
Fix for NumPy v2 release

### DIFF
--- a/docs/release/release_v1.6.md
+++ b/docs/release/release_v1.6.md
@@ -238,6 +238,7 @@
 - Fixed error on deprecated NumPy data type aliases (#364)
 - Fixed `qt4 backend` error by avoiding PyQt v5.15.8 (#431)
 - Fixed for deprecations through Matplotlib v3.9 (#649, #657)
+- Fixed for NumPy v2 (#661)
 
 #### R Dependency Changes
 

--- a/magmap/cv/detector.py
+++ b/magmap/cv/detector.py
@@ -16,6 +16,12 @@ import pprint
 from typing import Callable, Dict, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
+try:
+    # np >= v2
+    from numpy.lib._index_tricks_impl import IndexExpression
+except ModuleNotFoundError:
+    # np < v2
+    from numpy.lib.index_tricks import IndexExpression
 from skimage.feature import blob_log
 
 from magmap.cv import colocalizer, cv_nd
@@ -497,8 +503,7 @@ class Blobs:
             cls, blob: np.ndarray,
             col: Union[int, "Blobs.Cols", Sequence[Union[int, "Blobs.Cols"]]],
             val: Union[float, Sequence[float]],
-            mask: Union[
-                np.ndarray, np.lib.index_tricks.IndexExpression] = np.s_[:],
+            mask: Union[np.ndarray, IndexExpression] = np.s_[:],
             **kwargs
     ) -> np.ndarray:
         """Set the value for the given column of a blob or blobs.


### PR DESCRIPTION
NumPy v2 has just been released, bringing many changes to the API, including the `np.lib` subpackage (see https://numpy.org/devdocs/numpy_2_0_migration_guide.html#numpy-lib-namespace). Fix a reference to the `np.lib.index_tricks` module.