### PR TITLE
Remove `import` group from default environment setup

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -89,6 +89,30 @@ The `all` group installs the GUI and file import tools (see [optional dependenci
 
 Java will be installed automatically in Conda to support more image formats. To install it for Pip, download it from [here](https://www.azul.com/downloads/?package=jdk) and install Java before installing MM.
 
+### Optional installation groups
+
+| Group | Packages | Collection |
+|-----|-----|-----|
+| `most` | GUI and registration tools | `gui`, `itk` |
+| `all` | All groups plus `seaborn`, `scikit-learn` | Has all below |
+| `3D` | 3D rendering | |
+| `aws` | Tools for accessing AWS | |
+| `classifer` | Tensorflow | |
+| `docs` | Tools for building docs | |
+| `gui` | Main graphical interface | |
+| `import` | Imports proprietary image formats | |
+| `itk` | ITK-Elastix | |
+| `jupyter` | Running Notebooks | |
+| `pandas_plus` | Exports styled and Excel formats | |
+| `simpleitk` | Custom SimpleITK with Elastix | |
+
+To add an install group from within the `magellenmapper` directory of developer installs:
+
+```shell
+pip install -e ".[3d]" # add "3d" group
+pip install -e ".[3d,gui]" # add two groups
+```
+
 ### DEPRECATED: Installer packages
 
 <details>
@@ -193,10 +217,10 @@ Note 2: it may be necessary to update your environment for changes in dependenci
 
 | MagellanMapper Version | Python Versions Supported | Notes |
 |-----|-----|-----|
-| 1.7a1 | 3.10-3.13 | Defaults to 3.10. 3.6-3.9 support removed. |
-| >=1.6b1 | 3.6-3.11 | Defaults to 3.9. GUI support added for 3.10-3.11 in MM 1.6b2, 3.12 in MM 1.6b5. |
-| 1.6a1-a3 | 3.6-3.9 | GUI support added for 3.9; MM 1.6a2 base group no longer installs GUI |
-| 1.4-1.5 | 3.6-3.9 | No GUI support in 3.9 |
+| 1.7a1 | 3.10-3.13 | Defaults to Python 3.10. Python 3.6-3.9 support removed. |
+| >=1.6b1-1.6.x | 3.6-3.11 | Defaults to Python 3.9. GUI support added for Python 3.10-3.11 in MM 1.6b2, 3.12 in MM 1.6b5. |
+| 1.6a1-a3 | 3.6-3.9 | GUI support added for Python 3.9; MM 1.6a2 base group no longer installs GUI |
+| 1.4-1.5 | 3.6-3.9 | No GUI support in Python 3.9 |
 | < 1.4 | 3.6 | Initial releases |
 
 As of MM 1.6a2, the GUI can be excluded by installing the base group, eg without `[gui]` or `[most]`.
@@ -210,31 +234,6 @@ We've provided a few sets of pinned dependency versions:
 - Python 3.6 (deprecated): `envs/requirements_py36`
 
 These package versions are used for automated testing (continuous integration).
-
-### Optional installation groups
-
-| Group | Packages | Collection |
-|-----|-----|-----|
-| `most` | Import, GUI, and registration tools | Has `import`, `gui`, `itk` |
-| `all` | All groups plus `seaborn`, `scikit-learn` | Has all below |
-| `3D` | 3D rendering | |
-| `aws` | Tools for accessing AWS | |
-| `classifer` | Tensorflow | |
-| `docs` | Tools for building docs | |
-| `gui` | Main graphical interface | |
-| `import` | Imports proprietary image formats | |
-| `itk` | ITK-Elastix | |
-| `jupyter` | Running Notebooks | |
-| `pandas_plus` | Exports styled and Excel formats | |
-| `simpleitk` | Custom SimpleITK with Elastix | |
-
-To add an install group:
-
-```shell
-pip install "magellanmapper[3d]" # add "3d" group
-pip install "magellanmapper[3d,gui]" # add two groups
-pip install -e ".[3d]" # same but for editable install from clone
-```
 
 The same commands can be run to add groups after initial installation.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -14,12 +14,12 @@
 
 MagellanMapper supports several Python setups.
 
-### Quick Install
+### Quick install with Pip
 
-Install MagellanMapper with its graphical interface and registration tools:
+Install MagellanMapper with its graphical interface and registration tools with Python >= 3.10 (see [Python versions](#python-version-support); [virtual environment](https://realpython.com/python-virtual-environments-a-primer/) recommended):
 
 ```shell
-pip install "magellanmapper[gui,itk]"
+pip install "magellanmapper[most]"
 ```
 
 Then launch MagellanMapper:
@@ -28,11 +28,13 @@ Then launch MagellanMapper:
 mm
 ```
 
+Note: MM <1.7a1 installed import packages with `most`. For these versions, install with this command instead: `pip install "magellanmapper[gui,itk]"`
+
 See [below](#dependencies) for supported Python versions and adding install groups.
 
 See our [vignette](https://github.com/sanderslab/magellanmapper/blob/master/bin/sample_cmds_bash.ipynb) for getting started on MM!
 
-### Full install using Conda
+### Quick install with Conda
 
 If you use Conda (available [here](https://docs.conda.io/en/latest/miniconda.html)), you can install MagellanMapper into a new environment named `mag` (or replace with desired name):
 
@@ -47,25 +49,9 @@ conda activate mag
 mm
 ```
 
-Conda will also install Java, which we use to read proprietary image formats.
-
-The `mm` entry points was added in v1.6.0 to facilitate launching from installed packages.
-
-### Full install using Pip
-
-Install using Pip with Python >= 3.6 (see [Python versions](#python-version-support); Python >= 3.9 and [virtual environment](https://realpython.com/python-virtual-environments-a-primer/) recommended):
-
-```shell
-pip install "magellanmapper[most]" --extra-index-url https://pypi.fury.io/dd8/
-```
-
-The `most` group installs the GUI and file import tools (see [optional dependencies below](#optional-installation-groups)). The extra index accesses a few [customized dependencies](#custom-packages) for MagellanMapper.
-
-Java will need to be installed to support more image formats (eg from [here](https://www.azul.com/downloads/?package=jdk)).
-
 ### Developer installs
 
-You can install directly from the source code for the latest updates.
+You can install directly from the source code, which lets you use the latest updates without reinstallation.
 
 First, download the repo:
 
@@ -73,30 +59,41 @@ First, download the repo:
 git clone https://github.com/sanderslab/magellanmapper.git
 ```
 
-Next, install it:
-- For Conda:
+Next, install it with Conda:
 
 ```shell
 conda env create -n mag -f magellanmapper/environment.yml
 ```
 
-- Or Pip:
+or with Pip:
 
 ```shell
 pip install -e "magellanmapper[most]" --extra-index-url https://pypi.fury.io/dd8/
 ```
 
-MagellanMapper can be run using `mm` and `mm-cli` as above, or through the run script:
+MagellanMapper can be run using as above.
+
+**Alternative:** To install with all extra packages in Conda:
 
 ```shell
-python magellanmapper/run.py
+conda env create -n mag -f magellanmapper/environment_all.yml
 ```
 
-### Installer packages
+or with Pip:
 
-***Note**: We're in the process of determining how useful these are for the community. If you've liked them, please let us know! (And feedback welcome if you've run into any issues with them.)*
+```shell
+pip install -e "magellanmapper[all]" --extra-index-url https://pypi.fury.io/dd8/
+```
 
-The easiest way to install MagellanMapper is using one of the [installers](https://github.com/sanderslab/magellanmapper/releases) now available for Windows, macOS, and Linux.
+The `all` group installs the GUI and file import tools (see [optional dependencies below](#optional-installation-groups)). The extra index accesses a few [customized dependencies](#custom-packages) for MagellanMapper.
+
+Java will be installed automatically in Conda to support more image formats. To install it for Pip, download it from [here](https://www.azul.com/downloads/?package=jdk) and install Java before installing MM.
+
+### DEPRECATED: Installer packages
+
+<details>
+
+***Note**: We experiented with installer packages in MM v1.5 but discontinued them to streamline our efforts.*
 
 Windows users: The installer is not yet signed, meaning that Windows will still give some security warnings. If the Edge browser blocks the download, click the Downloads button -> the `...` button on the right of the file entry -> "Keep" -> "Show more" -> "Keep anyway". In the blue window after opening the file, click "More info" -> "Run anyway" to start the installer.
 
@@ -109,7 +106,11 @@ Windows users: The installer is not yet signed, meaning that Windows will still 
 
 On Windows and Mac, you can also use "Open with" on supported file types (eg `.npy`, `.mhd`, `.nii.gz`) to open them in MagellanMapper.
 
-### Installer scripts
+</details>
+
+### DEPRECATED: Installer scripts
+
+<details>
 
 We have also provided scripts to take care of installing Miniconda (if necessary), creating an environment, and installing MagellanMapper, without requiring command-line/terminal experience.
 
@@ -163,6 +164,8 @@ This setup script will check and install the following dependencies:
 - Performs a Pip install of MagellanMapper and all dependencies
 
 On Windows, the [Microsoft Visual C++ Redistributable for Visual Studio 2015, 2017 and 2019](https://visualstudio.microsoft.com/downloads/#microsoft-visual-c-redistributable-for-visual-studio-2019) (same package for all three years) is required.
+
+</details>
 
 ## Update MagellanMapper
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -239,7 +239,9 @@ The same commands can be run to add groups after initial installation.
 
 ### Optional Dependency Build and Runtime Requirements
 
-#### Custom packages
+#### DEPRECATED: Custom packages
+
+<details>
 
 In most cases MagellanMapper can be installed without a compiler by using custom dependency packages that we have pre-built and hosted.
 
@@ -263,12 +265,6 @@ Java versions:
 - Python-Javabridge uses JDK v8+ (v12+ in Javabridge 1.0.19; see [below](#image-loading) for image loading times and setup troubleshooting with various Java versions)
 - ImageJ/Fiji currently supports Java 8 best in our experience
 
-#### Additional optional packages
-
-- R for additional stats
-- Zstd (fallback to Zip) for compression on servers
-- MeshLab for 3D surface clean-up
-
 ### SimpleITK with Elastix dependency
 
 **Deprecated**: As of MM v1.6b2, ITK-Elastix will be installed instead. SimpleITK is still supported but no longer the default, and custom binaries are no longer generated.
@@ -282,6 +278,13 @@ If you would prefer to build SimpleITK with Elastix yourself, we have provided a
 
 As an alternative, the SimpleITK package can provide much of the same functionality except for our image registration pipeline.
 
+</details>
+
+#### Additional optional packages
+
+- R for additional stats
+- Zstd (fallback to Zip) for compression on servers
+- MeshLab for 3D surface clean-up
 
 ## Uninstallation
 
@@ -341,7 +344,7 @@ MagellanMapper has been built and tested to build on:
 
 - MacOS, tested on 10.11-10.15
 - Linux, tested on RHEL 7.4-7.5, Ubuntu 18.04-20.04
-- Windows, tested on Windows 10 (see below for details) in various environments:
+- Windows, tested on Windows 10-11 (see below for details) in various environments:
   - Native command-prompt and PowerShell
   - Via built-in Windows Subsystem for Linux (WSL), tested on Ubuntu 18.04 and an X Server
   - Bash scripts in Cygwin (tested on Cygwin 2.10+) and MSYS2

--- a/docs/install.md
+++ b/docs/install.md
@@ -165,27 +165,27 @@ This setup script will check and install the following dependencies:
 
 On Windows, the [Microsoft Visual C++ Redistributable for Visual Studio 2015, 2017 and 2019](https://visualstudio.microsoft.com/downloads/#microsoft-visual-c-redistributable-for-visual-studio-2019) (same package for all three years) is required.
 
-</details>
-
-## Update MagellanMapper
-
-### Update the MagellanMapper package
-
-If installed from a Python package, enter your virtual environment and run:
-
-```shell
-pip install -U magellanmapper --extra-index-url https://pypi.fury.io/dd8/
-```
-
-If installed from source:
-- For a cloned Git repo: run `git pull` to pull in all software updates
-- From a source code release: download the desired [release](https://github.com/sanderslab/magellanmapper/releases), extract it, and run MagellanMapper from there
-
-### Update the Conda or Venv environment
+#### Update the Conda or Venv environment
 
 Sometimes a virtual environment update is required for new dependencies.
 - To update a Conda environment, rerun the `bin/setup_conda` (macOS/Linux) or `bin\setup_conda.bat` (Windows) script
 - To update a Venv environment, rerun the `bin/setup_venv.sh` (macOS/Linux) or `bin\setup_venv.bat` (Windows) script
+
+</details>
+
+## Update MagellanMapper
+
+For developer installs, simply run `git pull` to update the source code.
+
+If installed from a Python package, enter your virtual environment and run:
+
+```shell
+pip install -U magellanmapper
+```
+
+Note: add ` --extra-index-url https://pypi.fury.io/dd8/` if the `import` or `all` groups were installed.
+
+Note 2: it may be necessary to update your environment for changes in dependencies. If so, create a new environment as [above](#installation-options).
 
 ## Dependencies
 

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,5 @@ channels:
 dependencies:
   - python=3.10
   - pip
-  - openjdk=8
   - pip:
-    - --extra-index-url https://pypi.fury.io/dd8/
     - -e .[most]

--- a/envs/environment_all.yml
+++ b/envs/environment_all.yml
@@ -1,0 +1,10 @@
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - python=3.10
+  - pip
+  - openjdk=8
+  - pip:
+    - --extra-index-url https://pypi.fury.io/dd8/
+    - -e .[all]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,10 +90,11 @@ most = [
     "pyamg",
     "magellanmapper[gui]",
     "magellanmapper[itk]",
-    "magellanmapper[import]",
 ]
 
-# (almost) all optional dependencies
+# (almost) all optional dependencies;
+# must use pip arg `--extra-index-url https://pypi.fury.io/dd8/` to install
+# because of the `import` group
 all = [
     "matplotlib_scalebar",
     "pyamg",


### PR DESCRIPTION
PR #738 enables importing multiplane TIF images without Javabridge/Bioformats, providing a workaround for accessing 3D+ images without these custom dependencies and the Java platform. This new PR removes the install group for these packages from the `most` install group to simplify installations and address #739.

We updated the installation docs to reflect this update, but we've left a few items unchanged until we make the next release:
- Readme docs remain unchanged until the next release with these changes
- The `envs/environment_rel.yml` script still includes Java and the extra dependencies URL