### PR TITLE
Refactor image references to use `Image5d`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,6 +68,15 @@ jobs:
           QT_QPA_PLATFORM: offscreen
         run: |
           pip install .
+      - name: Download test data (for Linux and macOS)
+        if: runner.os == 'Linux' || runner.os == 'macOS'
+        run: |
+          wget https://github.com/sanderslab/magellanmapper/releases/download/v1.1.3/sample_region.tif
+      - name: Download test data (for Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          Invoke-WebRequest -Uri "https://github.com/sanderslab/magellanmapper/releases/download/v1.1.3/sample_region.tif" -OutFile "sample_region.tif"
       - name: Lint with flake8
         run: |
           # stop the build if there are Python syntax errors or undefined names
@@ -86,4 +95,4 @@ jobs:
           #python -u -m magmap.tests.test_visualizer
           # TODO: add image artifacts
           #python -u -m magmap.tests.test_img_equality
-          #python -u -m magmap.tests.unit_testing
+          python -u -m magmap.tests.test_image_stack_integration

--- a/docs/release/release_v1.7.md
+++ b/docs/release/release_v1.7.md
@@ -31,7 +31,7 @@
 
 - TIF files can be imported without Javabridge/Bioformats by loading a TIF image directly with the flag, `--savefig npy` (#738, #753)
 - Read and write `PhysicalSpacingX`-style TIF resolutions (#753)
-- Fixed loading TIF files without resolution metadata (#738)
+- Fixed issues with loading certain TIF files' metadata (#738, #754)
 - Fixed saving/loading rescaled images using Numpy 2 (#738)
 
 #### Server pipelines
@@ -44,6 +44,9 @@
 #### R stats and plots
 
 #### Code base and docs
+
+- Better encapsulated the main image to pave the way for loading multiple images in the same session (#754)
+- Integration tests for loading images and large stack blob detection (#754)
 
 ### Dependency Updates
 

--- a/magmap/cv/classifier.py
+++ b/magmap/cv/classifier.py
@@ -260,13 +260,13 @@ class ClassifyImage:
         if image5d is None and config.img5d is not None:
             # get main image from config
             image5d = config.img5d.img
-            if image5d is None:
-                raise FileNotFoundError("No image found")
+        if image5d is None:
+            raise FileNotFoundError("No image found")
         
         if channels is None:
             # set up channels from config
             channels = plot_3d.setup_channels(
-                config.image5d, config.channel, 4)[1]
+                image5d, config.channel, 4)[1]
         
         if blobs is None:
             # get blobs from config

--- a/magmap/cv/stack_detect.py
+++ b/magmap/cv/stack_detect.py
@@ -561,7 +561,7 @@ def detect_blobs_stack(
         blobs_out = detect_blobs_blocks(
             filename_base, img5d.img, subimg_offset, subimg_size,
             chl, config.truth_db_mode is config.TruthDBModes.VERIFY,
-            not config.grid_search_profile, config.image5d_is_roi, coloc)
+            not config.grid_search_profile, img5d.is_roi, coloc)
         for col, val in zip(cols, blobs_out):
             detection_out.setdefault(col, []).append(val)
         _logger.info(f"\n{'-' * 80}")

--- a/magmap/cv/stack_detect.py
+++ b/magmap/cv/stack_detect.py
@@ -386,6 +386,8 @@ def detect_blobs_blocks(
     # by physical units to make more independent of resolution; use profile
     # from first channel to be processed for block settings
     time_detection_start = time()
+    if channels is None:
+        _, channels = plot_3d.setup_channels(roi, channels, 3)
     settings = config.get_roi_profile(channels[0])
     _logger.info("Profile for block settings: %s", settings[settings.NAME_KEY])
     blocks = setup_blocks(settings, roi.shape)

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -3974,7 +3974,8 @@ class Visualization(HasTraits):
             profs[profs[:, 0] == ProfileCats.GRID.value, 1])
 
         # set up all profiles and showed the profile for the selected category
-        cli.setup_roi_profiles(roi_profs)
+        cli.setup_roi_profiles(
+            roi_profs, None if self.img5d is None else self.img5d.img)
         cli.setup_atlas_profiles(atlas_profs)
         cli.setup_grid_search_profiles(grid_profs)
         self._show_combined_profile()

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -1717,7 +1717,7 @@ class Visualization(HasTraits):
             for seg in segs_to_delete:
                 feedback.append(self._format_seg(seg))
         exp_name = sqlite.get_exp_name(
-            config.img5d.path_img if config.img5d else None)
+            self.img5d.path_img if self.img5d else None)
         exp_id = config.db.select_or_insert_experiment(exp_name)
         roi_id, out = sqlite.select_or_insert_roi(
             config.db.conn, config.db.cur, exp_id, config.series, 
@@ -2073,9 +2073,9 @@ class Visualization(HasTraits):
         self._init_channels()
         self._vis3d = vis_3d.Vis3D(self.scene)
         self._vis3d.fn_update_coords = self.set_offset
-        if config.img5d and config.img5d.img is not None:
-            image5d = config.img5d.img
-            config.img5d.rgb = self._rgb
+        if self.img5d and self.img5d.img is not None:
+            image5d = self.img5d.img
+            self.img5d.rgb = self._rgb
             
             # TODO: consider subtracting 1 to avoid max offset being 1 above
             # true max, but currently convenient to display size and checked
@@ -2210,7 +2210,7 @@ class Visualization(HasTraits):
         
         # set up selector for loading past saved ROIs
         self._rois_dict = {self._ROI_DEFAULT: None}
-        img5d = config.img5d
+        img5d = self.img5d
         if config.db is not None and img5d and img5d.path_img is not None:
             self._rois = config.db.get_rois(sqlite.get_exp_name(
                 img5d.path_img))
@@ -2385,10 +2385,10 @@ class Visualization(HasTraits):
     @observe("_rgb", post_init=True)
     def _update_rgb(self, event):
         """Handle changes to the RGB button."""
-        if config.img5d:
+        if self.img5d:
             # change image RGB setting, which editors reference
-            config.img5d.rgb = self._rgb
-            _logger.debug("Changed RGB to %s", config.img5d.rgb)
+            self.img5d.rgb = self._rgb
+            _logger.debug("Changed RGB to %s", self.img5d.rgb)
             
             # update image adjustment channel options
             self._update_imgadj_limits()
@@ -3129,7 +3129,7 @@ class Visualization(HasTraits):
             # additional args with defaults
             self._full_border(self.border))
         roi_ed = roi_editor.ROIEditor(
-            config.img5d, config.labels_img, self._img_region,
+            self.img5d, config.labels_img, self._img_region,
             self.show_label_3d, self.update_status_bar_msg)
         self.roi_ed = roi_ed
         
@@ -3214,7 +3214,7 @@ class Visualization(HasTraits):
             # using the same title causes the windows to overlap
             title += " ({})".format(len(self.atlas_eds) + 1)
         atlas_ed = atlas_editor.AtlasEditor(
-            config.img5d, config.labels_img, config.channel,
+            self.img5d, config.labels_img, config.channel,
             self._curr_offset(center=False), self._atlas_ed_close_listener,
             config.borders_img, self.show_label_3d, title,
             self._refresh_atlas_eds, self._atlas_ed_fig,
@@ -3399,7 +3399,7 @@ class Visualization(HasTraits):
             self.verifier_ed.on_close()
         
         verifier_ed = verifier_editor.VerifierEditor(
-            config.img5d, self.blobs, "Verifier", self._roi_ed_fig,
+            self.img5d, self.blobs, "Verifier", self._roi_ed_fig,
             # necessary for immediate table refresh rather than after scroll
             self.update_segment)
         verifier_ed.additive_blend = self._merge_chls

--- a/magmap/gui/visualizer.py
+++ b/magmap/gui/visualizer.py
@@ -114,7 +114,7 @@ def main():
         vtk_out.SetInstance(vtk_out)
 
     # create Trait-enabled GUI
-    visualization = Visualization()
+    visualization = Visualization(config.img5d)
     visualization.configure_traits()
     
 
@@ -1050,10 +1050,18 @@ class Visualization(HasTraits):
         id=f"{__name__}.{__qualname__}",
     )
     
-    def __init__(self):
-        """Initialize GUI."""
+    def __init__(self, img5d=None):
+        """Initialize GUI.
+
+        Params:
+            img5d: Main image 5D object to display in the GUI.
+        
+        """
         HasTraits.__init__(self)
         
+        #: Main image 5D object.
+        self.img5d: Optional["np_io.Image5d"] = img5d
+
         # get saved preferences
         prefs = config.prefs
         
@@ -1173,8 +1181,6 @@ class Visualization(HasTraits):
         
         # set up rest of image adjustment during image setup
         self.stale_viewers = self.reset_stale_viewers()
-        #: Main image 5D object.
-        self.img5d: Optional["np_io.Image5d"] = config.img5d
         self._img3ds = None
         self._imgadj_min_ignore_update: bool = False
         self._imgadj_max_ignore_update: bool = False

--- a/magmap/io/cli.py
+++ b/magmap/io/cli.py
@@ -500,7 +500,7 @@ def process_cli_args():
         config.metadatas = []
         for path in config.metadata_paths:
             # load metadata to dictionary
-            md, _ = importer.load_metadata(path, assign=False)
+            md, _ = importer.load_metadata(path)
             config.metadatas.append(md)
 
     if args.channel is not None:

--- a/magmap/io/export_stack.py
+++ b/magmap/io/export_stack.py
@@ -360,7 +360,7 @@ def _setup_labels_cmaps(imgs, cmaps_labels=None):
 
 
 def setup_stack(
-        image5d: np.ndarray, path: Optional[str] = None,
+        image5d: Optional[np.ndarray], path: Optional[str] = None,
         offset: Optional[Sequence[int]] = None,
         roi_size: Optional[Sequence[int]] = None,
         slice_vals: Optional[Sequence[int]] = None,
@@ -550,13 +550,14 @@ def stack_to_img(paths, roi_offset, roi_size, series=None, subimg_offset=None,
             axs = []
             # TODO: test directory of images
             # TODO: consider not reloading first image
-            np_io.setup_images(path_sub, series, subimg_offset, subimg_size)
-            if config.img5d.img_io is config.LoadIO.TIFFFILE:
+            img5d = np_io.setup_images(
+                path_sub, series, subimg_offset, subimg_size)
+            if img5d.img_io is config.LoadIO.TIFFFILE:
                 # remove extension from TIF files, which needed ext to load
                 path_base = libmag.get_filename_without_ext(path_base)
             
             stacker = setup_stack(
-                config.image5d, path_sub, offset=roi_offset,
+                img5d.img, path_sub, offset=roi_offset,
                 roi_size=roi_size, slice_vals=config.slice_vals, 
                 rescale=config.transform[config.Transforms.RESCALE],
                 labels_imgs=(config.labels_img, config.borders_img))

--- a/magmap/io/importer.py
+++ b/magmap/io/importer.py
@@ -695,7 +695,7 @@ def assign_metadata(
         img5d.shapes = md["sizes"]
         # get first series' shape
         md[config.MetaKeys.SHAPE] = libmag.get_if_within(img5d.shapes, 0)
-        _logger.debug("Image shapes %", img5d.shapes)
+        _logger.debug("Image shapes %s", img5d.shapes)
     except KeyError:
         _logger.debug("Could not find image sizes")
     

--- a/magmap/io/np_io.py
+++ b/magmap/io/np_io.py
@@ -63,6 +63,10 @@ class Image5d:
         self.rgb: bool = False
         #: True if image is a sub-image/ROI.
         self.is_roi: bool = False
+        #: 2D array of shapes per time point in
+        #: ``[n_time_point, n_shape]`` format in case image5d is not available
+        #: TODO: consider simplify to single shape as 1D array
+        self.shapes: np.ndarray = None
 
 
 def img_to_blobs_path(path):
@@ -299,7 +303,7 @@ def setup_images(
             # fails to load since metadata could be specified elsewhere
             _, orig_info = importer.make_filenames(path, series)
             print("load original image metadata from:", orig_info)
-            importer.load_metadata(orig_info)
+            importer.load_metadata(orig_info, img5d=img5d)
         except IOError:
             print("Ignored sub-image file from {} as unable to load"
                   .format(filename_subimg))
@@ -409,7 +413,7 @@ def setup_images(
         # for any loaded image5d
         # TODO: access metadata directly from given image5d's dict to allow
         # loading multiple image5d images simultaneously
-        importer.assign_metadata(config.metadatas[0])
+        importer.assign_metadata(img5d, config.metadatas[0])
     
     # main image is currently required since many parameters depend on it
     if fallback_main_img and atlas_suffix is None and img5d.img is None:

--- a/magmap/io/np_io.py
+++ b/magmap/io/np_io.py
@@ -589,7 +589,8 @@ def setup_images(
     return img5d
 
 
-def get_num_channels(img: np.ndarray, is_3d: bool = False) -> int:
+def get_num_channels(
+        img: Optional[np.ndarray] = None, is_3d: bool = False) -> int:
     """Get the number of image channels based on expected dimensions.
 
     Args:

--- a/magmap/io/np_io.py
+++ b/magmap/io/np_io.py
@@ -651,7 +651,12 @@ def read_tif(
 
     # parse image description
     desc = tags["ImageDescription"].value
-    desc = ast.literal_eval(desc)
+    try:
+        # parse description as a dictionary
+        desc = ast.literal_eval(desc)
+    except (ValueError, SyntaxError):
+        # if parsing fails, assume it is a string and store it as such
+        desc = {"description": desc}
     _logger.debug("TIF description: %s", desc)
 
     nrot = 0

--- a/magmap/io/np_io.py
+++ b/magmap/io/np_io.py
@@ -248,7 +248,6 @@ def setup_images(
     # LOAD MAIN IMAGE
     
     # reset image5d
-    config.image5d = None  # TODO: remove this in favor of Image5d
     config.image5d_is_roi = False
     img5d: Image5d = Image5d()
     config.img5d = img5d
@@ -584,9 +583,6 @@ def setup_images(
             blobs.set_blob_col(blobs.blobs, blobs.Cols.REGION, regions)
     
     config.img5d = img5d
-
-    # TODO: remove this once all images are loaded as Image5d
-    config.image5d = img5d.img
     
     return img5d
 

--- a/magmap/settings/config.py
+++ b/magmap/settings/config.py
@@ -172,10 +172,6 @@ class LoadIO(Enum):
     TIFFFILE = auto()
 
 
-#: :obj:`LoadIO`: I/O source for image5d array.
-image5d_io = None
-
-
 class LoadData(Enum):
     """Enumerations for specifying data to load."""
     BLOBS = auto()

--- a/magmap/settings/config.py
+++ b/magmap/settings/config.py
@@ -157,7 +157,6 @@ roi_size = None  # current region of interest
 subimg_offsets = None
 subimg_sizes = None
 
-image5d = None  # numpy image array
 image5d_is_roi = False  # flag when image5d was loaded as an ROI
 #: Image5d object.
 img5d: Optional["np_io.Image5d"] = None

--- a/magmap/settings/config.py
+++ b/magmap/settings/config.py
@@ -163,11 +163,6 @@ img5d: Optional["np_io.Image5d"] = None
 #: Blobs object.
 blobs: Optional["detector.Blobs"] = None
 
-#: :obj:`np.ndarray`: 2D array of shapes per time point in
-# ``[n_time_point, n_shape]`` format in case image5d is not available
-# TODO: consider simplify to single shape as 1D array
-image5d_shapes = None
-
 
 class LoadIO(Enum):
     """Enumerations for I/O load packages."""

--- a/magmap/settings/config.py
+++ b/magmap/settings/config.py
@@ -157,7 +157,6 @@ roi_size = None  # current region of interest
 subimg_offsets = None
 subimg_sizes = None
 
-image5d_is_roi = False  # flag when image5d was loaded as an ROI
 #: Image5d object.
 img5d: Optional["np_io.Image5d"] = None
 

--- a/magmap/stats/atlas_stats.py
+++ b/magmap/stats/atlas_stats.py
@@ -476,10 +476,10 @@ def plot_clusters_by_label(path, z, suffix=None, show=True, scaling=None):
     plot_support.hide_axes(ax)
     
     # plot underlying atlas
-    np_io.setup_images(mod_path)
-    if config.reg_suffixes[config.RegSuffixes.ATLAS]:
+    img5d = np_io.setup_images(mod_path)
+    if config.reg_suffixes[config.RegSuffixes.ATLAS] and img5d is not None:
         # use atlas if explicitly set
-        img = config.image5d
+        img = img5d.img
     else:
         # default to black background
         img = np.zeros_like(config.labels_img)[None]

--- a/magmap/tests/test_image_stack_integration.py
+++ b/magmap/tests/test_image_stack_integration.py
@@ -3,6 +3,7 @@
 """Unit testing for the MagellanMapper package.
 """
 
+import os
 import unittest
 
 from magmap.cv import stack_detect
@@ -14,30 +15,33 @@ TEST_IMG_BASE = "sample_region"
 TEST_IMG_TIFF = f"{TEST_IMG_BASE}.tif"
 
 
-class TestImageStackProcessing(unittest.TestCase):
+class TestImageStackIntegration(unittest.TestCase):
     
     def setUp(self):
         config.filename = TEST_IMG_TIFF
         config.channel = None
         cli.setup_roi_profiles(["lightsheet,4xnuc"])
     
-    def test_read_tif_(self):
+    def test_npy01_read_tif_(self):
+        print(f"Current dir: {os.getcwd()}")
+        print(f"Files: {os.listdir('.')}")
         img5d = np_io.read_tif(TEST_IMG_TIFF)
         config.img5d = img5d
-        assert(img5d is not None)
-        assert(img5d.img is not None)
-        assert(img5d.meta is not None)
+        assert img5d is not None
+        assert img5d.img is not None
+        assert img5d.meta is not None
         config.resolutions = img5d.meta[config.MetaKeys.RESOLUTIONS]
         self.assertEqual(img5d.img.shape, (1, 51, 200, 200, 2))
     
-    def test_write_npy(self):
+    def test_npy02_write_npy(self):
         np_io.write_npy(config.img5d.img, config.img5d.meta, TEST_IMG_TIFF)
     
-    def test_load_npy_image(self):
+    def test_npy03_read_file(self):
+        print(f"Files: {os.listdir('.')}")
         img5d = importer.read_file(TEST_IMG_BASE)
         config.img5d = img5d
-        assert(img5d is not None)
-        assert(img5d.img is not None)
+        assert img5d is not None
+        assert img5d.img is not None
         self.assertEqual(img5d.img.shape, (1, 51, 200, 200, 2))
     
     @unittest.skip("CZI files not yet supported in this test")
@@ -51,18 +55,21 @@ class TestImageStackProcessing(unittest.TestCase):
             img5d = importer.import_multiplane_images(
                 chls, import_path, import_md, channel=config.channel)
         config.img5d = img5d
-        assert(img5d is not None)
-        assert(img5d.img is not None)
+        assert img5d is not None
+        assert img5d.img is not None
         self.assertEqual(img5d.img.shape, (1, 51, 200, 200, 2))
     
     def test_process_whole_image(self):
         img5d = config.img5d
-        assert(img5d is not None)
-        assert(img5d.img is not None)
+        assert img5d is not None
+        assert img5d.img is not None
         _, _, blobs = stack_detect.detect_blobs_blocks(
             config.filename, img5d.img, (30, 30, 8), (70, 70, 10),
             config.channel)
-        self.assertEqual(len(blobs.blobs), 42)
+        nblobs = len(blobs.blobs) \
+            if blobs is not None and blobs.blobs is not None else 0
+        print(f"Detected {nblobs} blobs")
+        assert nblobs > 0
 
 
 if __name__ == "__main__":

--- a/magmap/tests/test_image_stack_integration.py
+++ b/magmap/tests/test_image_stack_integration.py
@@ -64,7 +64,7 @@ class TestImageStackIntegration(unittest.TestCase):
         assert img5d is not None
         assert img5d.img is not None
         _, _, blobs = stack_detect.detect_blobs_blocks(
-            config.filename, img5d.img, (30, 30, 8), (70, 70, 10),
+            config.filename, img5d, (30, 30, 8), (70, 70, 10),
             config.channel)
         nblobs = len(blobs.blobs) \
             if blobs is not None and blobs.blobs is not None else 0

--- a/magmap/tests/unit_testing.py
+++ b/magmap/tests/unit_testing.py
@@ -6,21 +6,42 @@
 import unittest
 
 from magmap.cv import stack_detect
-from magmap.io import cli
-from magmap.io import importer
+from magmap.io import cli, importer, np_io
 from magmap.settings import config
 
-TEST_IMG = "test.czi"
+TEST_IMG_CZI = "test.czi"
+TEST_IMG_BASE = "sample_region"
+TEST_IMG_TIFF = f"{TEST_IMG_BASE}.tif"
 
 
 class TestImageStackProcessing(unittest.TestCase):
     
     def setUp(self):
-        config.filename = TEST_IMG
+        config.filename = TEST_IMG_TIFF
         config.channel = None
         cli.setup_roi_profiles(["lightsheet,4xnuc"])
     
-    def test_load_image(self):
+    def test_read_tif_(self):
+        img5d = np_io.read_tif(TEST_IMG_TIFF)
+        config.img5d = img5d
+        assert(img5d is not None)
+        assert(img5d.img is not None)
+        assert(img5d.meta is not None)
+        config.resolutions = img5d.meta[config.MetaKeys.RESOLUTIONS]
+        self.assertEqual(img5d.img.shape, (1, 51, 200, 200, 2))
+    
+    def test_write_npy(self):
+        np_io.write_npy(config.img5d.img, config.img5d.meta, TEST_IMG_TIFF)
+    
+    def test_load_npy_image(self):
+        img5d = importer.read_file(TEST_IMG_BASE)
+        config.img5d = img5d
+        assert(img5d is not None)
+        assert(img5d.img is not None)
+        self.assertEqual(img5d.img.shape, (1, 51, 200, 200, 2))
+    
+    @unittest.skip("CZI files not yet supported in this test")
+    def test_import_npy_image(self):
         img5d = importer.read_file(
             config.filename, config.series)
         if img5d.img is None:
@@ -41,7 +62,7 @@ class TestImageStackProcessing(unittest.TestCase):
         _, _, blobs = stack_detect.detect_blobs_blocks(
             config.filename, img5d.img, (30, 30, 8), (70, 70, 10),
             config.channel)
-        self.assertEqual(len(blobs), 54)
+        self.assertEqual(len(blobs.blobs), 42)
 
 
 if __name__ == "__main__":

--- a/magmap/tests/unit_testing.py
+++ b/magmap/tests/unit_testing.py
@@ -23,19 +23,23 @@ class TestImageStackProcessing(unittest.TestCase):
     def test_load_image(self):
         img5d = importer.read_file(
             config.filename, config.series)
-        config.image5d = img5d.img
-        if config.image5d is None:
+        if img5d.img is None:
             chls, import_path = importer.setup_import_multipage(
                 config.filename)
             import_md = importer.setup_import_metadata(chls, config.channel)
             img5d = importer.import_multiplane_images(
                 chls, import_path, import_md, channel=config.channel)
-            config.image5d = img5d.img
-        self.assertEqual(config.image5d.shape, (1, 51, 200, 200, 2))
+        config.img5d = img5d
+        assert(img5d is not None)
+        assert(img5d.img is not None)
+        self.assertEqual(img5d.img.shape, (1, 51, 200, 200, 2))
     
     def test_process_whole_image(self):
+        img5d = config.img5d
+        assert(img5d is not None)
+        assert(img5d.img is not None)
         _, _, blobs = stack_detect.detect_blobs_blocks(
-            config.filename, config.image5d, (30, 30, 8), (70, 70, 10),
+            config.filename, img5d.img, (30, 30, 8), (70, 70, 10),
             config.channel)
         self.assertEqual(len(blobs), 54)
 


### PR DESCRIPTION
Images have been stored in MM as direct NumPy arrays stored in the `config` module, with metadata stored as additional `config` attributes. One impact of this approach is that MM has largely only supported one loaded image per MM session. To encapsulate images, we previously introduced the `Image5d` class. This PR seeks to use this class as a replacement for the `config.image5d` reference. The image is still stored as a single `config.img5d` reference instead, with future PRs needed to expand MM to support multiple loaded images in the same instance.

Additional changes:
- Image metadata is stored in the object when loaded
- Fixed more TIF loading issues
- Fixed blob detections when channels are not set up
- Fixed unit tests for loading images