### PR TITLE
Fix exporting regions' RGB colors

### DIFF
--- a/magmap/io/export_regions.py
+++ b/magmap/io/export_regions.py
@@ -77,11 +77,16 @@ def export_region_ids(
     data = OrderedDict()
     label_ids = sitk_io.find_atlas_labels(
         config.load_labels, drawn_labels_only, labels_ref_lookup)
-    cm = colormaps.get_labels_discrete_colormap(None, 0, use_orig_labels=True)
     
-    # prep RGB values for labels, only available if showing drawn labels
+    # set up label image colormap for RGB values using original labels,
+    # which are only available if showing drawn labels; use same settings
+    # as in image setup, including duplicate set of colors for neg values
+    # since the color randomization depends on the exact number of colors
+    cm = colormaps.setup_labels_cmap(None, use_orig_labels=True)
     rgbs = cm.cmap_labels
     if rgbs is not None:
+        # remove colors for duplicated labels, keeping second half
+        rgbs = rgbs[len(rgbs)//2:]
         cols.append("RGB")
     
     for i, key in enumerate(label_ids):

--- a/magmap/plot/colormaps.py
+++ b/magmap/plot/colormaps.py
@@ -124,8 +124,10 @@ class DiscreteColormap(colors.ListedColormap):
         if dup_for_neg and np.sum(labels_unique < 0) == 0:
             # for labels that are only >= 0, duplicate the pos portion
             # as neg so that images with or without negs use the same colors
+            lbls = np.array(labels_unique[labels_unique > 0][::-1])
             labels_unique = np.append(
-                -1 * labels_unique[labels_unique > 0][::-1], labels_unique)
+                -1 * lbls.astype(libmag.dtype_within_range(
+                    min(lbls), max(lbls), signed=True)), labels_unique)
         num_colors = len(labels_unique)
 
         labels_offset = 0

--- a/magmap/plot/colormaps.py
+++ b/magmap/plot/colormaps.py
@@ -482,7 +482,8 @@ def make_binary_cmap(binary_colors):
 
 
 def setup_labels_cmap(
-        labels_img: np.ndarray, binary_colors: Optional[Sequence[str]] = None,
+        labels_img: Optional[np.ndarray],
+        binary_colors: Optional[Sequence[str]] = None,
         **kwargs) -> "DiscreteColormap":
     """Wrapper to set up a colormap for a labels image.
     


### PR DESCRIPTION
Region names can be exported along with their RGB colors, but these values were incorrect for region IDs that included corresponding positive and negative values. The RGB values are fixed here, along with support for generating this export in NumPy v2.