### PR TITLE
Option to import TIF files to NPY format without Javabridge

### DIFF
--- a/docs/release/release_v1.7.md
+++ b/docs/release/release_v1.7.md
@@ -24,6 +24,10 @@
 
 #### I/O
 
+- TIF files can be imported without Javabridge/Bioformats by loading a TIF image directly with the flag, `--savefig npy` (#738)
+- Fixed loading TIF files without resolution metadata (#738)
+- Fixed saving/loading rescaled images using Numpy 2 (#738)
+
 #### Server pipelines
 
 #### Python stats and plots

--- a/magmap/atlas/transformer.py
+++ b/magmap/atlas/transformer.py
@@ -277,11 +277,19 @@ def transpose_img(
         rescaled_shape = chunking.get_split_stack_total_shape(sub_rois)
         if offset > 0:
             rescaled_shape = np.concatenate(([1], rescaled_shape))
-        print("rescaled_shape: {}".format(rescaled_shape))
+        print(f"rescaled_shape: {rescaled_shape}")
+        
+        # WORKAROUND: fix error in Numpy 2 when shape for open_memmap contains
+        # np.int64 values instead of primitive int (see:
+        # https://github.com/numpy/numpy/issues/28334)
+        def fix_shape(shape):
+            import operator
+            return [operator.index(s) for s in rescaled_shape]
+
         # rescale chunks directly into memmap-backed array to minimize RAM usage
         image5d_transposed = np.lib.format.open_memmap(
             filename_image5d_npz, mode="w+", dtype=sub_rois[0, 0, 0].dtype,
-            shape=tuple(rescaled_shape))
+            shape=tuple(fix_shape(rescaled_shape)))
         chunking.merge_split_stack2(sub_rois, None, offset, image5d_transposed)
         
         if rescale is not None:

--- a/magmap/io/importer.py
+++ b/magmap/io/importer.py
@@ -583,7 +583,7 @@ def _update_image5d_np_ver(curr_ver, image5d, info, filename_info_npz):
                 print("bounds for plane {}: {}, {}".format(i, low, high))
                 lows.append(low)
                 highs.append(high)
-            near_mins, near_maxs = _calc_near_intensity_bounds(
+            near_mins, near_maxs = calc_near_intensity_bounds(
                 near_mins, near_maxs, lows, highs)
         info["near_min"] = near_mins
         info["near_max"] = near_maxs
@@ -1148,7 +1148,7 @@ def import_multiplane_images(chl_paths, prefix, import_md, series=None,
                 print("Multiple channels imported per plane, will assume "
                       "all channels are imported and end channel import")
                 break
-            near_mins, near_maxs = _calc_near_intensity_bounds(
+            near_mins, near_maxs = calc_near_intensity_bounds(
                 near_mins, near_maxs, lows, highs)
             chli += 1
         if rdr is not None:
@@ -1405,7 +1405,16 @@ def calc_intensity_bounds(image5d, lower=0.5, upper=99.5, dim_channel=4):
     return lows, highs
 
 
-def _calc_near_intensity_bounds(near_mins, near_maxs, lows, highs):
+def calc_near_intensity_bounds(near_mins, near_maxs, lows, highs):
+    """Calculate near min/max intensity values from lists of low/high values.
+    
+    Args:
+        near_mins: List of near min values.
+        near_maxs: List of near max values.
+        lows: List of low values for each channel.
+        highs: List of high values for each channel.
+    
+    """
     # get the extremes from lists of near-min/max vals
     if lows:
         num_channels = len(lows[0])

--- a/magmap/io/np_io.py
+++ b/magmap/io/np_io.py
@@ -687,6 +687,22 @@ def read_tif(
     img5d.img = tif_memmap
     img5d.path_img = path
     img5d.img_io = config.LoadIO.TIFFFILE
+
+    # save image5d metadata to file
+    filename_image5d, filename_meta = importer.make_filenames(
+        libmag.splitext(path)[0], keep_ext=True)
+    importer.save_image_info(
+        filename_meta, [os.path.basename(path)], [tif_memmap.shape],
+        md[config.MetaKeys.RESOLUTIONS],
+        md[config.MetaKeys.MAGNIFICATION],
+        md[config.MetaKeys.ZOOM], [0.], [0.])
+    
+    # save image5d to an NPY file using memory mapping
+    image5d = np.lib.format.open_memmap(
+        filename_image5d, mode="w+", dtype=tif_memmap.dtype,
+        shape=tif_memmap.shape)
+    image5d[:] = tif_memmap[:]
+    image5d.flush()
     
     return img5d, md
 

--- a/magmap/io/np_io.py
+++ b/magmap/io/np_io.py
@@ -648,10 +648,15 @@ def read_tif(
                     nrot = int(rotate.group().split("=")[1]) // -90
                     
         for i, name in enumerate(("YResolution", "XResolution")):
-            # parse x/y-resolution from standard TIF metadata
-            axis_res = tif.pages[0].tags[name].value
-            if axis_res and len(axis_res) > 1 and axis_res[0]:
-                res[0, i + 1] = axis_res[1] / axis_res[0]
+            try:
+                # parse x/y-resolution from standard TIF metadata
+                axis_res = tif.pages[0].tags[name].value
+                if axis_res and len(axis_res) > 1 and axis_res[0]:
+                    res[0, i + 1] = axis_res[1] / axis_res[0]
+            except KeyError:
+                # no resolution found, default to 1
+                _logger.info(
+                    "No %s tag found in TIF metadata, defaulting to 1", name)
     md[config.MetaKeys.RESOLUTIONS] = res
     
     # load TIFF by memory mapping


### PR DESCRIPTION
MM can open TIF files without prior import using the `Tifffile` package. This PR allows exporting the opened TIF file to NPY format, which serves a couple purposes:
- TIF can be imported to NPY without using Javabridge/Bioformats
- Metadata in the resulting imported file can be modified without changing the original TIF file

The TIF will only be exported if the CLI flag `--savefig npy` is set. Note also that the save step is itself fast, but the near-intensity value calculation can be slower (eg increased save time from 1s to 4s). The new `write_npy` function has an option to turn off this calculation, but not currently accessible to the user.

The image resolution metadata is typically extracted when loading the TIF file but would give an error if missing. This PR now tolerates this missing metadata.

Files opened using `open_memmap` in Numpy 2 and saved cannot currently be opened (see https://github.com/numpy/numpy/issues/28334), with workaround in this PR.